### PR TITLE
call redeemAll instead of redeem

### DIFF
--- a/dapp/src/components/GetOUSD.js
+++ b/dapp/src/components/GetOUSD.js
@@ -40,7 +40,11 @@ const GetOUSD = ({
             source: trackSource,
           })
           const provider = providerName()
-          if (provider.match('coinbase|imtoken|cipher|alphawallet|gowallet|trust|status|mist|parity')) {
+          if (
+            provider.match(
+              'coinbase|imtoken|cipher|alphawallet|gowallet|trust|status|mist|parity'
+            )
+          ) {
             activate(injected)
           } else if (showLogin) {
             showLogin()

--- a/dapp/src/components/buySell/SellWidget.js
+++ b/dapp/src/components/buySell/SellWidget.js
@@ -99,7 +99,7 @@ const SellWidget = ({
 
   useEffect(() => {
     const newFormErrors = {}
-    if (ousdToSell > parseFloat(animatedOusdBalance)) {
+    if (parseFloat(ousdToSell) > parseFloat(animatedOusdBalance)) {
       newFormErrors.ousd = 'not_have_enough'
     }
 
@@ -122,8 +122,19 @@ const SellWidget = ({
       setSellWidgetCoinSplit([])
     }
 
+    const ousdToSellNumber = parseFloat(ousdToSell)
+    const ousdBalanceNumber = parseFloat(ousdBalance)
+    /* User might toggle the sellAll button or manually input the OUSD value that is slightly above their
+     * wallet ballance, but lower than the animated value. Since we don't trigger form errors when the
+     * value is smaller than the animated value, we instead call redeemAll in place of redeem
+     * to avoid the error where the contract receives a slighlty higher OUSD amount than is user's balance
+     * (even in cases when the sellAll button is not toggled).
+     */
+    const forceSellAll =
+      ousdToSellNumber >= ousdBalanceNumber &&
+      ousdToSellNumber <= animatedOusdBalance
     setSellWidgetState('waiting-user')
-    if (sellAllActive) {
+    if (sellAllActive || forceSellAll) {
       try {
         const result = await vaultContract.redeemAll({
           gasLimit: gasLimits.REDEEM_GAS_LIMIT,
@@ -321,7 +332,7 @@ const SellWidget = ({
             <div className="remaining-ousd d-flex align-items-center justify-content-end">
               <div className="balance ml-auto pr-3">
                 {formatCurrency(
-                  Math.max(0, animatedOusdBalance - ousdToSell),
+                  Math.max(0, animatedOusdBalance - ousdToSellNumber),
                   6
                 )}{' '}
                 OUSD
@@ -413,7 +424,7 @@ const SellWidget = ({
             <button
               disabled={
                 sellFormHasErrors ||
-                !(ousdToSell > 0) ||
+                !(ousdToSellNumber > 0) ||
                 // wait for the coins splits to load up before enabling button otherwise transaction in history UI breaks
                 !(positiveCoinSplitCurrencies.length > 0) ||
                 sellWidgetState !== 'sell now'

--- a/dapp/src/utils/web3.js
+++ b/dapp/src/utils/web3.js
@@ -49,53 +49,35 @@ export function providerName() {
 
   if (ethereum.isMetaMask) {
     return 'metamask'
-  }
-
-  if (ethereum.isImToken) {
+  } else if (ethereum.isImToken) {
     return 'imtoken'
-  }
-
-  if (typeof window.__CIPHER__ !== 'undefined') {
+  } else if (typeof window.__CIPHER__ !== 'undefined') {
     return 'cipher'
-  }
-
-  if (!web3.currentProvider) {
+  } else if (!web3.currentProvider) {
     return null
-  }
-
-  if (web3.currentProvider.isToshi) {
+  } else if (web3.currentProvider.isToshi) {
     return 'coinbase'
-  }
-
-  if (web3.currentProvider.isTrust) {
+  } else if (web3.currentProvider.isTrust) {
     return 'trust'
-  }
-
-  if (web3.currentProvider.isGoWallet) {
+  } else if (web3.currentProvider.isGoWallet) {
     return 'gowallet'
-  }
-
-  if (web3.currentProvider.isAlphaWallet) {
+  } else if (web3.currentProvider.isAlphaWallet) {
     return 'alphawallet'
-  }
-
-  if (web3.currentProvider.isStatus) {
+  } else if (web3.currentProvider.isStatus) {
     return 'status'
-  }
-
-  if (web3.currentProvider.constructor.name === 'EthereumProvider') {
+  } else if (web3.currentProvider.constructor.name === 'EthereumProvider') {
     return 'mist'
-  }
-
-  if (web3.currentProvider.constructor.name === 'Web3FrameProvider') {
+  } else if (web3.currentProvider.constructor.name === 'Web3FrameProvider') {
     return 'parity'
-  }
-
-  if (web3.currentProvider.host && web3.currentProvider.host.indexOf('infura') !== -1) {
+  } else if (
+    web3.currentProvider.host &&
+    web3.currentProvider.host.indexOf('infura') !== -1
+  ) {
     return 'infura'
-  }
-
-  if (web3.currentProvider.host && web3.currentProvider.host.indexOf('localhost') !== -1) {
+  } else if (
+    web3.currentProvider.host &&
+    web3.currentProvider.host.indexOf('localhost') !== -1
+  ) {
     return 'localhost'
   }
 


### PR DESCRIPTION
When user toggles the `sellAll` on and then off the value of OUSD is above user's balance and below the animated one. This caused the dapp to falsely send a too hight OUSD value to the redeem function. 

This PR fixes the issue, so that `redeemAll` is called instead of redeem when the OUSD values is between OUSD balance and OUSD animated value.

**Related issue:** https://github.com/OriginProtocol/origin-dollar/issues/263#issuecomment-699777340
