### PR TITLE
Implement redeem properly

### DIFF
--- a/contracts/contracts/token/OUSD.sol
+++ b/contracts/contracts/token/OUSD.sol
@@ -230,7 +230,7 @@ contract OUSD is Initializable, InitializableToken {
         uint256 creditAmount = _amount.mulTruncate(creditsPerToken);
         _creditBalances[_account] = _creditBalances[_account].sub(
             creditAmount,
-            "Burn _amount exceeds balance"
+            "Burn exceeds balance"
         );
         totalCredits = totalCredits.sub(creditAmount);
 

--- a/contracts/test/vault.js
+++ b/contracts/test/vault.js
@@ -70,7 +70,7 @@ describe("Vault", function () {
     await vault.connect(anna).mint(usdc.address, usdcUnits("50.0"));
     await expect(anna).has.a.balanceOf("50.00", ousd);
     await ousd.connect(anna).approve(vault.address, ousdUnits("50.0"));
-    await vault.connect(anna).redeem(usdc.address, ousdUnits("50.0"));
+    await vault.connect(anna).redeem(usdc.address, usdcUnits("50.0"));
     await expect(anna).has.a.balanceOf("0.00", ousd);
     await expect(anna).has.a.balanceOf("1000.00", usdc);
   });


### PR DESCRIPTION
Fixes the implementation of withdraw and hooks it up with the strategy stuff.

I feel the redeem interface is awkward:

- Pass an _asset and an _amount of that asset that you want doesn't feel natural. Generally you want to pass the _amount in OUSD.
- Passing an _asset and an _amount in OUSD also feels wrong.

This might resolve itself if we change the Oracle setup.