### PR TITLE
Fix LedgerConnector initialization

### DIFF
--- a/dapp/src/utils/LedgerConnector.js
+++ b/dapp/src/utils/LedgerConnector.js
@@ -135,19 +135,16 @@ export class LedgerConnector extends AbstractConnector {
 
   async _getBalance(account) {
     const rpcSubprovider = getRPCProvider(this.engine._providers)
+    const JSONRequest = {
+      id: 123,
+      method: 'eth_getBalance',
+      params: [account, 'latest'],
+    }
     return new Promise((resolve, reject) => {
-      rpcSubprovider.handleRequest(
-        {
-          id: 123,
-          method: 'eth_getBalance',
-          params: [account],
-        },
-        null,
-        (err, resp) => {
-          if (err) return reject(err)
-          resolve(resp)
-        }
-      )
+      rpcSubprovider.handleRequest(JSONRequest, null, (err, resp) => {
+        if (err) return reject(err)
+        resolve(resp)
+      })
     })
   }
 


### PR DESCRIPTION
Sorry, I should have noticed these issues in my testing.  Though I'm still not able to properly test this because my local environment is fucked(contract deploys not happening?) and I'm not sure why.  The initialization of the connector succeeds now but I can't test contract calls yet because contracts aren't able to initialize on my local.  The RPC calls that were failing before are now fixed.

This fixes the W3PE subprovider initialization so the RpcSubprovider is now available when the LedgerProvider is being initialized(for balance checks).

@sparrowDom give me a shout when you're around again today?