### PR TITLE
Mixpanel Conversion Tracking

### DIFF
--- a/dapp/src/components/buySell/BuySellWidget.js
+++ b/dapp/src/components/buySell/BuySellWidget.js
@@ -281,6 +281,9 @@ const BuySellWidget = ({
       setStoredCoinValuesToZero()
 
       const receipt = await rpcProvider.waitForTransaction(result.hash)
+      mixpanel.track('Mint tx succeeded', {
+        coins: mintedCoins.join(','),
+      })
       if (localStorage.getItem('addOUSDModalShown') !== 'true') {
         AccountStore.update((s) => {
           s.addOusdModalState = 'waiting'
@@ -290,13 +293,17 @@ const BuySellWidget = ({
       // 4001 code happens when a user rejects the transaction
       if (e.code !== 4001) {
         await storeTransactionError(`mint`, mintedCoins.join(','))
+        mixpanel.track('Mint tx failed', {
+          coins: mintedCoins.join(','),
+        })
+      } else {
+        mixpanel.track('Mint tx canceled', {
+          coins: mintedCoins.join(','),
+        })
       }
 
       onMintingError(e)
       console.error('Error minting ousd! ', e)
-      mixpanel.track('Mint tx failed', {
-        coins: mintedCoins.join(','),
-      })
     }
     setBuyWidgetState(`buy`)
   }

--- a/dapp/src/components/buySell/SellWidget.js
+++ b/dapp/src/components/buySell/SellWidget.js
@@ -140,7 +140,11 @@ const SellWidget = ({
     mixpanel.track('Sell now clicked')
     const returnedCoins = positiveCoinSplitCurrencies.join(',')
 
-    const onSellSuccessfull = () => {
+    const onSellFailure = (amount) => {
+      mixpanel.track('Redeem tx failed', { amount })
+    }
+    const onSellSuccess = (amount) => {
+      mixpanel.track('Redeem tx succeeded', { amount })
       setOusdToSellValue('0')
       setSellWidgetCoinSplit([])
     }
@@ -177,13 +181,15 @@ const SellWidget = ({
         setSellWidgetState('waiting-network')
 
         const receipt = await rpcProvider.waitForTransaction(result.hash)
-        onSellSuccessfull()
+        onSellSuccess(ousdToSell)
       } catch (e) {
         // 4001 code happens when a user rejects the transaction
         if (e.code !== 4001) {
           storeTransactionError(`redeem`, returnedCoins, coinData)
+          onSellFailure(ousdToSell)
         }
         console.error('Error selling all OUSD: ', e)
+        onSellFailure(ousdToSell)
       }
     } else {
       try {
@@ -199,11 +205,12 @@ const SellWidget = ({
         setSellWidgetState('waiting-network')
 
         const receipt = await rpcProvider.waitForTransaction(result.hash)
-        onSellSuccessfull()
+        onSellSuccess(ousdToSell)
       } catch (e) {
         // 4001 code happens when a user rejects the transaction
         if (e.code !== 4001) {
           storeTransactionError(`redeem`, returnedCoins, coinData)
+          onSellFailure(ousdToSell)
         }
         console.error('Error selling OUSD: ', e)
       }

--- a/dapp/src/utils/account.js
+++ b/dapp/src/utils/account.js
@@ -1,9 +1,13 @@
 import AccountStore from 'stores/AccountStore'
 
+import mixpanel from './mixpanel'
+
 export const login = (address, setCookie) => {
   AccountStore.update((s) => {
     s.address = address
   })
+
+  mixpanel.alias(address)
 
   localStorage.setItem('eagerConnect', true)
   setCookie('loggedIn', address, { path: '/' })

--- a/dapp/src/utils/hooks.js
+++ b/dapp/src/utils/hooks.js
@@ -18,16 +18,17 @@ export function useEagerConnect() {
       if (isAuthorized) {
         activate(injected, undefined, true)
           .then(() => {
+            const connectorName = Object.keys(connectorsByName).filter(
+              (cKey) => {
+                return connectorsByName[cKey].connector === injected
+              }
+            )[0]
             mixpanel.track('Wallet connected', {
+              vendor: connectorName,
               eagerConnect: true,
             })
 
             AccountStore.update((s) => {
-              const connectorName = Object.keys(connectorsByName).filter(
-                (cKey) => {
-                  return connectorsByName[cKey].connector === injected
-                }
-              )[0]
               s.connectorIcon = getConnectorImage(
                 connectorsByName[connectorName]
               )


### PR DESCRIPTION
This adds some missing events to the end of the mint and redeem funnels. It also adds the Ethereum account address as an alias on users, which probably isn't the best solution but is a start.