### PR TITLE
Use latest Ledger Live derivation path

### DIFF
--- a/dapp/src/utils/connectors.js
+++ b/dapp/src/utils/connectors.js
@@ -24,10 +24,14 @@ export const injected = new InjectedConnector({
   supportedChainIds: [1, 3, 4, 5, 42, 1337, 31337],
 })
 
+// This is the newer style Ledger Live derivation path
+// Ref: https://github.com/oplabs/origin-dollar/issues/21
+const baseDerivationPath = "44'/60'/0'/0"
 export const ledger = new LedgerConnector({
   chainId: getChainId(),
   url: RPC_URLS[1],
   pollingInterval: POLLING_INTERVAL,
+  baseDerivationPath,
 })
 
 export const walletConnect = new WalletConnectConnector({


### PR DESCRIPTION
This is a short-term "fix" that I don't really like but may be the best option right now for Ledger users.

This updates our LedgerConnector to use the same HD path as Ledger Live.  Anyone who created accounts on their ledger using the previous Ledger chrome app, or MEW will be surprised that the address that shows up after connection is different.  LedgerConnector currently defaults to using the path that Ledger chrome app used.

Long term, I think we should create our own `web3-react` error for Ledger so it can try different derivations looking for an account with an ETH balance and falling back to the first account on the Ledger Live HD path.  This is the behavior of Ledger Live when looking for accounts on the device.

Anyone who initialized their Ledger in the last year(?) or so will use this derivation path.

More info in #21