### PR TITLE
public on state var generates not that useful getter on MixOracle

### DIFF
--- a/contracts/contracts/oracle/MixOracle.sol
+++ b/contracts/contracts/oracle/MixOracle.sol
@@ -14,7 +14,7 @@ import {
 } from "../governance/InitializableGovernable.sol";
 
 contract MixOracle is IMinMaxOracle, InitializableGovernable {
-    address[] public ethUsdOracles;
+    address[] ethUsdOracles;
 
     struct MixConfig {
         address[] usdOracles;
@@ -38,6 +38,10 @@ contract MixOracle is IMinMaxOracle, InitializableGovernable {
     {
         maxDrift = _maxDrift;
         minDrift = _minDrift;
+    }
+
+    function getEthUsdOracles() external view returns (address[] memory) {
+        return ethUsdOracles;
     }
 
     /**


### PR DESCRIPTION
the generated getter is a bit useless as it gives a method that gives addr by index, not the full `address[]` 

hence:

1. removed public on `    address[] ethUsdOracles`
2. added view method to get the full `address[]`