### PR TITLE
better handle Ledger errors

### DIFF
--- a/dapp/src/components/LoginWidget.js
+++ b/dapp/src/components/LoginWidget.js
@@ -107,7 +107,7 @@ const LoginWidget = ({}) => {
                    * are suppressed.
                    */
                   (err) => {
-                    console.log('Setting the error: ', err)
+                    console.debug('Setting the error: ', err)
                     setError(err)
                   },
                   // do not throw the error, handle it in the onError callback above

--- a/dapp/src/components/LoginWidget.js
+++ b/dapp/src/components/LoginWidget.js
@@ -98,10 +98,20 @@ const LoginWidget = ({}) => {
                 setActivatingConnector(currentConnector)
                 await activate(
                   currentConnector,
+                  /* According to documentation: https://github.com/NoahZinsmeister/web3-react/tree/v6/docs#understanding-error-bubbling
+                   * if this onError function is specified no changes shall be done to the "useWeb3React" global context.
+                   * also with the 3rd parameter being false errors should not be thrown.
+                   *
+                   * When I test using my ledger Nano S [sparrowDom] the below function doesn't consistently throw errors
+                   * when I either lock my Ledger or exit Ethereum app. On my end it sometimes just seems that the errors
+                   * are suppressed.
+                   */
                   (err) => {
+                    console.log('Setting the error: ', err)
                     setError(err)
                   },
-                  true
+                  // do not throw the error, handle it in the onError callback above
+                  false
                 )
               }}
             >

--- a/dapp/src/components/LoginWidget.js
+++ b/dapp/src/components/LoginWidget.js
@@ -40,6 +40,15 @@ const LoginWidget = ({}) => {
         'Unlock your Ledger wallet and open Ethereum application',
         'Unlock ledger and open eth app'
       )
+    } else if (
+      error.message.includes(
+        'Failed to sign with Ledger device: U2F DEVICE_INELIGIBLE'
+      )
+    ) {
+      return fbt(
+        'Unlock your Ledger wallet and open Ethereum application',
+        'Unlock ledger and open eth app'
+      )
     }
 
     return error.message

--- a/dapp/src/components/buySell/ApproveCurrencyRow.js
+++ b/dapp/src/components/buySell/ApproveCurrencyRow.js
@@ -17,6 +17,7 @@ const ApproveCurrencyRow = ({
   rpcProvider,
   onApproved,
   isApproved,
+  onMintingError,
 }) => {
   //approve, waiting-user, waiting-network, done
   const [stage, setStage] = useState(isApproved ? 'done' : 'approve')
@@ -75,6 +76,7 @@ const ApproveCurrencyRow = ({
                   }
                   setStage('done')
                 } catch (e) {
+                  onMintingError(e)
                   storeTransactionError('approve', coin)
                   console.error('Exception happened: ', e)
                   setStage('approve')

--- a/dapp/src/components/buySell/ApproveModal.js
+++ b/dapp/src/components/buySell/ApproveModal.js
@@ -13,6 +13,7 @@ const ApproveModal = ({
   onClose,
   onFinalize,
   buyWidgetState,
+  onMintingError,
 }) => {
   const ousdBalance = useStoreState(
     AccountStore,
@@ -63,6 +64,7 @@ const ApproveModal = ({
                     key={coin}
                     coin={coin}
                     isLast={currenciesActive.length - 1 === index}
+                    onMintingError={onMintingError}
                   />
                 )
               })}

--- a/dapp/src/components/buySell/BuySellWidget.js
+++ b/dapp/src/components/buySell/BuySellWidget.js
@@ -9,6 +9,7 @@ import ContractStore from 'stores/ContractStore'
 import CoinRow from 'components/buySell/CoinRow'
 import SellWidget from 'components/buySell/SellWidget'
 import ApproveModal from 'components/buySell/ApproveModal'
+import ErrorModal from 'components/buySell/ErrorModal'
 import DisclaimerTooltip from 'components/buySell/DisclaimerTooltip'
 import ApproveCurrencyInProgressModal from 'components/buySell/ApproveCurrencyInProgressModal'
 import { currencies } from 'constants/Contract'
@@ -53,6 +54,7 @@ const BuySellWidget = ({
   const [daiActive, setDaiActive] = useState(false)
   const [usdtActive, setUsdtActive] = useState(false)
   const [usdcActive, setUsdcActive] = useState(false)
+  const [buyErrorToDisplay, setBuyErrorToDisplay] = useState(false)
   const [dai, setDai] = useState(0)
   const [usdt, setUsdt] = useState(0)
   const [usdc, setUsdc] = useState(0)
@@ -140,6 +142,35 @@ const BuySellWidget = ({
     }
   }, [dai, usdt, usdc, pendingMintTransactions])
 
+  const errorMap = [
+    {
+      errorCheck: (err) => {
+        return err.name === 'EthAppPleaseEnableContractData'
+      },
+      friendlyMessage: fbt(
+        'Contract data not enabled. Go to Ethereum app Settings and set "Contract Data" to "Allowed"',
+        'Enable contract data'
+      ),
+    },
+    {
+      errorCheck: (err) => {
+        return err.message.includes(
+          'Failed to sign with Ledger device: U2F DEVICE_INELIGIBL'
+        )
+      },
+      friendlyMessage: fbt(
+        'Can not detect ledger device. Please make sure your Ledger is unlocked and Ethereum App is opened.',
+        'See ledger connected'
+      ),
+    },
+  ]
+
+  const onMintingError = (error) => {
+    if (errorMap.filter((eMap) => eMap.errorCheck(error)).length > 0) {
+      setBuyErrorToDisplay(error)
+    }
+  }
+
   const onMintOusd = async (prependStage) => {
     const mintedCoins = []
     setBuyWidgetState(`${prependStage}waiting-user`)
@@ -210,6 +241,7 @@ const BuySellWidget = ({
       if (e.code !== 4001) {
         await storeTransactionError(`mint`, mintedCoins.join(','))
       }
+      onMintingError(e)
       console.error('Error minting ousd! ', e)
       mixpanel.track('Mint tx failed', {
         coins: mintedCoins.join(','),
@@ -302,6 +334,16 @@ const BuySellWidget = ({
               setShowApproveModal(false)
             }}
             buyWidgetState={buyWidgetState}
+            onMintingError={onMintingError}
+          />
+        )}
+        {buyErrorToDisplay && (
+          <ErrorModal
+            error={buyErrorToDisplay}
+            errorMap={errorMap}
+            onClose={() => {
+              setBuyErrorToDisplay(false)
+            }}
           />
         )}
         {buyWidgetState === 'waiting-user' && (

--- a/dapp/src/components/buySell/ErrorModal.js
+++ b/dapp/src/components/buySell/ErrorModal.js
@@ -1,0 +1,85 @@
+import React, { useState, useEffect } from 'react'
+import { fbt } from 'fbt-runtime'
+import { useStoreState } from 'pullstate'
+
+import AccountStore from 'stores/AccountStore'
+
+const ErrorModal = ({ error, errorMap, onClose }) => {
+  const connectorIcon = useStoreState(AccountStore, (s) => s.connectorIcon)
+
+  const errorTxt = () => {
+    const errorMetadata = errorMap.filter((eMeta) => eMeta.errorCheck(error))[0]
+
+    if (errorMetadata) {
+      return errorMetadata.friendlyMessage
+    }
+
+    return error.message
+  }
+
+  return (
+    <>
+      <div className="error-modal d-flex" onClick={onClose}>
+        <div
+          className="error-modal-body shadowed-box d-flex flex-column"
+          onClick={(e) => {
+            // so the modal doesn't close
+            e.stopPropagation()
+          }}
+        >
+          <div className="body-coins d-flex flex-column">
+            <div className="d-flex align-items-center error">
+              <img
+                className="connector-icon"
+                src={`/images/${connectorIcon}`}
+              />
+              {errorTxt()}
+            </div>
+          </div>
+          <div className="body-actions d-flex align-items-center justify-content-center"></div>
+        </div>
+      </div>
+      <style jsx>{`
+        .error-modal {
+          position: absolute;
+          border-radius: 0px 0px 10px 10px;
+          border: solid 1px #cdd7e0;
+          background-color: rgba(250, 251, 252, 0.6);
+          top: -1px;
+          right: -1px;
+          bottom: -1px;
+          left: -1px;
+          z-index: 2;
+          padding-left: 110px;
+          padding-right: 110px;
+        }
+
+        .error-modal-body {
+          background-color: white;
+          place-self: center;
+          padding: 20px;
+        }
+
+        .error-modal-body .error {
+          color: rgb(237 41 40);
+          line-height: 1.3;
+        }
+
+        .connector-icon {
+          width: 30px;
+          height: 30px;
+          margin-right: 15px;
+        }
+
+        @media (max-width: 799px) {
+          .error-modal {
+            padding-left: 30px;
+            padding-right: 30px;
+          }
+        }
+      `}</style>
+    </>
+  )
+}
+
+export default ErrorModal


### PR DESCRIPTION
Adds error handling to Mint / Approve function calls. When Ledger user doesn't have contract data enabled an error and error is thrown the user is presented with this modal: 
<img width="972" alt="Screenshot 2020-09-23 at 20 13 45" src="https://user-images.githubusercontent.com/579910/94052879-d9add480-fdd9-11ea-89cb-d2dd96bbaf06.png">

Have done additional testing with Logging in With Ledger device. For some reason the library wouldn't consistently throw an error when my Ledger is locked / not inside Ethereum app. But when the error does get thrown this is shown to the user: 
<img width="381" alt="Screenshot 2020-09-23 at 19 44 52" src="https://user-images.githubusercontent.com/579910/94053001-0a8e0980-fdda-11ea-9751-7131df77be36.png">
