### PR TITLE
Mobile Metamask

### DIFF
--- a/dapp/package.json
+++ b/dapp/package.json
@@ -75,11 +75,11 @@
     "react-autosize-textarea": "^7.1.0",
     "react-bootstrap": "^1.0.0-beta.16",
     "react-cookie": "^4.0.3",
+    "react-copy-to-clipboard": "^5.0.2",
     "react-dom": "16.13.1",
     "react-router-dom": "5.2.0",
     "react-styl": "^0.0.3",
     "react-toastify": "^6.0.8",
-    "react-copy-to-clipboard": "^5.0.2",
     "sass": "^1.26.10",
     "web3modal": "^1.9.0"
   },
@@ -128,7 +128,8 @@
     "terser-webpack-plugin": "4.1.0",
     "typeface-lato": "0.0.75",
     "typeface-poppins": "0.0.72",
-    "url-loader": "4.1.0"
+    "url-loader": "4.1.0",
+    "vconsole": "^3.3.4"
   },
   "eslintIgnore": [
     "node_modules",

--- a/dapp/pages/_app.js
+++ b/dapp/pages/_app.js
@@ -23,6 +23,11 @@ import 'react-toastify/scss/main.scss'
 import '../node_modules/bootstrap/dist/css/bootstrap.min.css'
 import '../styles/globals.css'
 
+let VConsole
+if (process.browser && process.env.NODE_ENV === 'development') {
+  VConsole = require('vconsole/dist/vconsole.min.js') 
+}
+
 initSentry()
 
 function App({ Component, pageProps, err }) {
@@ -56,6 +61,10 @@ function App({ Component, pageProps, err }) {
     if (error) {
       alert(error)
       console.log(error)
+    }
+
+    if (process.browser && process.env.NODE_ENV === 'development') {
+      var vConsole = new VConsole()
     }
   }, [])
 

--- a/dapp/pages/_app.js
+++ b/dapp/pages/_app.js
@@ -15,6 +15,7 @@ import { useEagerConnect } from 'utils/hooks'
 import { logout, login } from 'utils/account'
 import LoginModal from 'components/LoginModal'
 import { ToastContainer } from 'react-toastify'
+import { getConnector, getConnectorImage } from 'utils/connectors'
 
 import mixpanel from 'utils/mixpanel'
 import { initSentry } from 'utils/sentry'
@@ -56,6 +57,26 @@ function App({ Component, pageProps, err }) {
       router.push('/')
     }
   }, [active, tried, account])
+
+  useEffect(() => {
+    if (connector) {
+      const lastConnector = getConnector(connector)
+      if (active) {
+        mixpanel.track('Wallet connected', {
+          vendor: lastConnector.name,
+          eagerConnect: false,
+        })
+        AccountStore.update((s) => {
+          s.connectorIcon = getConnectorImage(lastConnector)
+        })
+        localStorage.setItem('eagerConnect', true)
+      } else {
+        AccountStore.update((s) => {
+          s.connectorIcon = null
+        })
+      }
+    }
+  }, [active])
 
   useEffect(() => {
     if (error) {

--- a/dapp/pages/index.js
+++ b/dapp/pages/index.js
@@ -38,7 +38,7 @@ const Home = ({ locale, onLocale }) => {
       id: 'hero-index-ousd-animation',
     })
   }, [])
-
+  
   return (
     <Layout>
       <header className="text-white">

--- a/dapp/src/components/GetOUSD.js
+++ b/dapp/src/components/GetOUSD.js
@@ -7,6 +7,7 @@ import withLoginModal from 'hoc/withLoginModal'
 import { injected } from 'utils/connectors'
 import mixpanel from 'utils/mixpanel'
 import { providerName } from 'utils/web3'
+import { isMobileDevice } from 'utils/device'
 
 const GetOUSD = ({
   className,
@@ -42,8 +43,8 @@ const GetOUSD = ({
           const provider = providerName() || ''
           if (
             provider.match(
-              'coinbase|imtoken|cipher|alphawallet|gowallet|trust|status|mist|parity'
-            )
+              'metamask|coinbase|imtoken|cipher|alphawallet|gowallet|trust|status|mist|parity'
+            ) && isMobileDevice()
           ) {
             activate(injected)
           } else if (showLogin) {

--- a/dapp/src/components/GetOUSD.js
+++ b/dapp/src/components/GetOUSD.js
@@ -7,7 +7,7 @@ import withLoginModal from 'hoc/withLoginModal'
 import { injected } from 'utils/connectors'
 import mixpanel from 'utils/mixpanel'
 import { providerName } from 'utils/web3'
-import { isMobileDevice } from 'utils/device'
+import { isMobileMetamask } from 'utils/device'
 
 const GetOUSD = ({
   className,
@@ -37,18 +37,21 @@ const GetOUSD = ({
         className={classList}
         style={style}
         onClick={() => {
-          mixpanel.track('Get OUSD', {
-            source: trackSource,
-          })
-          const provider = providerName() || ''
-          if (
-            provider.match(
-              'metamask|coinbase|imtoken|cipher|alphawallet|gowallet|trust|status|mist|parity'
-            ) && isMobileDevice()
-          ) {
-            activate(injected)
-          } else if (showLogin) {
-            showLogin()
+          if (process.browser) {
+            mixpanel.track('Get OUSD', {
+              source: trackSource,
+            })
+            const provider = providerName() || ''
+            if (
+              provider.match(
+                'coinbase|imtoken|cipher|alphawallet|gowallet|trust|status|mist|parity'
+              ) ||
+              isMobileMetamask()
+            ) {
+              activate(injected)
+            } else if (showLogin) {
+              showLogin()
+            }
           }
         }}
       >

--- a/dapp/src/components/LoginWidget.js
+++ b/dapp/src/components/LoginWidget.js
@@ -2,11 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { fbt } from 'fbt-runtime'
 import { useWeb3React } from '@web3-react/core'
 
-import {
-  connectorsByName,
-  getConnector,
-  getConnectorImage,
-} from 'utils/connectors'
+import { connectorsByName } from 'utils/connectors'
 import AccountStore from 'stores/AccountStore'
 
 import mixpanel from 'utils/mixpanel'
@@ -17,6 +13,13 @@ const LoginWidget = ({}) => {
   const [error, setError] = useState(null)
   const [warning, setWarning] = useState(null)
   const [warningShowTimeout, setWarningShowTimeout] = useState(null)
+
+  useEffect(() => {
+    if (active) {
+      setActivatingConnector(null)
+      closeLoginModal()
+    }
+  }, [active])
 
   const closeLoginModal = () => {
     mixpanel.track('Wallet modal closed')
@@ -58,28 +61,6 @@ const LoginWidget = ({}) => {
 
     return error.message
   }
-
-  useEffect(() => {
-    if (connector) {
-      const lastConnector = getConnector(connector)
-      if (active) {
-        mixpanel.track('Wallet connected', {
-          vendor: lastConnector.name,
-          eagerConnect: false,
-        })
-        AccountStore.update((s) => {
-          s.connectorIcon = getConnectorImage(lastConnector)
-        })
-        setActivatingConnector(null)
-        localStorage.setItem('eagerConnect', true)
-        closeLoginModal()
-      } else {
-        AccountStore.update((s) => {
-          s.connectorIcon = null
-        })
-      }
-    }
-  }, [active])
 
   return (
     <>

--- a/dapp/src/components/UserActivityListener.js
+++ b/dapp/src/components/UserActivityListener.js
@@ -2,27 +2,12 @@ import React, { Component } from 'react'
 import { useStoreState } from 'pullstate'
 
 import AccountStore from 'stores/AccountStore'
-
-const activeDelay = 10000 // time in miliseconds after last activity and we consider user still active
-
 /* Intentionally not using withIsMobile since that one is more interested in screen sizes. Here it is important
  * for us to detect a touch device (since those ones do not have mouses)
  */
-const isMobile = () => {
-  let check = false
-  if (process.browser) {
-    const userAgent = navigator.userAgent || navigator.vendor || window.opera
-    return (
-      /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino|android|ipad|playbook|silk/i.test(
-        userAgent
-      ) ||
-      /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(
-        userAgent.substr(0, 4)
-      )
-    )
-  }
-  return false
-}
+import { isMobileDevice } from 'utils/device'
+
+const activeDelay = 10000 // time in miliseconds after last activity and we consider user still active
 
 /* Listens for user activity and triggers the state from 'active' to 'idle' accordingly.
  * ⚠️ Doesn't work on mobile ⚠️ - defaults to always 'active' on mobile
@@ -70,7 +55,7 @@ class UserActivityListener extends React.Component {
      * implement more inteligent mobile activity checks. (probably listen to scrool events and
      * button interaction events )
      */
-    if (!isMobile()) {
+    if (!isMobileDevice()) {
       document.addEventListener('mousemove', this.onMouseMove)
       // check for user activity and adjust states when needed
       this.setState({

--- a/dapp/src/utils/device.js
+++ b/dapp/src/utils/device.js
@@ -1,0 +1,15 @@
+
+export function isMobileDevice() {
+  if (process.browser) {
+    const userAgent = navigator.userAgent || navigator.vendor || window.opera
+    return (
+      /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino|android|ipad|playbook|silk/i.test(
+        userAgent
+      ) ||
+      /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(
+        userAgent.substr(0, 4)
+      )
+    )
+  }
+  return false
+}

--- a/dapp/src/utils/device.js
+++ b/dapp/src/utils/device.js
@@ -1,3 +1,4 @@
+import { providerName } from 'utils/web3'
 
 export function isMobileDevice() {
   if (process.browser) {
@@ -12,4 +13,12 @@ export function isMobileDevice() {
     )
   }
   return false
+}
+
+export function isMobileMetamask() {
+  if (!process.browser) {
+    return false
+  }
+
+  return isMobileDevice() && providerName() === 'metamask'
 }

--- a/dapp/src/utils/hooks.js
+++ b/dapp/src/utils/hooks.js
@@ -13,7 +13,7 @@ export function useEagerConnect() {
   useEffect(() => {
     if (tried || localStorage.getItem('eagerConnect') === 'false') return
 
-    // TODO: solve for other connectors
+    //TODO: solve for other connectors
     injected.isAuthorized().then((isAuthorized) => {
       if (isAuthorized) {
         activate(injected, undefined, true)

--- a/dapp/yarn.lock
+++ b/dapp/yarn.lock
@@ -14707,6 +14707,11 @@ vary@^1, vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
+vconsole@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/vconsole/-/vconsole-3.3.4.tgz#a7dacd8887b3d3e902e8d18425cda56c34e77f51"
+  integrity sha512-9yihsic96NPoMLQx/lCQwH9d89H0bbMW3LZPzo/t4yGQcS1X+vTCe9OHm1XSH7WNxzGDmcSwBiKLsFGwvJpQBg==
+
 vendors@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.4.tgz#e2b800a53e7a29b93506c3cf41100d16c4c4ad8e"


### PR DESCRIPTION
- login popup is no longer shows up on mobile metamask, but directly logs in
- automatically hides the "waiting for you to approve" modal after 5 seconds if environment is Metamask app.
- adding vConsole for easier debugging on mobile devices

**corresponding issue:** https://github.com/OriginProtocol/origin-dollar/issues/129

The second workaround is required because the Metamask app has a bug where the contract call does not throw an exception when user rejects the transaction. The javascript execution is just stuck on the `await` line calling the contract function. Interestingly if you quit the app and re-enter immediately, the correct error with "user rejected the transaction..." still gets thrown.

The other interesting error I've found is that in 60% of the cases on my android (Oneplus 8Pro) the metamask app wouldn't inject the provider to window object (window.ethereum). Not reproducible on the iPhone, but happens constantly on Android. The dapp login doesn't work of course when that happens, and there is not much we can do about it. 