### PR TITLE
Bug fixes

### DIFF
--- a/dapp/src/components/buySell/BalanceHeader.js
+++ b/dapp/src/components/buySell/BalanceHeader.js
@@ -193,7 +193,7 @@ const BalanceHeader = () => {
           <div className="contents d-flex align-items-center justify-content-center flex-column">
             <div className="light-grey-label apy-label">APY</div>
             <div className="apy-percentage">
-              {apy ? formatCurrency(apy * 100, 2) : '--.--'}
+              {typeof apy === 'number' ? formatCurrency(apy * 100, 2) : '--.--'}
             </div>
           </div>
         </div>

--- a/dapp/src/components/buySell/BuySellWidget.js
+++ b/dapp/src/components/buySell/BuySellWidget.js
@@ -42,6 +42,7 @@ const BuySellWidget = ({
   const [ousdToSell, setOusdToSell] = useState(0)
   const [sellFormErrors, setSellFormErrors] = useState({})
   const [sellAllActive, setSellAllActive] = useState(false)
+  const [generalErrorReason, setGeneralErrorReason] = useState(null)
   const [sellWidgetIsCalculating, setSellWidgetIsCalculating] = useState(false)
   const [sellWidgetCoinSplit, setSellWidgetCoinSplit] = useState([])
   // sell now, waiting-user, waiting-network
@@ -324,8 +325,26 @@ const BuySellWidget = ({
 
   const onBuyNow = async (e) => {
     e.preventDefault()
-
     mixpanel.track('Buy Now clicked')
+
+    const allowancesNotLoaded = ['dai', 'usdt', 'usdc'].filter(
+      (coin) => !allowances[coin] || Number.isNaN(parseFloat(allowances[coin]))
+    )
+
+    if (allowancesNotLoaded.length > 0) {
+      setGeneralErrorReason(
+        fbt(
+          'Can not load allowances for ' +
+            fbt.param(
+              'coin-name(s)',
+              allowancesNotLoaded.join(', ').toUpperCase()
+            ) +
+            '.',
+          'Allowance load error'
+        )
+      )
+      return
+    }
 
     const needsApproval = []
 
@@ -403,6 +422,13 @@ const BuySellWidget = ({
             }}
             buyWidgetState={buyWidgetState}
             onMintingError={onMintingError}
+          />
+        )}
+        {generalErrorReason && (
+          <ErrorModal
+            reason={generalErrorReason}
+            showRefreshButton={true}
+            onClose={() => {}}
           />
         )}
         {buyErrorToDisplay && (

--- a/dapp/src/components/buySell/ErrorModal.js
+++ b/dapp/src/components/buySell/ErrorModal.js
@@ -4,7 +4,13 @@ import { useStoreState } from 'pullstate'
 
 import AccountStore from 'stores/AccountStore'
 
-const ErrorModal = ({ error, errorMap, onClose }) => {
+const ErrorModal = ({
+  error,
+  errorMap,
+  onClose,
+  showRefreshButton,
+  reason,
+}) => {
   const connectorIcon = useStoreState(AccountStore, (s) => s.connectorIcon)
 
   const errorTxt = () => {
@@ -33,10 +39,24 @@ const ErrorModal = ({ error, errorMap, onClose }) => {
                 className="connector-icon"
                 src={`/images/${connectorIcon}`}
               />
-              {errorTxt()}
+              {reason !== undefined && reason}
+              {errorMap && errorTxt()}
             </div>
           </div>
-          <div className="body-actions d-flex align-items-center justify-content-center"></div>
+          <div className="body-actions d-flex align-items-center justify-content-center">
+            {showRefreshButton && (
+              <div>
+                <button
+                  className="btn-blue mt-4"
+                  onClick={(e) => {
+                    location.reload()
+                  }}
+                >
+                  {fbt('Refresh', 'Refresh')}
+                </button>
+              </div>
+            )}
+          </div>
         </div>
       </div>
       <style jsx>{`


### PR DESCRIPTION
- when allowances do not load up in the dapp show a blocking error modal prompting the user to refresh
- fix false display of Apy when the backend returns 0

This is what the error modal looks like. Not super polished but should be okayish to that couple (hopefully not more) of users who will see it
<img width="633" alt="Screenshot 2020-10-16 at 16 16 14" src="https://user-images.githubusercontent.com/579910/96270096-7d4e6700-0fcb-11eb-8bb7-9bf069c12429.png">
