### PR TITLE
Add reward liqudation threshold to strategies and some safeguards for 3pool

### DIFF
--- a/contracts/contracts/mocks/curve/MockCurvePool.sol
+++ b/contracts/contracts/mocks/curve/MockCurvePool.sol
@@ -37,6 +37,9 @@ contract MockCurvePool is ERC20 {
                 sum += _amounts[i].scaleBy(int8(18 - assetDecimals));
             }
         }
+        // Hacky way of simulating slippage to check _minAmount
+        if (sum == 29000e18) sum = 14500e18;
+        require(sum > _minAmount, "Slippage ruined your day");
         // Send LP token to sender, e.g. 3CRV
         IMintableERC20(lpToken).mint(sum);
         IERC20(lpToken).transfer(msg.sender, sum);

--- a/contracts/contracts/strategies/ThreePoolStrategy.sol
+++ b/contracts/contracts/strategies/ThreePoolStrategy.sol
@@ -5,6 +5,8 @@ pragma solidity 0.5.11;
  * @notice Investment strategy for investing stablecoins via Curve 3Pool
  * @author Origin Protocol Inc
  */
+import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
+
 import { ICurvePool } from "./ICurvePool.sol";
 import { ICurveGauge } from "./ICurveGauge.sol";
 import { ICRVMinter } from "./ICRVMinter.sol";
@@ -12,8 +14,13 @@ import {
     IERC20,
     InitializableAbstractStrategy
 } from "../utils/InitializableAbstractStrategy.sol";
+import { Helpers } from "../utils/Helpers.sol";
+import { StableMath } from "../utils/StableMath.sol";
 
 contract ThreePoolStrategy is InitializableAbstractStrategy {
+    using SafeMath for uint256;
+    using StableMath for uint256;
+
     event RewardTokenCollected(address recipient, uint256 amount);
 
     address crvGaugeAddress;
@@ -89,8 +96,14 @@ contract ThreePoolStrategy is InitializableAbstractStrategy {
         uint256[] memory _amounts = new uint256[](3);
         // Set the amount on the asset we want to deposit
         _amounts[uint256(poolCoinIndex)] = _amount;
+        // Calculate a minimum amount of LP tokens (at worst 10% less than
+        // amount being deposited).
+        uint256 assetDecimals = Helpers.getDecimals(_asset);
+        uint256 minLPTokenAmount = _amount
+            .scaleBy(int8(18 - assetDecimals))
+            .mulTruncate(9e17);
         // Do the deposit to 3pool
-        ICurvePool(platformAddress).add_liquidity(_amounts, uint256(0));
+        ICurvePool(platformAddress).add_liquidity(_amounts, minLPTokenAmount);
         // Deposit into Gauge
         IERC20 pToken = IERC20(assetToPToken[_asset]);
         ICurveGauge(crvGaugeAddress).deposit(
@@ -135,7 +148,9 @@ contract ThreePoolStrategy is InitializableAbstractStrategy {
             // in Gauge, unstake
             ICurveGauge(crvGaugeAddress).withdraw(withdrawPTokens);
         }
-        curvePool.remove_liquidity_one_coin(withdrawPTokens, poolCoinIndex, 0);
+        uint256 assetDecimals = Helpers.getDecimals(_asset);
+        uint256 minAssetAmount = _amount.scaleBy(int8(18 - assetDecimals));
+        curvePool.remove_liquidity_one_coin(withdrawPTokens, poolCoinIndex, minAssetAmount);
         IERC20(_asset).transfer(_recipient, _amount);
         // Transfer any leftover dust back to the vault buffer.
         uint256 dust = IERC20(_asset).balanceOf(address(this));

--- a/contracts/contracts/strategies/ThreePoolStrategy.sol
+++ b/contracts/contracts/strategies/ThreePoolStrategy.sol
@@ -157,6 +157,7 @@ contract ThreePoolStrategy is InitializableAbstractStrategy {
         if (dust > 0) {
             IERC20(_asset).safeTransfer(vaultAddress, dust);
         }
+        amountWithdrawn = _amount;
         emit Withdrawal(
             _asset,
             address(assetToPToken[_asset]),

--- a/contracts/contracts/utils/InitializableAbstractStrategy.sol
+++ b/contracts/contracts/utils/InitializableAbstractStrategy.sol
@@ -30,6 +30,7 @@ contract InitializableAbstractStrategy is Initializable, Governable {
 
     // Reward token address
     address public rewardTokenAddress;
+    uint256 public rewardLiquidationThreshold;
 
     /**
      * @dev Internal initialize function, to set up initial internal state
@@ -116,6 +117,18 @@ contract InitializableAbstractStrategy is Initializable, Governable {
         onlyGovernor
     {
         rewardTokenAddress = _rewardTokenAddress;
+    }
+
+    /**
+     * @dev Set the reward token liquidation threshold.
+     * @param _threshold Threshold amount in decimals of reward token that will
+     * cause the Vault to claim and liquidate on allocate() calls.
+     */
+    function setRewardLiquidationThreshold(uint256 _threshold)
+        external
+        onlyGovernor
+    {
+        rewardLiquidationThreshold = _threshold;
     }
 
     /**

--- a/contracts/deploy/013_three_pool_strategies.js
+++ b/contracts/deploy/013_three_pool_strategies.js
@@ -46,6 +46,7 @@ const threePoolStrategiesDeploy = async ({ getNamedAccounts, deployments }) => {
   //
   // Deploy Curve USDC Strategy and Proxy
   //
+
   const dCurveUSDCStrategyProxy = await deploy("CurveUSDCStrategyProxy", {
     from: deployerAddr,
     contract: "ThreePoolStrategyProxy",

--- a/contracts/test/strategies/3pool-standalone.js
+++ b/contracts/test/strategies/3pool-standalone.js
@@ -1,4 +1,5 @@
 const { expect } = require("chai");
+const { utils } = require("ethers");
 
 const { BigNumber } = require("ethers");
 const { threepoolFixture } = require("../_fixture");
@@ -15,7 +16,8 @@ describe("3Pool Strategy Standalone", function () {
     tpStandalone,
     usdt,
     threePoolStrategy,
-    threePoolGauge;
+    threePoolGauge,
+    anna;
 
   beforeEach(async function () {
     const fixture = await loadFixture(threepoolFixture);
@@ -25,6 +27,7 @@ describe("3Pool Strategy Standalone", function () {
     threePoolGauge = fixture.threePoolGauge;
     tpStandalone = fixture.tpStandalone;
     usdt = fixture.usdt;
+    anna = fixture.anna;
 
     threePoolStrategy = tpStandalone.connect(governor);
   });
@@ -72,5 +75,26 @@ describe("3Pool Strategy Standalone", function () {
       threePoolStrategy,
       threePoolGauge
     );
+  });
+
+  it("Should read reward liquidation threshold", async () => {
+    expect(await tpStandalone.rewardLiquidationThreshold()).to.equal("0");
+  });
+
+  it("Should allow Governor to set reward liquidation threshold", async () => {
+    await tpStandalone
+      .connect(governor)
+      .setRewardLiquidationThreshold(utils.parseUnits("1", 18));
+    expect(await tpStandalone.rewardLiquidationThreshold()).to.equal(
+      utils.parseUnits("1", 18)
+    );
+  });
+
+  it("Should not allow non-Governor to set reward liquidation threshold", async () => {
+    await expect(
+      tpStandalone
+        .connect(anna)
+        .setRewardLiquidationThreshold(utils.parseUnits("10", 18))
+    ).to.be.revertedWith("Caller is not the Governor");
   });
 });

--- a/contracts/test/strategies/3pool.js
+++ b/contracts/test/strategies/3pool.js
@@ -34,7 +34,7 @@ describe("3Pool Strategy", function () {
   const mint = async (amount, asset) => {
     await asset.connect(anna).mint(units(amount, asset));
     await asset.connect(anna).approve(vault.address, units(amount, asset));
-    await vault.connect(anna).mint(asset.address, units(amount, asset));
+    return await vault.connect(anna).mint(asset.address, units(amount, asset));
   };
 
   beforeEach(async function () {
@@ -74,6 +74,18 @@ describe("3Pool Strategy", function () {
       await expect(threePoolGauge).has.an.approxBalanceOf(
         "50000",
         threePoolToken
+      );
+    });
+
+    it("Should use a minimum LP token amount when depositing USDT into 3pool", async function () {
+      await expect(mint("29000", usdt)).to.be.revertedWith(
+        "Slippage ruined your day"
+      );
+    });
+
+    it("Should use a minimum LP token amount when depositing USDC into 3pool", async function () {
+      await expect(mint("29000", usdc)).to.be.revertedWith(
+        "Slippage ruined your day"
       );
     });
 

--- a/contracts/test/strategies/compound.js
+++ b/contracts/test/strategies/compound.js
@@ -170,4 +170,28 @@ describe("Compound strategy", function () {
       .to.emit(cStandalone, "SkippedWithdrawal")
       .withArgs(usdc, 1);
   });
+
+  it("Should read reward liquidation threshold", async () => {
+    const { cStandalone } = await loadFixture(compoundFixture);
+    expect(await cStandalone.rewardLiquidationThreshold()).to.equal("0");
+  });
+
+  it("Should allow Governor to set reward liquidation threshold", async () => {
+    const { cStandalone, governor } = await loadFixture(compoundFixture);
+    await cStandalone
+      .connect(governor)
+      .setRewardLiquidationThreshold(utils.parseUnits("1", 18));
+    expect(await cStandalone.rewardLiquidationThreshold()).to.equal(
+      utils.parseUnits("1", 18)
+    );
+  });
+
+  it("Should not allow non-Governor to set reward liquidation threshold", async () => {
+    const { cStandalone, anna } = await loadFixture(compoundFixture);
+    await expect(
+      cStandalone
+        .connect(anna)
+        .setRewardLiquidationThreshold(utils.parseUnits("10", 18))
+    ).to.be.revertedWith("Caller is not the Governor");
+  });
 });


### PR DESCRIPTION
- Sets some minimum LP token amounts for 3pool.
- Adds a reward liquidation threshold option to strategies so we can hook into it to liquidate rewards at a certain level from allocate() in the vault.