### PR TITLE
Maximum default allowance

### DIFF
--- a/dapp/pages/dapp/dashboard.js
+++ b/dapp/pages/dapp/dashboard.js
@@ -9,6 +9,7 @@ import Nav from 'components/Nav'
 import AccountStore from 'stores/AccountStore'
 import ContractStore from 'stores/ContractStore'
 import { currencies } from 'constants/Contract'
+import { formatCurrency } from 'utils/math'
 
 const governorAddress = '0xeAD9C93b79Ae7C1591b1FB5323BD777E86e150d4'
 
@@ -187,15 +188,22 @@ const Dashboard = ({ locale, onLocale }) => {
   }
 
   const tableRows = () => {
-    return [...Object.keys(currencies), 'ousd'].map((x) => (
-      <tr key={x}>
-        <td>{x.toUpperCase()}</td>
-        <td>{get(allowances, x) > 100000000000 ? 'Unlimited' : 'None'}</td>
-        <td>1</td>
-        <td>{get(balances, x)}</td>
-        <td>{get(allowances, x)}</td>
-      </tr>
-    ))
+    return [...Object.keys(currencies), 'ousd'].map((x) => {
+      const name = x.toUpperCase()
+      const balance = get(balances, x)
+      const allowance = Number(get(allowances, x))
+      const unlimited = allowance && allowance > Number.MAX_SAFE_INTEGER
+
+      return (
+          <tr key={x}>
+          <td>{name}</td>
+          <td>{unlimited ? 'Unlimited' : (allowance ? 'Some' : 'None')}</td>
+          <td>1</td>
+          <td>{formatCurrency(balance)}</td>
+          <td>{unlimited ? 'Max' : formatCurrency(allowance)}</td>
+        </tr>
+      )
+    })
   }
 
   return (

--- a/dapp/src/components/buySell/ApproveCurrencyRow.js
+++ b/dapp/src/components/buySell/ApproveCurrencyRow.js
@@ -56,13 +56,8 @@ const ApproveCurrencyRow = ({
                 })
                 setStage('waiting-user')
                 try {
-                  const result = await contract.approve(
-                    vault.address,
-                    ethers.utils.parseUnits(
-                      '10000000.0',
-                      await contract.decimals()
-                    )
-                  )
+                  const maximum = ethers.constants.MaxUint256
+                  const result = await contract.approve(vault.address, maximum)
                   storeTransaction(result, 'approve', coin)
                   setStage('waiting-network')
 

--- a/dapp/src/components/buySell/CoinWithdrawBox.js
+++ b/dapp/src/components/buySell/CoinWithdrawBox.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { useStoreState } from 'pullstate'
 
 import { currencies } from 'constants/Contract'
-import { formatCurrency } from 'utils/math.js'
+import { formatCurrency } from 'utils/math'
 
 const CoinWithdrawBox = ({ coin, exchangeRate, amount, loading }) => {
   return (

--- a/dapp/src/components/buySell/SellWidget.js
+++ b/dapp/src/components/buySell/SellWidget.js
@@ -3,7 +3,7 @@ import { fbt } from 'fbt-runtime'
 import { useStoreState } from 'pullstate'
 import ethers from 'ethers'
 
-import { formatCurrency } from 'utils/math.js'
+import { formatCurrency } from 'utils/math'
 import CoinWithdrawBox from 'components/buySell/CoinWithdrawBox'
 import ContractStore from 'stores/ContractStore'
 import AccountStore from 'stores/AccountStore'


### PR DESCRIPTION
I'm proposing that we default to an "unlimited" allowance for ERC-20 approvals. We're currently defaulting to "10,000,000", which potentially isn't sufficient on the off-chance that we have a whale using our DApp to mint an eight-figure (or larger) number. But even for average DeFi enthusiasts, they're likely familiar with seeing the ugly "unlimited" number in MetaMask when using other DApps and might find it suspicious if we're doing something different.