### PR TITLE
JSON-RPC request reduction - polling interval change

### DIFF
--- a/dapp/src/components/AccountListener.js
+++ b/dapp/src/components/AccountListener.js
@@ -10,6 +10,9 @@ import { useStoreState } from 'pullstate'
 import { setupContracts } from 'utils/contracts'
 import { login } from 'utils/account'
 
+const BALANCE_CHECK_INTERVAL = 30000 // ms
+let balanceInterval
+
 const AccountListener = (props) => {
   const web3react = useWeb3React()
   const { account, chainId, library } = web3react
@@ -108,8 +111,6 @@ const AccountListener = (props) => {
       login(account, setCookie)
     }
 
-    let balanceInterval
-
     const setupContractsAndLoad = async () => {
       /* If we have a web3 provider present and is signed into the allowed network:
        * - NODE_ENV === production -> mainnet
@@ -128,9 +129,13 @@ const AccountListener = (props) => {
       const contracts = await setupContracts(account, library, usedChainId)
       loadData(contracts)
 
+      if (balanceInterval) {
+        clearInterval(balanceInterval)
+      }
+
       balanceInterval = setInterval(() => {
         loadData(contracts)
-      }, 5000)
+      }, BALANCE_CHECK_INTERVAL)
     }
 
     setupContractsAndLoad()

--- a/dapp/src/utils/contracts.js
+++ b/dapp/src/utils/contracts.js
@@ -126,7 +126,7 @@ export async function setupContracts(account, library, chainId) {
   // execute in parallel and repeat in an interval
   window.fetchInterval = setInterval(() => {
     callWithDelay()
-  }, 5000)
+  }, 30000)
 
   const contractToExport = {
     usdt,


### PR DESCRIPTION
This reducing polling for balances and APR from 5s to 30s.  Slight improvement that will hopefully reduce the rate limiting we're seeing from Alchemy.

I think this is probably good for now but it does impact things like the balance ticker, and how quickly we notice an approval/balance change, so there's a UX impact here.  Perhaps there's a more intelligent way of doing this that requires a bit more of a UI change?

CC: @micahalcorn @franckc 