### PR TITLE
[WIP] Adding uniswap strategy - accommodate specific deposit strategies 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ website/network.json
 /playground/public/build/
 
 todo.txt
+.tern-port

--- a/contracts/contracts/interfaces/IStrategy.sol
+++ b/contracts/contracts/interfaces/IStrategy.sol
@@ -1,21 +1,34 @@
 pragma solidity 0.5.11;
+pragma experimental ABIEncoderV2;
+
+import { ParticularConfig } from "../utils/Params.sol";
 
 /**
  * @title Platform interface to integrate with lending platform like Compound, AAVE etc.
  */
 interface IStrategy {
-    function uses_callback() external returns (bool memory);
+    function uses_callback() external returns (bool);
+
+    function use_extra_bytes_for_treasury_actions()
+        external
+        pure
+        returns (ParticularConfig.EscapeHatch);
+
+    function specific_treasury_action_deposit(address asset, uint256 amount)
+        external;
+
+    /* { */
+    /*     return (false, EscapeHatch.None); */
+    /* } */
 
     /**
      * @dev Deposit the given asset to Lending platform.
      * @param _asset asset address
      * @param _amount Amount to deposit
      */
-    function deposit(
-        address _asset,
-        uint256 _amount,
-        bytes calldata data
-    ) external returns (uint256 amountDeposited);
+    function deposit(address _asset, uint256 _amount)
+        external
+        returns (uint256 amountDeposited);
 
     /**
      * @dev Withdraw given asset from Lending platform

--- a/contracts/contracts/interfaces/IStrategy.sol
+++ b/contracts/contracts/interfaces/IStrategy.sol
@@ -52,6 +52,11 @@ interface IStrategy {
         uint256 _amount1
     ) external returns (uint256 amountWithdrawn0, uint256 amountWithdrawn1);
 
+    function check_all_underlying_balances(address pair_addr)
+        external
+        view
+        returns (uint256[] memory balances);
+
     /**
      * @dev Returns the current balance of the given asset.
      */

--- a/contracts/contracts/interfaces/IStrategy.sol
+++ b/contracts/contracts/interfaces/IStrategy.sol
@@ -44,6 +44,14 @@ interface IStrategy {
         uint256 _amount
     ) external returns (uint256 amountWithdrawn);
 
+    function withdraw_two(
+        address _recipient,
+        address _asset0,
+        address _asset1,
+        uint256 _amount0,
+        uint256 _amount1
+    ) external returns (uint256 amountWithdrawn0, uint256 amountWithdrawn1);
+
     /**
      * @dev Returns the current balance of the given asset.
      */

--- a/contracts/contracts/interfaces/IStrategy.sol
+++ b/contracts/contracts/interfaces/IStrategy.sol
@@ -7,13 +7,10 @@ import { ParticularConfig } from "../utils/Params.sol";
  * @title Platform interface to integrate with lending platform like Compound, AAVE etc.
  */
 interface IStrategy {
-    function use_extra_bytes_for_treasury_actions()
+    function deposit_kind()
         external
         pure
-        returns (ParticularConfig.EscapeHatch);
-
-    function specific_treasury_action_deposit(address asset, uint256 amount)
-        external;
+        returns (ParticularConfig.DepositKind);
 
     /**
      * @dev Deposit the given asset to Lending platform.
@@ -23,6 +20,15 @@ interface IStrategy {
     function deposit(address _asset, uint256 _amount)
         external
         returns (uint256 amountDeposited);
+
+    // hack - wanted address[] but can't maintain memory for external, wants calldata
+    // that is needless copying
+    function deposit_two(
+        address _asset0,
+        address _asset1,
+        uint256 _amount0,
+        uint256 _amount1
+    ) external returns (uint256[] memory amountDeposited);
 
     /**
      * @dev Withdraw given asset from Lending platform

--- a/contracts/contracts/interfaces/IStrategy.sol
+++ b/contracts/contracts/interfaces/IStrategy.sol
@@ -9,7 +9,12 @@ import { ParticularConfig } from "../utils/Params.sol";
 interface IStrategy {
     function deposit_kind()
         external
-        pure
+        view
+        returns (ParticularConfig.DepositKind);
+
+    function withdraw_kind()
+        external
+        view
         returns (ParticularConfig.DepositKind);
 
     /**

--- a/contracts/contracts/interfaces/IStrategy.sol
+++ b/contracts/contracts/interfaces/IStrategy.sol
@@ -15,10 +15,6 @@ interface IStrategy {
     function specific_treasury_action_deposit(address asset, uint256 amount)
         external;
 
-    /* { */
-    /*     return (false, EscapeHatch.None); */
-    /* } */
-
     /**
      * @dev Deposit the given asset to Lending platform.
      * @param _asset asset address

--- a/contracts/contracts/interfaces/IStrategy.sol
+++ b/contracts/contracts/interfaces/IStrategy.sol
@@ -4,14 +4,18 @@ pragma solidity 0.5.11;
  * @title Platform interface to integrate with lending platform like Compound, AAVE etc.
  */
 interface IStrategy {
+    function uses_callback() external returns (bool memory);
+
     /**
      * @dev Deposit the given asset to Lending platform.
      * @param _asset asset address
      * @param _amount Amount to deposit
      */
-    function deposit(address _asset, uint256 _amount)
-        external
-        returns (uint256 amountDeposited);
+    function deposit(
+        address _asset,
+        uint256 _amount,
+        bytes calldata data
+    ) external returns (uint256 amountDeposited);
 
     /**
      * @dev Withdraw given asset from Lending platform

--- a/contracts/contracts/interfaces/IStrategy.sol
+++ b/contracts/contracts/interfaces/IStrategy.sol
@@ -7,8 +7,6 @@ import { ParticularConfig } from "../utils/Params.sol";
  * @title Platform interface to integrate with lending platform like Compound, AAVE etc.
  */
 interface IStrategy {
-    function uses_callback() external returns (bool);
-
     function use_extra_bytes_for_treasury_actions()
         external
         pure

--- a/contracts/contracts/interfaces/uniswap/IUniswapV2Router02.sol
+++ b/contracts/contracts/interfaces/uniswap/IUniswapV2Router02.sol
@@ -27,4 +27,14 @@ interface IUniswapV2Router {
             uint256 amountB,
             uint256 liquidity
         );
+
+    function removeLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 liquidity,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    ) external returns (uint256 amountA, uint256 amountB);
 }

--- a/contracts/contracts/interfaces/uniswap/IUniswapV2Router02.sol
+++ b/contracts/contracts/interfaces/uniswap/IUniswapV2Router02.sol
@@ -10,4 +10,21 @@ interface IUniswapV2Router {
         address to,
         uint256 deadline
     ) external returns (uint256[] memory amounts);
+
+    function addLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 amountADesired,
+        uint256 amountBDesired,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    )
+        external
+        returns (
+            uint256 amountA,
+            uint256 amountB,
+            uint256 liquidity
+        );
 }

--- a/contracts/contracts/strategies/CompoundStrategy.sol
+++ b/contracts/contracts/strategies/CompoundStrategy.sol
@@ -204,8 +204,4 @@ contract CompoundStrategy is InitializableAbstractStrategy {
         // e.g. 1e8*1e18 / 205316390724364402565641705 = 0.45 or 0
         amount = _underlying.mul(1e18).div(exchangeRate);
     }
-
-    function use_extra_bytes() external pure returns (bool) {
-        return false;
-    }
 }

--- a/contracts/contracts/strategies/CompoundStrategy.sol
+++ b/contracts/contracts/strategies/CompoundStrategy.sol
@@ -15,15 +15,6 @@ contract CompoundStrategy is InitializableAbstractStrategy {
     event RewardTokenCollected(address recipient, uint256 amount);
     event SkippedWithdrawal(address asset, uint256 amount);
 
-    function requires_multiple_tokens_at_deposit()
-        external
-        pure
-        returns (bool, address[] memory)
-    {
-        address[] memory empty;
-        return (false, empty);
-    }
-
     /**
      * @dev Collect accumulated reward token (COMP) and send to Vault.
      */

--- a/contracts/contracts/strategies/CompoundStrategy.sol
+++ b/contracts/contracts/strategies/CompoundStrategy.sol
@@ -61,7 +61,7 @@ contract CompoundStrategy is InitializableAbstractStrategy {
         address _recipient,
         address _asset,
         uint256 _amount
-    ) external onlyVault returns (uint256 amountWithdrawn, bytes memory) {
+    ) external onlyVault returns (uint256 amountWithdrawn) {
         require(_amount > 0, "Must withdraw something");
         require(_recipient != address(0), "Must specify recipient");
 
@@ -70,7 +70,7 @@ contract CompoundStrategy is InitializableAbstractStrategy {
         uint256 cTokensToRedeem = _convertUnderlyingToCToken(cToken, _amount);
         if (cTokensToRedeem == 0) {
             emit SkippedWithdrawal(_asset, _amount);
-            return (0, bytes(""));
+            return 0;
         }
 
         amountWithdrawn = _amount;

--- a/contracts/contracts/strategies/CompoundStrategy.sol
+++ b/contracts/contracts/strategies/CompoundStrategy.sol
@@ -15,6 +15,15 @@ contract CompoundStrategy is InitializableAbstractStrategy {
     event RewardTokenCollected(address recipient, uint256 amount);
     event SkippedWithdrawal(address asset, uint256 amount);
 
+    function requires_multiple_tokens_at_deposit()
+        external
+        pure
+        returns (bool, address[] memory)
+    {
+        address[] memory empty;
+        return (false, empty);
+    }
+
     /**
      * @dev Collect accumulated reward token (COMP) and send to Vault.
      */
@@ -61,7 +70,7 @@ contract CompoundStrategy is InitializableAbstractStrategy {
         address _recipient,
         address _asset,
         uint256 _amount
-    ) external onlyVault returns (uint256 amountWithdrawn) {
+    ) external onlyVault returns (uint256 amountWithdrawn, bytes memory) {
         require(_amount > 0, "Must withdraw something");
         require(_recipient != address(0), "Must specify recipient");
 
@@ -70,7 +79,7 @@ contract CompoundStrategy is InitializableAbstractStrategy {
         uint256 cTokensToRedeem = _convertUnderlyingToCToken(cToken, _amount);
         if (cTokensToRedeem == 0) {
             emit SkippedWithdrawal(_asset, _amount);
-            return 0;
+            return (0, bytes(""));
         }
 
         amountWithdrawn = _amount;
@@ -140,8 +149,12 @@ contract CompoundStrategy is InitializableAbstractStrategy {
      * @dev Retuns bool indicating whether asset is supported by strategy
      * @param _asset Address of the asset
      */
-    function supportsAsset(address _asset) external view returns (bool) {
-        return assetToPToken[_asset] != address(0);
+    function supportsAsset(address _asset)
+        external
+        view
+        returns (bool, bytes memory)
+    {
+        return (assetToPToken[_asset] != address(0), bytes(""));
     }
 
     /**
@@ -199,5 +212,9 @@ contract CompoundStrategy is InitializableAbstractStrategy {
         // e.g. 1e18*1e18 / 205316390724364402565641705 = 50e8
         // e.g. 1e8*1e18 / 205316390724364402565641705 = 0.45 or 0
         amount = _underlying.mul(1e18).div(exchangeRate);
+    }
+
+    function use_extra_bytes() external pure returns (bool) {
+        return false;
     }
 }

--- a/contracts/contracts/strategies/ThreePoolStrategy.sol
+++ b/contracts/contracts/strategies/ThreePoolStrategy.sol
@@ -114,7 +114,7 @@ contract ThreePoolStrategy is InitializableAbstractStrategy {
         address _recipient,
         address _asset,
         uint256 _amount
-    ) external onlyVault returns (uint256 amountWithdrawn) {
+    ) external onlyVault returns (uint256 amountWithdrawn, bytes memory) {
         require(_recipient != address(0), "Invalid recipient");
         require(_amount > 0, "Invalid amount");
         // Calculate how much of the pool token we need to withdraw
@@ -204,8 +204,12 @@ contract ThreePoolStrategy is InitializableAbstractStrategy {
      * @dev Retuns bool indicating whether asset is supported by strategy
      * @param _asset Address of the asset
      */
-    function supportsAsset(address _asset) external view returns (bool) {
-        return assetToPToken[_asset] != address(0);
+    function supportsAsset(address _asset)
+        external
+        view
+        returns (bool, bytes memory)
+    {
+        return (assetToPToken[_asset] != address(0), bytes(""));
     }
 
     /**
@@ -258,5 +262,9 @@ contract ThreePoolStrategy is InitializableAbstractStrategy {
         // Gauge for LP token
         pToken.safeApprove(crvGaugeAddress, 0);
         pToken.safeApprove(crvGaugeAddress, uint256(-1));
+    }
+
+    function use_extra_bytes() external pure returns (bool) {
+        return false;
     }
 }

--- a/contracts/contracts/strategies/ThreePoolStrategy.sol
+++ b/contracts/contracts/strategies/ThreePoolStrategy.sol
@@ -114,7 +114,7 @@ contract ThreePoolStrategy is InitializableAbstractStrategy {
         address _recipient,
         address _asset,
         uint256 _amount
-    ) external onlyVault returns (uint256 amountWithdrawn, bytes memory) {
+    ) external onlyVault returns (uint256 amountWithdrawn) {
         require(_recipient != address(0), "Invalid recipient");
         require(_amount > 0, "Invalid amount");
         // Calculate how much of the pool token we need to withdraw

--- a/contracts/contracts/strategies/UniswapStrategy.sol
+++ b/contracts/contracts/strategies/UniswapStrategy.sol
@@ -1,0 +1,98 @@
+pragma solidity 0.5.11;
+
+import "@uniswap/v2-periphery/contracts/interfaces/IUniswapV2Router02.sol";
+import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol";
+import "@uniswap/lib/contracts/libraries/Babylonian.sol";
+
+contract UniswapStrategy {
+    using SafeMath for uint256;
+
+    address
+        private constant router = 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D;
+    address private pair;
+
+    function _get_liquidity_value() external view returns (uint256, uint256) {
+        /* (uint256 reserve0, uint256 reserve1, ) = IUniswapV2Pair(pair) */
+        /*     .getReserves(); */
+        /* uint256 pool_token = IERC20(pair).balanceOf(address(this)); */
+        /* uint256 all_pool_token = IERC20(pair).totalSupply(); */
+        /* uint256 _our_share = pool_token / kLast; */
+        /* uint256 root_K = Babylonian.sqrt(reserve0.mul(reserve1)); */
+    }
+
+    function _other_token_of_pair(address asset) internal returns (address) {
+        /* (address token0, address token1) = ( */
+        /*     IUniswapV2Pair(pair).token0(), */
+        /*     IUniswapV2Pair(pair).token1() */
+        /* ); */
+        /* require(asset == token0 || asset == token1, "asset not in pair"); */
+        /* return asset == token0 ? token1 : token0; */
+    }
+
+    function initialize(
+        address _pair,
+        address _token0,
+        address _token1
+    ) external {
+        // so at init time we decide what pair to use
+        /* token0 = _token0; */
+        /* token1 = _token1; */
+        pair = _pair;
+
+        /* IERC20(_token0).safeIncreaseAllowance(router, uint256(-1)); */
+        /* IERC20(_token1).safeIncreaseAllowance(router, uint256(-1)); */
+    }
+
+    //
+    function deposit(address _asset, uint256 _amount)
+        external
+        returns (uint256 amountDeposited)
+    {
+        address _other_token = _other_token_of_pair(asset);
+        if (token0 == _asset) {
+            /* IERC20(token1).safeTransferFrom(msg.sender, address(this), ) */
+        } else {
+            //
+        }
+
+        (, , uint256 lp_token) = IUniswapV2Router02(router).addLiquidity(
+            _other_token,
+            _asset,
+            0,
+            0,
+            0,
+            0,
+            address(this),
+            now + 1200
+        );
+
+        return lp_token;
+    }
+
+    /**
+     * @dev Withdraw given asset from Lending platform
+     */
+    function withdraw(
+        address _recipient,
+        address _asset,
+        uint256 _amount
+    ) external returns (uint256 amountWithdrawn) {
+        address _other_token = _other_token_of_pair(_asset);
+        /* 				IUniswapV2Router02(router).removeLiquidity(_other_token, */
+        /* 																									 _asset, */
+
+        /* ) */
+    }
+
+    /**
+     * @dev Returns the current balance of the given asset.
+     */
+    function checkBalance(address _asset)
+        external
+        view
+        returns (uint256 balance)
+    {
+        //
+        //
+    }
+}

--- a/contracts/contracts/strategies/UniswapStrategy.sol
+++ b/contracts/contracts/strategies/UniswapStrategy.sol
@@ -1,87 +1,210 @@
 pragma solidity 0.5.11;
+pragma experimental ABIEncoderV2;
 
-import "@uniswap/v2-periphery/contracts/interfaces/IUniswapV2Router02.sol";
-import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol";
+// can't just import router - it wants >=0.6.2;
+/* import "@uniswap/v2-periphery/contracts/interfaces/IUniswapV2Router02.sol"; */
+
+// prefer this one
+/* import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol"; */
+import { IUniswapV2Pair } from "../interfaces/uniswap/IUniswapV2Pair.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+
 import "@uniswap/lib/contracts/libraries/Babylonian.sol";
 
-contract UniswapStrategy {
-    using SafeMath for uint256;
+import {
+    IERC20,
+    InitializableAbstractStrategy
+} from "../utils/InitializableAbstractStrategy.sol";
+import { ParticularConfig } from "../utils/Params.sol";
+
+interface IUniswapV2Router02 {
+    function addLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 amountADesired,
+        uint256 amountBDesired,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    )
+        external
+        returns (
+            uint256 amountA,
+            uint256 amountB,
+            uint256 liquidity
+        );
+
+    function removeLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 liquidity,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    ) external returns (uint256 amountA, uint256 amountB);
+}
+
+contract UniswapStrategy is InitializableAbstractStrategy {
+    using SafeERC20 for IERC20;
+
+    struct InPair {
+        address pair;
+        uint256 last_deposited_amount_token0;
+        uint256 last_deposited_amount_token1;
+        uint256 when_deposited;
+    }
+
+    InPair[] in_pairs;
 
     address
         private constant router = 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D;
-    address private pair;
 
-    function _get_liquidity_value() external view returns (uint256, uint256) {
-        /* (uint256 reserve0, uint256 reserve1, ) = IUniswapV2Pair(pair) */
-        /*     .getReserves(); */
-        /* uint256 pool_token = IERC20(pair).balanceOf(address(this)); */
-        /* uint256 all_pool_token = IERC20(pair).totalSupply(); */
-        /* uint256 _our_share = pool_token / kLast; */
-        /* uint256 root_K = Babylonian.sqrt(reserve0.mul(reserve1)); */
+    // for strategy
+    function use_extra_bytes_for_treasury_actions()
+        external
+        pure
+        returns (bool, ParticularConfig.EscapeHatch)
+    {
+        return (true, ParticularConfig.EscapeHatch.Uniswap);
     }
 
-    function _other_token_of_pair(address asset) internal returns (address) {
-        /* (address token0, address token1) = ( */
-        /*     IUniswapV2Pair(pair).token0(), */
-        /*     IUniswapV2Pair(pair).token1() */
-        /* ); */
-        /* require(asset == token0 || asset == token1, "asset not in pair"); */
-        /* return asset == token0 ? token1 : token0; */
+    function _tokens(address p) private returns (address, address) {
+        return (IUniswapV2Pair(p).token0(), IUniswapV2Pair(p).token1());
     }
 
     function initialize(
-        address _pair,
-        address _token0,
-        address _token1
-    ) external {
-        // so at init time we decide what pair to use
-        /* token0 = _token0; */
-        /* token1 = _token1; */
-        pair = _pair;
+        InPair[] calldata start_out_with,
+        address[] calldata router_approvals
+    ) external onlyGovernor initializer {
+        uint256 i = 0;
 
-        /* IERC20(_token0).safeIncreaseAllowance(router, uint256(-1)); */
-        /* IERC20(_token1).safeIncreaseAllowance(router, uint256(-1)); */
+        for (; i < start_out_with.length; i++) {
+            (address token0, address token1) = _tokens(start_out_with[i].pair);
+            in_pairs.push(InPair(start_out_with[i].pair, 0, 0, 0));
+        }
+
+        i = 0;
+
+        for (; i < router_approvals.length; i++) {
+            IERC20(router_approvals[i]).safeIncreaseAllowance(
+                router,
+                uint256(-1)
+            );
+        }
     }
 
-    //
+    function _best_pair_for_asset(address asset) private returns (address) {
+        // todo - does a for loop over pairs and picks the best for
+        // this coin
+        /* return in_pairs[i] */
+        // temp dai_usdt
+        return 0xB20bd5D04BE54f870D5C0d3cA85d82b34B836405;
+    }
+
+    function specific_treasury_action_deposit(address asset, uint256 amount)
+        external
+    {
+        address _best_pair = _best_pair_for_asset(asset);
+        (address token0, address token1) = _tokens(_best_pair);
+        // the transferFroms
+        //
+    }
+
+    // deposit takes a meaning of LP token as percentage of the total pair
+    // TODO could change deposit signature elsewhere?
     function deposit(address _asset, uint256 _amount)
         external
         returns (uint256 amountDeposited)
     {
-        address _other_token = _other_token_of_pair(asset);
-        if (token0 == _asset) {
-            /* IERC20(token1).safeTransferFrom(msg.sender, address(this), ) */
-        } else {
-            //
-        }
+        require(_amount <= 1000, "must be percentage");
 
-        (, , uint256 lp_token) = IUniswapV2Router02(router).addLiquidity(
-            _other_token,
-            _asset,
-            0,
-            0,
-            0,
-            0,
-            address(this),
-            now + 1200
-        );
+        uint256 total_amount = IERC20(_asset).totalSupply();
+        uint256 want_lp_deposit_worth = (total_amount * _amount) / 1000;
 
-        return lp_token;
+        (address token0, address token1) = _tokens(_asset);
+
+        // TODO need to use sqrt to figure out of much of each token to do
+        // the transferFrom
+
+        /* IERC20(token0).transferFrom( */
+        /*     msg.sender, */
+        /*     start_out_with[i].last_deposited_amount_token0 */
+        /* ); */
+
+        /* IERC20(token1).transferFrom( */
+        /*     msg.sender, */
+        /*     start_out_with[i].last_deposited_amount_token0 */
+        /* ); */
+
+        /* address _other_token = _other_token_of_pair(_asset); */
+        /* if (token0 == _asset) { */
+        /* IERC20(token1).safeTransferFrom(msg.sender, address(this), ) */
+        /* } else { */
+        /*     // */
+        /* } */
+
+        /* (, , uint256 lp_token) = IUniswapV2Router02(router).addLiquidity( */
+        /*     _other_token, */
+        /*     _asset, */
+        /*     0, */
+        /*     0, */
+        /*     0, */
+        /*     0, */
+        /*     address(this), */
+        /*     now + 1200 */
+        /* ); */
+        return 0;
+        /* return lp_token; */
     }
 
     /**
      * @dev Withdraw given asset from Lending platform
      */
+
+    // amount is lp token pool amount by percentage
+
+    struct WithdrawAmounts {
+        address token0;
+        address token1;
+        uint256 how_much_remove;
+    }
+
+    function _how_much_remove(address _asset, uint256 _amount)
+        private
+        returns (WithdrawAmounts memory)
+    {
+        (address token0, address token1) = _tokens(_asset);
+        uint256 total_amount = IERC20(_asset).balanceOf(address(this));
+        return WithdrawAmounts(token0, token1, (total_amount * _amount) / 1000);
+    }
+
     function withdraw(
         address _recipient,
         address _asset,
+        // percentage scaled to 1e4
         uint256 _amount
-    ) external returns (uint256 amountWithdrawn) {
-        address _other_token = _other_token_of_pair(_asset);
-        /* 				IUniswapV2Router02(router).removeLiquidity(_other_token, */
-        /* 																									 _asset, */
+    ) external returns (uint256 amountWithdrawn, bytes memory) {
+        require(_amount < 1000, "at most 1000");
+        WithdrawAmounts memory withdraws = _how_much_remove(_asset, _amount);
 
-        /* ) */
+        (uint256 token0_received, uint256 token1_received) = IUniswapV2Router02(
+            router
+        )
+            .removeLiquidity(
+            withdraws.token0,
+            withdraws.token1,
+            withdraws.how_much_remove,
+            // TODO revisit next two params
+            0,
+            0,
+            _recipient,
+            now + 1200
+        );
+
+        // returning uint256(-1) means look at the return bytes
+        return (uint256(-1), abi.encode(token0_received, token1_received));
     }
 
     /**
@@ -94,5 +217,36 @@ contract UniswapStrategy {
     {
         //
         //
+        return 1;
+    }
+
+    function _abstractSetPToken(address _asset, address _pToken) internal {
+        //
+    }
+
+    function safeApproveAllTokens() external {
+        //
+    }
+
+    function liquidate() external {
+        //
+    }
+
+    function supportsAsset(address _asset)
+        external
+        view
+        returns (bool, bytes memory extra_data)
+    {
+        for (uint256 i = 0; i < in_pairs.length; i++) {
+            (address token0, address token1) = (
+                IUniswapV2Pair(in_pairs[i].pair).token0(),
+                IUniswapV2Pair(in_pairs[i].pair).token1()
+            );
+            if (token0 == _asset || token1 == _asset) {
+                return (true, abi.encode(in_pairs[i]));
+            }
+        }
+
+        return (false, bytes(""));
     }
 }

--- a/contracts/contracts/strategies/UniswapStrategy.sol
+++ b/contracts/contracts/strategies/UniswapStrategy.sol
@@ -89,6 +89,22 @@ contract UniswapStrategy is InitializableAbstractStrategy, PairReader {
         return (IUniswapV2Pair(p).token0(), IUniswapV2Pair(p).token1());
     }
 
+    function check_all_underlying_balances(address pair_addr)
+        external
+        view
+        returns (uint256[] memory balances)
+    {
+        uint256[] memory amts = new uint256[](2);
+        uint256 bal = IERC20(pair_addr).balanceOf(address(this));
+        uint256 total_supply = IERC20(pair_addr).totalSupply();
+
+        (uint256 token0, uint256 token1, ) = IUniswapV2Pair(pair_addr)
+            .getReserves();
+        amts[0] = (bal * token0) / total_supply;
+        amts[1] = (bal * token1) / total_supply;
+        return amts;
+    }
+
     function initialize(
         InPair[] calldata start_out_with,
         address[] calldata router_approvals
@@ -140,8 +156,6 @@ contract UniswapStrategy is InitializableAbstractStrategy, PairReader {
         revert("did not find the pair");
     }
 
-    // deposit takes a meaning of LP token as percentage of the total pair
-    // TODO could change deposit signature elsewhere?
     function deposit(address _asset, uint256 _amount)
         external
         returns (uint256 amountDeposited)
@@ -220,9 +234,7 @@ contract UniswapStrategy is InitializableAbstractStrategy, PairReader {
         view
         returns (uint256 balance)
     {
-        //
-        //
-        return 1;
+        revert("not implemented");
     }
 
     function _abstractSetPToken(address _asset, address _pToken) internal {

--- a/contracts/contracts/strategies/UniswapStrategy.sol
+++ b/contracts/contracts/strategies/UniswapStrategy.sol
@@ -66,12 +66,12 @@ contract UniswapStrategy is InitializableAbstractStrategy, PairReader {
         private constant router = 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D;
 
     // for strategy
-    function use_extra_bytes_for_treasury_actions()
+    function deposit_kind()
         external
         pure
-        returns (bool, ParticularConfig.EscapeHatch)
+        returns (ParticularConfig.DepositKind)
     {
-        return (true, ParticularConfig.EscapeHatch.Uniswap);
+        return ParticularConfig.DepositKind.UniswapTwoAsset;
     }
 
     function _tokens(address p) public returns (address, address) {
@@ -99,20 +99,12 @@ contract UniswapStrategy is InitializableAbstractStrategy, PairReader {
         }
     }
 
-    function _best_pair_for_asset(address asset) private returns (address) {
-        // todo - does a for loop over pairs and picks the best for
-        // this coin
-        /* return in_pairs[i] */
-        // temp dai_usdt
-        return 0xB20bd5D04BE54f870D5C0d3cA85d82b34B836405;
-    }
-
-    function specific_treasury_action_deposit(address asset, uint256 amount)
-        external
-    {
-        address _best_pair = _best_pair_for_asset(asset);
-        (address token0, address token1) = _tokens(_best_pair);
-        // the transferFroms
+    function deposit_two(
+        address _token0,
+        address _token1,
+        uint256 _amount0,
+        uint256 _amount1
+    ) public returns (uint256[] memory) {
         //
     }
 

--- a/contracts/contracts/strategies/UniswapStrategy.sol
+++ b/contracts/contracts/strategies/UniswapStrategy.sol
@@ -71,10 +71,18 @@ contract UniswapStrategy is InitializableAbstractStrategy, PairReader {
     // for strategy
     function deposit_kind()
         external
-        pure
+        view
         returns (ParticularConfig.DepositKind)
     {
         return ParticularConfig.DepositKind.UniswapTwoAsset;
+    }
+
+    function withdraw_kind()
+        external
+        view
+        returns (ParticularConfig.WithdrawKind)
+    {
+        return (ParticularConfig.WithdrawKind.UniswapTwoAsset);
     }
 
     function _tokens(address p) public returns (address, address) {

--- a/contracts/contracts/strategies/UniswapStrategy.sol
+++ b/contracts/contracts/strategies/UniswapStrategy.sol
@@ -46,7 +46,11 @@ interface IUniswapV2Router02 {
     ) external returns (uint256 amountA, uint256 amountB);
 }
 
-contract UniswapStrategy is InitializableAbstractStrategy {
+interface PairReader {
+    function _tokens(address p) external returns (address, address);
+}
+
+contract UniswapStrategy is InitializableAbstractStrategy, PairReader {
     using SafeERC20 for IERC20;
 
     struct InPair {
@@ -70,7 +74,7 @@ contract UniswapStrategy is InitializableAbstractStrategy {
         return (true, ParticularConfig.EscapeHatch.Uniswap);
     }
 
-    function _tokens(address p) private returns (address, address) {
+    function _tokens(address p) public returns (address, address) {
         return (IUniswapV2Pair(p).token0(), IUniswapV2Pair(p).token1());
     }
 

--- a/contracts/contracts/utils/InitializableAbstractStrategy.sol
+++ b/contracts/contracts/utils/InitializableAbstractStrategy.sol
@@ -226,7 +226,7 @@ contract InitializableAbstractStrategy is Initializable, Governable {
         address _recipient,
         address _asset,
         uint256 _amount
-    ) external returns (uint256 amountWithdrawn, bytes memory);
+    ) external returns (uint256 amountWithdrawn);
 
     /**
      * @dev Liquidate entire contents of strategy sending assets to Vault.

--- a/contracts/contracts/utils/InitializableAbstractStrategy.sol
+++ b/contracts/contracts/utils/InitializableAbstractStrategy.sol
@@ -15,10 +15,6 @@ contract InitializableAbstractStrategy is Initializable, Governable {
     using SafeERC20 for IERC20;
     using SafeMath for uint256;
 
-    ParticularConfig.EscapeHatch escape_hatch = ParticularConfig
-        .EscapeHatch
-        .None;
-
     event PTokenAdded(address indexed _asset, address _pToken);
     event Deposit(address indexed _asset, address _pToken, uint256 _amount);
     event Withdrawal(address indexed _asset, address _pToken, uint256 _amount);
@@ -185,19 +181,12 @@ contract InitializableAbstractStrategy is Initializable, Governable {
         IERC20(_asset).transfer(governor(), _amount);
     }
 
-    // some contracts need escape valve
-    function use_extra_bytes_for_treasury_actions()
+    function deposit_kind()
         external
         pure
-        returns (bool, ParticularConfig.EscapeHatch)
+        returns (ParticularConfig.DepositKind)
     {
-        return (false, ParticularConfig.EscapeHatch.None);
-    }
-
-    function extra_treasury_action_deposit(address asset, uint256 amount)
-        external
-    {
-        // no op
+        return (ParticularConfig.DepositKind.SingleAsset);
     }
 
     /***************************************

--- a/contracts/contracts/utils/InitializableAbstractStrategy.sol
+++ b/contracts/contracts/utils/InitializableAbstractStrategy.sol
@@ -183,10 +183,18 @@ contract InitializableAbstractStrategy is Initializable, Governable {
 
     function deposit_kind()
         external
-        pure
+        view
         returns (ParticularConfig.DepositKind)
     {
         return (ParticularConfig.DepositKind.SingleAsset);
+    }
+
+    function withdraw_kind()
+        external
+        view
+        returns (ParticularConfig.WithdrawKind)
+    {
+        return (ParticularConfig.WithdrawKind.SingleAsset);
     }
 
     /***************************************

--- a/contracts/contracts/utils/InitializableAbstractStrategy.sol
+++ b/contracts/contracts/utils/InitializableAbstractStrategy.sol
@@ -244,6 +244,11 @@ contract InitializableAbstractStrategy is Initializable, Governable {
         view
         returns (uint256 balance);
 
+    function check_all_underlying_balances(address pair_addr)
+        external
+        view
+        returns (uint256[] memory balances);
+
     /**
      * @dev Check if an asset is supported.
      * @param _asset    Address of the asset

--- a/contracts/contracts/utils/Params.sol
+++ b/contracts/contracts/utils/Params.sol
@@ -1,0 +1,5 @@
+pragma solidity 0.5.11;
+
+library ParticularConfig {
+    enum EscapeHatch { None, Uniswap }
+}

--- a/contracts/contracts/utils/Params.sol
+++ b/contracts/contracts/utils/Params.sol
@@ -2,4 +2,6 @@ pragma solidity 0.5.11;
 
 library ParticularConfig {
     enum DepositKind { SingleAsset, UniswapTwoAsset }
+
+    enum WithdrawKind { SingleAsset, UniswapTwoAsset }
 }

--- a/contracts/contracts/utils/Params.sol
+++ b/contracts/contracts/utils/Params.sol
@@ -1,5 +1,5 @@
 pragma solidity 0.5.11;
 
 library ParticularConfig {
-    enum EscapeHatch { None, Uniswap }
+    enum DepositKind { SingleAsset, UniswapTwoAsset }
 }

--- a/contracts/contracts/vault/VaultCore.sol
+++ b/contracts/contracts/vault/VaultCore.sol
@@ -14,6 +14,7 @@ import "./VaultStorage.sol";
 import { IMinMaxOracle } from "../interfaces/IMinMaxOracle.sol";
 import { IRebaseHooks } from "../interfaces/IRebaseHooks.sol";
 import { ParticularConfig } from "../utils/Params.sol";
+import { PairReader } from "../strategies/UniswapStrategy.sol";
 
 contract VaultCore is VaultStorage {
     /**
@@ -262,7 +263,21 @@ contract VaultCore is VaultStorage {
                     asset.safeTransfer(address(strategy), allocateAmount);
                     strategy.deposit(address(asset), allocateAmount);
                 } else {
-                    //
+                    // since uniswap is the only one right now then the else is
+                    // okay - later in future refactor as switch/if/else like thing
+                    // does vault need to approve on strategy for transferFrom?
+                    PairReader r = PairReader(address(asset));
+                    /* IERC20(address(asset)).safeIncreaseAllowance( */
+                    /*     strategy, */
+                    /*     allocateAmount */
+                    /* ); */
+
+                    /* (address token0) */
+
+                    strategy.specific_treasury_action_deposit(
+                        address(asset),
+                        allocateAmount
+                    );
                 }
             }
         }

--- a/contracts/contracts/vault/VaultCore.sol
+++ b/contracts/contracts/vault/VaultCore.sol
@@ -13,6 +13,7 @@ pragma solidity 0.5.11;
 import "./VaultStorage.sol";
 import { IMinMaxOracle } from "../interfaces/IMinMaxOracle.sol";
 import { IRebaseHooks } from "../interfaces/IRebaseHooks.sol";
+import { ParticularConfig } from "../utils/Params.sol";
 
 contract VaultCore is VaultStorage {
     /**
@@ -253,11 +254,15 @@ contract VaultCore is VaultStorage {
                 IStrategy strategy = IStrategy(depositStrategyAddr);
                 // Transfer asset to Strategy and call deposit method to
                 // mint or take required action
-                asset.safeTransfer(address(strategy), allocateAmount);
-                if (strategy.uses_callback()) {
-                    //
-                } else {
+
+                ParticularConfig.EscapeHatch escape_hatch = strategy
+                    .use_extra_bytes_for_treasury_actions();
+
+                if (escape_hatch == ParticularConfig.EscapeHatch.None) {
+                    asset.safeTransfer(address(strategy), allocateAmount);
                     strategy.deposit(address(asset), allocateAmount);
+                } else {
+                    //
                 }
             }
         }

--- a/contracts/contracts/vault/VaultCore.sol
+++ b/contracts/contracts/vault/VaultCore.sol
@@ -254,7 +254,11 @@ contract VaultCore is VaultStorage {
                 // Transfer asset to Strategy and call deposit method to
                 // mint or take required action
                 asset.safeTransfer(address(strategy), allocateAmount);
-                strategy.deposit(address(asset), allocateAmount);
+                if (strategy.uses_callback()) {
+                    //
+                } else {
+                    strategy.deposit(address(asset), allocateAmount);
+                }
             }
         }
     }

--- a/contracts/contracts/vault/VaultCore.sol
+++ b/contracts/contracts/vault/VaultCore.sol
@@ -288,11 +288,6 @@ contract VaultCore is VaultStorage {
                         token0_amt,
                         token0_amt
                     );
-
-                    /* IERC20(address(asset)).safeIncreaseAllowance( */
-                    /*     strategy, */
-                    /*     allocateAmount */
-                    /* ); */
                 } else {
                     // not possible state
                 }

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -55,6 +55,8 @@
     "web3-utils": "^1.2.11"
   },
   "dependencies": {
+    "@uniswap/v2-core": "^1.0.1",
+    "@uniswap/v2-periphery": "^1.1.0-beta.0",
     "truffle": "^5.1.45"
   }
 }

--- a/contracts/test/_fixture.js
+++ b/contracts/test/_fixture.js
@@ -14,246 +14,252 @@ const crvAbi = require("./abi/erc20.json");
 const crvMinterAbi = require("./abi/crvMinter.json");
 
 async function defaultFixture() {
-  const { governorAddr } = await getNamedAccounts();
+    const { governorAddr } = await getNamedAccounts();
 
-  await deployments.fixture();
+    await deployments.fixture();
 
-  const ousdProxy = await ethers.getContract("OUSDProxy");
-  const vaultProxy = await ethers.getContract("VaultProxy");
-  const compoundStrategyProxy = await ethers.getContract(
-    "CompoundStrategyProxy"
-  );
-
-  const ousd = await ethers.getContractAt("OUSD", ousdProxy.address);
-  const vault = await ethers.getContractAt("IVault", vaultProxy.address);
-  const viewVault = await ethers.getContractAt(
-    "IViewVault",
-    vaultProxy.address
-  );
-  const timelock = await ethers.getContract("Timelock");
-  const minuteTimelock = await ethers.getContract("MinuteTimelock");
-  const governorContract = await ethers.getContract("Governor");
-  const CompoundStrategyFactory = await ethers.getContractFactory(
-    "CompoundStrategy"
-  );
-  const compoundStrategy = await ethers.getContractAt(
-    "CompoundStrategy",
-    compoundStrategyProxy.address
-  );
-  const rebaseHooks = await ethers.getContract("RebaseHooks");
-
-  const curveUSDTStrategyProxy = await ethers.getContract(
-    "CurveUSDTStrategyProxy"
-  );
-  const curveUSDTStrategy = await ethers.getContractAt(
-    "ThreePoolStrategy",
-    curveUSDTStrategyProxy.address
-  );
-
-  const curveUSDCStrategyProxy = await ethers.getContract(
-    "CurveUSDCStrategyProxy"
-  );
-  const curveUSDCStrategy = await ethers.getContractAt(
-    "ThreePoolStrategy",
-    curveUSDCStrategyProxy.address
-  );
-
-  let usdt, dai, tusd, usdc, nonStandardToken, cusdt, cdai, cusdc, comp;
-  let mixOracle,
-    mockOracle,
-    openOracle,
-    chainlinkOracle,
-    chainlinkOracleFeedETH,
-    chainlinkOracleFeedDAI,
-    chainlinkOracleFeedUSDT,
-    chainlinkOracleFeedUSDC,
-    chainlinkOracleFeedTUSD,
-    chainlinkOracleFeedNonStandardToken,
-    openUniswapOracle,
-    viewOpenUniswapOracle,
-    uniswapPairDAI_ETH,
-    uniswapPairUSDC_ETH,
-    uniswapPairUSDT_ETH,
-    crv,
-    crvMinter,
-    threePool,
-    threePoolToken,
-    threePoolGauge;
-
-  if (isGanacheFork) {
-    usdt = await ethers.getContractAt(usdtAbi, addresses.mainnet.USDT);
-    dai = await ethers.getContractAt(daiAbi, addresses.mainnet.DAI);
-    tusd = await ethers.getContractAt(tusdAbi, addresses.mainnet.TUSD);
-    usdc = await ethers.getContractAt(usdcAbi, addresses.mainnet.USDC);
-    comp = await ethers.getContractAt(compAbi, addresses.mainnet.COMP);
-    crv = await ethers.getContractAt(crvAbi, addresses.mainnet.CRV);
-    crvMinter = await ethers.getContractAt(
-      crvMinterAbi,
-      addresses.mainnet.CRVMinter
-    );
-  } else {
-    usdt = await ethers.getContract("MockUSDT");
-    dai = await ethers.getContract("MockDAI");
-    tusd = await ethers.getContract("MockTUSD");
-    usdc = await ethers.getContract("MockUSDC");
-    nonStandardToken = await ethers.getContract("MockNonStandardToken");
-
-    cdai = await ethers.getContract("MockCDAI");
-    cusdt = await ethers.getContract("MockCUSDT");
-    cusdc = await ethers.getContract("MockCUSDC");
-    comp = await ethers.getContract("MockCOMP");
-
-    crv = await ethers.getContract("MockCRV");
-    crvMinter = await ethers.getContract("MockCRVMinter");
-    threePool = await ethers.getContract("MockCurvePool");
-    threePoolToken = await ethers.getContract("Mock3CRV");
-    threePoolGauge = await ethers.getContract("MockCurveGauge");
-
-    // Oracle related fixtures.
-    uniswapPairDAI_ETH = await ethers.getContract("MockUniswapPairDAI_ETH");
-    uniswapPairUSDC_ETH = await ethers.getContract("MockUniswapPairUSDC_ETH");
-    uniswapPairUSDT_ETH = await ethers.getContract("MockUniswapPairUSDT_ETH");
-    openUniswapOracle = await ethers.getContract("OpenUniswapOracle");
-    viewOpenUniswapOracle = await ethers.getContractAt(
-      "IViewEthUsdOracle",
-      openUniswapOracle.address
+    const ousdProxy = await ethers.getContract("OUSDProxy");
+    const vaultProxy = await ethers.getContract("VaultProxy");
+    const compoundStrategyProxy = await ethers.getContract(
+        "CompoundStrategyProxy"
     );
 
-    const chainlinkOracleAddress = (await ethers.getContract("ChainlinkOracle"))
-      .address;
-    chainlinkOracle = await ethers.getContractAt(
-      "IViewEthUsdOracle",
-      chainlinkOracleAddress
+    const ousd = await ethers.getContractAt("OUSD", ousdProxy.address);
+    const vault = await ethers.getContractAt("IVault", vaultProxy.address);
+    const viewVault = await ethers.getContractAt(
+        "IViewVault",
+        vaultProxy.address
+    );
+    const timelock = await ethers.getContract("Timelock");
+    const minuteTimelock = await ethers.getContract("MinuteTimelock");
+    const governorContract = await ethers.getContract("Governor");
+    const CompoundStrategyFactory = await ethers.getContractFactory(
+        "CompoundStrategy"
+    );
+    const compoundStrategy = await ethers.getContractAt(
+        "CompoundStrategy",
+        compoundStrategyProxy.address
+    );
+    const rebaseHooks = await ethers.getContract("RebaseHooks");
+
+    const curveUSDTStrategyProxy = await ethers.getContract(
+        "CurveUSDTStrategyProxy"
+    );
+    const curveUSDTStrategy = await ethers.getContractAt(
+        "ThreePoolStrategy",
+        curveUSDTStrategyProxy.address
     );
 
-    chainlinkOracleFeedETH = await ethers.getContract(
-      "MockChainlinkOracleFeedETH"
+    const curveUSDCStrategyProxy = await ethers.getContract(
+        "CurveUSDCStrategyProxy"
     );
-    chainlinkOracleFeedDAI = await ethers.getContract(
-      "MockChainlinkOracleFeedDAI"
-    );
-    chainlinkOracleFeedUSDT = await ethers.getContract(
-      "MockChainlinkOracleFeedUSDT"
-    );
-    chainlinkOracleFeedUSDC = await ethers.getContract(
-      "MockChainlinkOracleFeedUSDC"
-    );
-    chainlinkOracleFeedTUSD = await ethers.getContract(
-      "MockChainlinkOracleFeedTUSD"
-    );
-    chainlinkOracleFeedNonStandardToken = await ethers.getContract(
-      "MockChainlinkOracleFeedNonStandardToken"
+    const curveUSDCStrategy = await ethers.getContractAt(
+        "ThreePoolStrategy",
+        curveUSDCStrategyProxy.address
     );
 
-    const mixOracleAddress = (await ethers.getContract("MixOracle")).address;
-    mixOracle = await ethers.getContractAt(
-      "IViewMinMaxOracle",
-      mixOracleAddress
-    );
+    let usdt, dai, tusd, usdc, nonStandardToken, cusdt, cdai, cusdc, comp;
+    let mixOracle,
+        mockOracle,
+        openOracle,
+        chainlinkOracle,
+        chainlinkOracleFeedETH,
+        chainlinkOracleFeedDAI,
+        chainlinkOracleFeedUSDT,
+        chainlinkOracleFeedUSDC,
+        chainlinkOracleFeedTUSD,
+        chainlinkOracleFeedNonStandardToken,
+        openUniswapOracle,
+        viewOpenUniswapOracle,
+        uniswapPairDAI_ETH,
+        uniswapPairUSDC_ETH,
+        uniswapPairUSDT_ETH,
+        crv,
+        crvMinter,
+        threePool,
+        threePoolToken,
+        threePoolGauge;
 
-    // MockOracle mocks the open oracle interface,
-    // and is used by the MixOracle.
-    mockOracle = await ethers.getContract("MockOracle");
-    openOracle = mockOracle;
-  }
+    if (isGanacheFork) {
+        usdt = await ethers.getContractAt(usdtAbi, addresses.mainnet.USDT);
+        dai = await ethers.getContractAt(daiAbi, addresses.mainnet.DAI);
+        tusd = await ethers.getContractAt(tusdAbi, addresses.mainnet.TUSD);
+        usdc = await ethers.getContractAt(usdcAbi, addresses.mainnet.USDC);
+        comp = await ethers.getContractAt(compAbi, addresses.mainnet.COMP);
+        crv = await ethers.getContractAt(crvAbi, addresses.mainnet.CRV);
+        crvMinter = await ethers.getContractAt(
+            crvMinterAbi,
+            addresses.mainnet.CRVMinter
+        );
+    } else {
+        usdt = await ethers.getContract("MockUSDT");
+        dai = await ethers.getContract("MockDAI");
+        tusd = await ethers.getContract("MockTUSD");
+        usdc = await ethers.getContract("MockUSDC");
+        nonStandardToken = await ethers.getContract("MockNonStandardToken");
 
-  const cOracle = await ethers.getContract("ChainlinkOracle");
-  const assetAddresses = await getAssetAddresses(deployments);
+        cdai = await ethers.getContract("MockCDAI");
+        cusdt = await ethers.getContract("MockCUSDT");
+        cusdc = await ethers.getContract("MockCUSDC");
+        comp = await ethers.getContract("MockCOMP");
 
-  const sGovernor = await ethers.provider.getSigner(governorAddr);
-  // Add TUSD in fixture, it is disabled by default in deployment
-  await vault.connect(sGovernor).supportAsset(assetAddresses.TUSD);
+        crv = await ethers.getContract("MockCRV");
+        crvMinter = await ethers.getContract("MockCRVMinter");
+        threePool = await ethers.getContract("MockCurvePool");
+        threePoolToken = await ethers.getContract("Mock3CRV");
+        threePoolGauge = await ethers.getContract("MockCurveGauge");
 
-  await cOracle
-    .connect(sGovernor)
-    .registerFeed(chainlinkOracleFeedTUSD.address, "TUSD", false);
+        // Oracle related fixtures.
+        uniswapPairDAI_ETH = await ethers.getContract("MockUniswapPairDAI_ETH");
+        uniswapPairUSDC_ETH = await ethers.getContract(
+            "MockUniswapPairUSDC_ETH"
+        );
+        uniswapPairUSDT_ETH = await ethers.getContract(
+            "MockUniswapPairUSDT_ETH"
+        );
+        openUniswapOracle = await ethers.getContract("OpenUniswapOracle");
+        viewOpenUniswapOracle = await ethers.getContractAt(
+            "IViewEthUsdOracle",
+            openUniswapOracle.address
+        );
 
-  //need to register now
-  const mainOracle = await ethers.getContract("MixOracle");
-  await mainOracle
-    .connect(sGovernor)
-    .registerTokenOracles("TUSD", [cOracle.address], []);
+        const chainlinkOracleAddress = (
+            await ethers.getContract("ChainlinkOracle")
+        ).address;
+        chainlinkOracle = await ethers.getContractAt(
+            "IViewEthUsdOracle",
+            chainlinkOracleAddress
+        );
 
-  if (nonStandardToken) {
+        chainlinkOracleFeedETH = await ethers.getContract(
+            "MockChainlinkOracleFeedETH"
+        );
+        chainlinkOracleFeedDAI = await ethers.getContract(
+            "MockChainlinkOracleFeedDAI"
+        );
+        chainlinkOracleFeedUSDT = await ethers.getContract(
+            "MockChainlinkOracleFeedUSDT"
+        );
+        chainlinkOracleFeedUSDC = await ethers.getContract(
+            "MockChainlinkOracleFeedUSDC"
+        );
+        chainlinkOracleFeedTUSD = await ethers.getContract(
+            "MockChainlinkOracleFeedTUSD"
+        );
+        chainlinkOracleFeedNonStandardToken = await ethers.getContract(
+            "MockChainlinkOracleFeedNonStandardToken"
+        );
+
+        const mixOracleAddress = (await ethers.getContract("MixOracle"))
+            .address;
+        mixOracle = await ethers.getContractAt(
+            "IViewMinMaxOracle",
+            mixOracleAddress
+        );
+
+        // MockOracle mocks the open oracle interface,
+        // and is used by the MixOracle.
+        mockOracle = await ethers.getContract("MockOracle");
+        openOracle = mockOracle;
+    }
+
+    const cOracle = await ethers.getContract("ChainlinkOracle");
+    const assetAddresses = await getAssetAddresses(deployments);
+
+    const sGovernor = await ethers.provider.getSigner(governorAddr);
+    // Add TUSD in fixture, it is disabled by default in deployment
+    await vault.connect(sGovernor).supportAsset(assetAddresses.TUSD);
+
     await cOracle
-      .connect(sGovernor)
-      .registerFeed(
-        chainlinkOracleFeedNonStandardToken.address,
-        "NonStandardToken",
-        false
-      );
+        .connect(sGovernor)
+        .registerFeed(chainlinkOracleFeedTUSD.address, "TUSD", false);
+
+    //need to register now
+    const mainOracle = await ethers.getContract("MixOracle");
     await mainOracle
-      .connect(sGovernor)
-      .registerTokenOracles("NonStandardToken", [cOracle.address], []);
-  }
+        .connect(sGovernor)
+        .registerTokenOracles("TUSD", [cOracle.address], []);
 
-  const signers = await bre.ethers.getSigners();
-  const governor = signers[1];
-  const matt = signers[4];
-  const josh = signers[5];
-  const anna = signers[6];
+    if (nonStandardToken) {
+        await cOracle
+            .connect(sGovernor)
+            .registerFeed(
+                chainlinkOracleFeedNonStandardToken.address,
+                "NonStandardToken",
+                false
+            );
+        await mainOracle
+            .connect(sGovernor)
+            .registerTokenOracles("NonStandardToken", [cOracle.address], []);
+    }
 
-  await fundAccounts();
+    const signers = await bre.ethers.getSigners();
+    const governor = signers[1];
+    const matt = signers[4];
+    const josh = signers[5];
+    const anna = signers[6];
 
-  // Matt and Josh each have $100 OUSD
-  for (const user of [matt, josh]) {
-    await dai.connect(user).approve(vault.address, daiUnits("100"));
-    await vault.connect(user).mint(dai.address, daiUnits("100"));
-  }
+    await fundAccounts();
 
-  return {
-    // Accounts
-    matt,
-    josh,
-    anna,
-    governor,
-    // Contracts
-    ousd,
-    vault,
-    viewVault,
-    rebaseHooks,
-    // Oracle
-    mixOracle,
-    mockOracle,
-    openOracle,
-    chainlinkOracle,
-    chainlinkOracleFeedETH,
-    chainlinkOracleFeedDAI,
-    chainlinkOracleFeedUSDT,
-    chainlinkOracleFeedUSDC,
-    chainlinkOracleFeedTUSD,
-    chainlinkOracleFeedNonStandardToken,
-    openUniswapOracle,
-    viewOpenUniswapOracle,
-    uniswapPairDAI_ETH,
-    uniswapPairUSDC_ETH,
-    uniswapPairUSDT_ETH,
-    timelock,
-    minuteTimelock,
-    governorContract,
-    compoundStrategy,
-    // Assets
-    usdt,
-    dai,
-    tusd,
-    usdc,
-    nonStandardToken,
-    // cTokens
-    cdai,
-    cusdc,
-    cusdt,
-    comp,
-    // CompoundStrategy contract factory to deploy
-    CompoundStrategyFactory,
-    // ThreePool
-    crv,
-    crvMinter,
-    threePool,
-    threePoolGauge,
-    threePoolToken,
-    curveUSDTStrategy,
-    curveUSDCStrategy,
-  };
+    // Matt and Josh each have $100 OUSD
+    for (const user of [matt, josh]) {
+        await dai.connect(user).approve(vault.address, daiUnits("100"));
+        await vault.connect(user).mint(dai.address, daiUnits("100"));
+    }
+
+    return {
+        // Accounts
+        matt,
+        josh,
+        anna,
+        governor,
+        // Contracts
+        ousd,
+        vault,
+        viewVault,
+        rebaseHooks,
+        // Oracle
+        mixOracle,
+        mockOracle,
+        openOracle,
+        chainlinkOracle,
+        chainlinkOracleFeedETH,
+        chainlinkOracleFeedDAI,
+        chainlinkOracleFeedUSDT,
+        chainlinkOracleFeedUSDC,
+        chainlinkOracleFeedTUSD,
+        chainlinkOracleFeedNonStandardToken,
+        openUniswapOracle,
+        viewOpenUniswapOracle,
+        uniswapPairDAI_ETH,
+        uniswapPairUSDC_ETH,
+        uniswapPairUSDT_ETH,
+        timelock,
+        minuteTimelock,
+        governorContract,
+        compoundStrategy,
+        // Assets
+        usdt,
+        dai,
+        tusd,
+        usdc,
+        nonStandardToken,
+        // cTokens
+        cdai,
+        cusdc,
+        cusdt,
+        comp,
+        // CompoundStrategy contract factory to deploy
+        CompoundStrategyFactory,
+        // ThreePool
+        crv,
+        crvMinter,
+        threePool,
+        threePoolGauge,
+        threePoolToken,
+        curveUSDTStrategy,
+        curveUSDCStrategy,
+    };
 }
 
 /**
@@ -261,186 +267,230 @@ async function defaultFixture() {
  * assets and then upgrade the Vault implementation via VaultProxy.
  */
 async function mockVaultFixture() {
-  const fixture = await defaultFixture();
+    const fixture = await defaultFixture();
 
-  // Initialize and configure MockVault
-  const cMockVault = await ethers.getContract("MockVault");
+    // Initialize and configure MockVault
+    const cMockVault = await ethers.getContract("MockVault");
 
-  const { governorAddr } = await getNamedAccounts();
-  const sGovernor = ethers.provider.getSigner(governorAddr);
+    const { governorAddr } = await getNamedAccounts();
+    const sGovernor = ethers.provider.getSigner(governorAddr);
 
-  // There is no need to initialize and setup the mock vault because the
-  // proxy itself is already setup and the proxy is the one with the storage
+    // There is no need to initialize and setup the mock vault because the
+    // proxy itself is already setup and the proxy is the one with the storage
 
-  // Upgrade Vault to MockVault via proxy
-  const cVaultProxy = await ethers.getContract("VaultProxy");
-  await cVaultProxy.connect(sGovernor).upgradeTo(cMockVault.address);
+    // Upgrade Vault to MockVault via proxy
+    const cVaultProxy = await ethers.getContract("VaultProxy");
+    await cVaultProxy.connect(sGovernor).upgradeTo(cMockVault.address);
 
-  return {
-    ...fixture,
-    vault: await ethers.getContractAt("MockVault", cVaultProxy.address),
-  };
+    return {
+        ...fixture,
+        vault: await ethers.getContractAt("MockVault", cVaultProxy.address),
+    };
 }
 
 /**
  * Configure a Vault with only the Compound strategy.
  */
 async function compoundVaultFixture() {
-  const fixture = await defaultFixture();
+    const fixture = await defaultFixture();
 
-  const { governorAddr } = await getNamedAccounts();
-  const sGovernor = await ethers.provider.getSigner(governorAddr);
+    const { governorAddr } = await getNamedAccounts();
+    const sGovernor = await ethers.provider.getSigner(governorAddr);
 
-  await fixture.vault
-    .connect(sGovernor)
-    .addStrategy(fixture.compoundStrategy.address, utils.parseUnits("1", 18));
+    await fixture.vault
+        .connect(sGovernor)
+        .addStrategy(
+            fixture.compoundStrategy.address,
+            utils.parseUnits("1", 18)
+        );
 
-  return fixture;
+    return fixture;
 }
 
 /**
  * Configure a Vault with only the 3Pool strategy.
  */
 async function threepoolVaultFixture() {
-  const fixture = await defaultFixture();
+    const fixture = await defaultFixture();
 
-  const { governorAddr } = await getNamedAccounts();
-  const sGovernor = await ethers.provider.getSigner(governorAddr);
-  // Add 3Pool USDT
-  await fixture.vault
-    .connect(sGovernor)
-    .addStrategy(fixture.curveUSDTStrategy.address, utils.parseUnits("1", 18));
-  // Add 3Pool USDC
-  await fixture.vault
-    .connect(sGovernor)
-    .addStrategy(fixture.curveUSDCStrategy.address, utils.parseUnits("1", 18));
-  return fixture;
+    const { governorAddr } = await getNamedAccounts();
+    const sGovernor = await ethers.provider.getSigner(governorAddr);
+    // Add 3Pool USDT
+    await fixture.vault
+        .connect(sGovernor)
+        .addStrategy(
+            fixture.curveUSDTStrategy.address,
+            utils.parseUnits("1", 18)
+        );
+    // Add 3Pool USDC
+    await fixture.vault
+        .connect(sGovernor)
+        .addStrategy(
+            fixture.curveUSDCStrategy.address,
+            utils.parseUnits("1", 18)
+        );
+    return fixture;
 }
 
 /**
  * Configure a compound fixture with a false valt for testing
  */
 async function compoundFixture() {
-  const { deploy } = deployments;
-  const fixture = await defaultFixture();
+    const { deploy } = deployments;
+    const fixture = await defaultFixture();
 
-  const assetAddresses = await getAssetAddresses(deployments);
+    const assetAddresses = await getAssetAddresses(deployments);
 
-  const { governorAddr } = await getNamedAccounts();
-  const sGovernor = await ethers.provider.getSigner(governorAddr);
+    const { governorAddr } = await getNamedAccounts();
+    const sGovernor = await ethers.provider.getSigner(governorAddr);
 
-  await deploy("StandaloneCompound", {
-    from: governorAddr,
-    contract: "CompoundStrategy",
-  });
+    await deploy("StandaloneCompound", {
+        from: governorAddr,
+        contract: "CompoundStrategy",
+    });
 
-  fixture.cStandalone = await ethers.getContract("StandaloneCompound");
+    fixture.cStandalone = await ethers.getContract("StandaloneCompound");
 
-  // Set governor as vault
-  await fixture.cStandalone.connect(sGovernor).initialize(
-    addresses.dead,
-    governorAddr, // Using Governor in place of Vault here
-    assetAddresses.COMP,
-    [assetAddresses.DAI, assetAddresses.USDC],
-    [assetAddresses.cDAI, assetAddresses.cUSDC]
-  );
+    // Set governor as vault
+    await fixture.cStandalone.connect(sGovernor).initialize(
+        addresses.dead,
+        governorAddr, // Using Governor in place of Vault here
+        assetAddresses.COMP,
+        [assetAddresses.DAI, assetAddresses.USDC],
+        [assetAddresses.cDAI, assetAddresses.cUSDC]
+    );
 
-  await fixture.usdc.transfer(
-    await fixture.matt.getAddress(),
-    utils.parseUnits("1000", 6)
-  );
+    await fixture.usdc.transfer(
+        await fixture.matt.getAddress(),
+        utils.parseUnits("1000", 6)
+    );
 
-  return fixture;
+    return fixture;
 }
 
 /**
  * Configure a threepool fixture with the governer as vault for testing
  */
 async function threepoolFixture() {
-  const { deploy } = deployments;
-  const fixture = await defaultFixture();
-  const assetAddresses = await getAssetAddresses(deployments);
-  const { governorAddr } = await getNamedAccounts();
-  const sGovernor = await ethers.provider.getSigner(governorAddr);
+    const { deploy } = deployments;
+    const fixture = await defaultFixture();
+    const assetAddresses = await getAssetAddresses(deployments);
+    const { governorAddr } = await getNamedAccounts();
+    const sGovernor = await ethers.provider.getSigner(governorAddr);
 
-  await deploy("StandaloneThreePool", {
-    from: governorAddr,
-    contract: "ThreePoolStrategy",
-  });
+    await deploy("StandaloneThreePool", {
+        from: governorAddr,
+        contract: "ThreePoolStrategy",
+    });
 
-  fixture.tpStandalone = await ethers.getContract("StandaloneThreePool");
+    fixture.tpStandalone = await ethers.getContract("StandaloneThreePool");
 
-  // Set governor as vault
-  await fixture.tpStandalone
-    .connect(sGovernor)
-    ["initialize(address,address,address,address,address,address,address)"](
-      assetAddresses.ThreePool,
-      governorAddr, // Using Governor in place of Vault here
-      assetAddresses.CRV,
-      assetAddresses.USDT,
-      assetAddresses.ThreePoolToken,
-      assetAddresses.ThreePoolGauge,
-      assetAddresses.CRVMinter
+    // Set governor as vault
+    await fixture.tpStandalone
+        .connect(sGovernor)
+        ["initialize(address,address,address,address,address,address,address)"](
+            assetAddresses.ThreePool,
+            governorAddr, // Using Governor in place of Vault here
+            assetAddresses.CRV,
+            assetAddresses.USDT,
+            assetAddresses.ThreePoolToken,
+            assetAddresses.ThreePoolGauge,
+            assetAddresses.CRVMinter
+        );
+
+    return fixture;
+}
+
+/**
+ * Configure a uniswap fixture with the governer as vault for testing
+ */
+async function uniswapFixture() {
+    const { deploy } = deployments;
+    const fixture = await defaultFixture();
+    const assetAddresses = await getAssetAddresses(deployments);
+    const { governorAddr } = await getNamedAccounts();
+    const sGovernor = await ethers.provider.getSigner(governorAddr);
+
+    await deploy("StandaloneUniswap", {
+        from: governorAddr,
+        contract: "UniswapStrategy",
+    });
+
+    fixture.uniswapStandalone = await ethers.getContract("StandaloneUniswap");
+
+    // Set governor as vault
+    fixture.uniswapStandalone = await fixture.uniswapStandalone.connect(
+        sGovernor
     );
+    // ["initialize(address,address,address,address,address,address,address)"](
+    //     assetAddresses.ThreePool,
+    //     governorAddr, // Using Governor in place of Vault here
+    //     assetAddresses.CRV,
+    //     assetAddresses.USDT,
+    //     assetAddresses.ThreePoolToken,
+    //     assetAddresses.ThreePoolGauge,
+    //     assetAddresses.CRVMinter
+    // );
 
-  return fixture;
+    return fixture;
 }
 
 /**
  * Configure a Vault with two strategies
  */
 async function multiStrategyVaultFixture() {
-  const { deploy } = deployments;
+    const { deploy } = deployments;
 
-  const fixture = await compoundVaultFixture();
+    const fixture = await compoundVaultFixture();
 
-  const assetAddresses = await getAssetAddresses(deployments);
+    const assetAddresses = await getAssetAddresses(deployments);
 
-  const { governorAddr } = await getNamedAccounts();
-  const sGovernor = await ethers.provider.getSigner(governorAddr);
+    const { governorAddr } = await getNamedAccounts();
+    const sGovernor = await ethers.provider.getSigner(governorAddr);
 
-  await deploy("StrategyTwo", {
-    from: governorAddr,
-    contract: "CompoundStrategy",
-  });
+    await deploy("StrategyTwo", {
+        from: governorAddr,
+        contract: "CompoundStrategy",
+    });
 
-  const cStrategyTwo = await ethers.getContract("StrategyTwo");
-  //
-  // Initialize the secons strategy with only DAI
-  await cStrategyTwo
-    .connect(sGovernor)
-    .initialize(
-      addresses.dead,
-      fixture.vault.address,
-      assetAddresses.COMP,
-      [assetAddresses.DAI, assetAddresses.USDC],
-      [assetAddresses.cDAI, assetAddresses.cUSDC]
-    );
+    const cStrategyTwo = await ethers.getContract("StrategyTwo");
+    //
+    // Initialize the secons strategy with only DAI
+    await cStrategyTwo
+        .connect(sGovernor)
+        .initialize(
+            addresses.dead,
+            fixture.vault.address,
+            assetAddresses.COMP,
+            [assetAddresses.DAI, assetAddresses.USDC],
+            [assetAddresses.cDAI, assetAddresses.cUSDC]
+        );
 
-  // Add second strategy to Vault
-  await fixture.vault
-    .connect(sGovernor)
-    .addStrategy(cStrategyTwo.address, utils.parseUnits("1", 18));
+    // Add second strategy to Vault
+    await fixture.vault
+        .connect(sGovernor)
+        .addStrategy(cStrategyTwo.address, utils.parseUnits("1", 18));
 
-  // Set strategy weights to 5e17 each (50%)
-  await fixture.vault
-    .connect(sGovernor)
-    .setStrategyWeights(
-      [fixture.compoundStrategy.address, cStrategyTwo.address],
-      [utils.parseUnits("5", 17), utils.parseUnits("5", 17)]
-    );
+    // Set strategy weights to 5e17 each (50%)
+    await fixture.vault
+        .connect(sGovernor)
+        .setStrategyWeights(
+            [fixture.compoundStrategy.address, cStrategyTwo.address],
+            [utils.parseUnits("5", 17), utils.parseUnits("5", 17)]
+        );
 
-  fixture.strategyTwo = cStrategyTwo;
+    fixture.strategyTwo = cStrategyTwo;
 
-  return fixture;
+    return fixture;
 }
 
 module.exports = {
-  defaultFixture,
-  mockVaultFixture,
-  compoundFixture,
-  compoundVaultFixture,
-  multiStrategyVaultFixture,
-  threepoolFixture,
-  threepoolVaultFixture,
+    defaultFixture,
+    mockVaultFixture,
+    compoundFixture,
+    compoundVaultFixture,
+    multiStrategyVaultFixture,
+    threepoolFixture,
+    uniswapFixture,
+    threepoolVaultFixture,
 };

--- a/contracts/test/strategies/truf-based-uniswap-strat.js
+++ b/contracts/test/strategies/truf-based-uniswap-strat.js
@@ -1,0 +1,76 @@
+const BigNumber = require("bignumber.js");
+BigNumber.set({ EXPONENTIAL_AT: [-70, 200] });
+const UniswapStrategy = artifacts.require("UniswapStrategy");
+const Vault = artifacts.require("Vault");
+const {
+    abi: erc20_abi,
+} = require("@openzeppelin/contracts/build/contracts/ERC20");
+
+const { abi: pair_abi } = require("@uniswap/v2-core/build/IUniswapV2Pair");
+
+const Binance = "0x3f5CE5FBFe3E9af3971dD833D26bA9b5C936f0bE";
+
+const usdc_addr = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+const dai_addr = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
+const usdt_addr = `0xdAC17F958D2ee523a2206206994597C13D831ec7`;
+
+const stablecoins = [usdc_addr, dai_addr, usdt_addr];
+
+const vault_addr = `0xf251Cb9129fdb7e9Ca5cad097dE3eA70caB9d8F9`;
+// const mainnet_vault = await Vault.at(vault_addr);
+
+const usdc = new web3.eth.Contract(erc20_abi, usdc_addr);
+const usdt = new web3.eth.Contract(erc20_abi, usdt_addr);
+const dai = new web3.eth.Contract(erc20_abi, dai_addr);
+
+const dai_usdt = `0xb20bd5d04be54f870d5c0d3ca85d82b34b836405`;
+const usdc_usdt = `0x3041cbd36888becc7bbcbc0045e3b1f144466f5f`;
+const dai_usdc = `0xae461ca67b15dc8dc81ce7615e0320da1a9ab8d5`;
+
+const PAIRS = [
+    Object.values({
+        pair: dai_usdt,
+        last_deposited_amount_token0: 0,
+        last_deposited_amount_token1: 0,
+        when_deposited: 0,
+    }),
+    Object.values({
+        pair: usdc_usdt,
+        last_deposited_amount_token0: 0,
+        last_deposited_amount_token1: 0,
+        when_deposited: 0,
+    }),
+    Object.values({
+        pair: dai_usdc,
+        last_deposited_amount_token0: 0,
+        last_deposited_amount_token1: 0,
+        when_deposited: 0,
+    }),
+];
+
+contract("UniswapStrategy", (accounts) => {
+    const [main_account, someone_else] = accounts;
+
+    const fund_contract = async (addr) => {
+        return Promise.all([
+            usdc.methods.transfer(addr, `${1000e6}`).send({ from: Binance }),
+            usdt.methods.transfer(addr, `${1000e6}`).send({ from: Binance }),
+            dai.methods
+                .transfer(addr, new BigNumber(`${1000e18}`).toString())
+                .send({ from: Binance }),
+        ]);
+    };
+
+    it("initializes with pairs", async () => {
+        const instance = await UniswapStrategy.new();
+        await instance.initialize(PAIRS, stablecoins);
+    });
+
+    it("intializes and funds the contract, depositing liquidity", async () => {
+        const instance = await UniswapStrategy.new();
+        await instance.initialize(PAIRS, stablecoins);
+        await fund_contract(instance.address);
+        // 1%
+        await instance.deposit(usdc_usdt, `10`);
+    });
+});

--- a/contracts/test/strategies/truf-based-uniswap-strat.js
+++ b/contracts/test/strategies/truf-based-uniswap-strat.js
@@ -1,9 +1,11 @@
+const { utils } = require("ethers");
+
 const BigNumber = require("bignumber.js");
 BigNumber.set({ EXPONENTIAL_AT: [-70, 200] });
 const UniswapStrategy = artifacts.require("UniswapStrategy");
 const Vault = artifacts.require("Vault");
 const {
-    abi: erc20_abi,
+  abi: erc20_abi,
 } = require("@openzeppelin/contracts/build/contracts/ERC20");
 
 const { abi: pair_abi } = require("@uniswap/v2-core/build/IUniswapV2Pair");
@@ -28,49 +30,60 @@ const usdc_usdt = `0x3041cbd36888becc7bbcbc0045e3b1f144466f5f`;
 const dai_usdc = `0xae461ca67b15dc8dc81ce7615e0320da1a9ab8d5`;
 
 const PAIRS = [
-    Object.values({
-        pair: dai_usdt,
-        last_deposited_amount_token0: 0,
-        last_deposited_amount_token1: 0,
-        when_deposited: 0,
-    }),
-    Object.values({
-        pair: usdc_usdt,
-        last_deposited_amount_token0: 0,
-        last_deposited_amount_token1: 0,
-        when_deposited: 0,
-    }),
-    Object.values({
-        pair: dai_usdc,
-        last_deposited_amount_token0: 0,
-        last_deposited_amount_token1: 0,
-        when_deposited: 0,
-    }),
+  Object.values({
+    pair: dai_usdt,
+    last_deposited_amount_token0: 0,
+    last_deposited_amount_token1: 0,
+    when_deposited: 0,
+  }),
+  Object.values({
+    pair: usdc_usdt,
+    last_deposited_amount_token0: 0,
+    last_deposited_amount_token1: 0,
+    when_deposited: 0,
+  }),
+  Object.values({
+    pair: dai_usdc,
+    last_deposited_amount_token0: 0,
+    last_deposited_amount_token1: 0,
+    when_deposited: 0,
+  }),
 ];
 
 contract("UniswapStrategy", (accounts) => {
-    const [main_account, someone_else] = accounts;
+  const [main_account, someone_else] = accounts;
 
-    const fund_contract = async (addr) => {
-        return Promise.all([
-            usdc.methods.transfer(addr, `${1000e6}`).send({ from: Binance }),
-            usdt.methods.transfer(addr, `${1000e6}`).send({ from: Binance }),
-            dai.methods
-                .transfer(addr, new BigNumber(`${1000e18}`).toString())
-                .send({ from: Binance }),
-        ]);
-    };
+  const fund_contract = async (addr) => {
+    return Promise.all([
+      usdc.methods.transfer(addr, `${1000e6}`).send({ from: Binance }),
+      usdt.methods.transfer(addr, `${1000e6}`).send({ from: Binance }),
+      dai.methods
+        .transfer(addr, new BigNumber(`${1000e18}`).toString())
+        .send({ from: Binance }),
+    ]);
+  };
 
-    it("initializes with pairs", async () => {
-        const instance = await UniswapStrategy.new();
-        await instance.initialize(PAIRS, stablecoins);
-    });
+  it("initializes with pairs", async () => {
+    const instance = await UniswapStrategy.new();
+    await instance.initialize(PAIRS, stablecoins);
+  });
 
-    it("intializes and funds the contract, depositing liquidity", async () => {
-        const instance = await UniswapStrategy.new();
-        await instance.initialize(PAIRS, stablecoins);
-        await fund_contract(instance.address);
-        // 1%
-        await instance.deposit(usdc_usdt, `10`);
-    });
+  it("initializes and funds the contract, depositing liquidity", async () => {
+    const instance = await UniswapStrategy.new();
+    await instance.initialize(PAIRS, stablecoins);
+    await fund_contract(instance.address);
+    // 1%
+    await instance.deposit(usdc_usdt, `10`);
+  });
+
+  it("initializes, funds, and runs vault depositing ", async () => {
+    const vault_instance = await Vault.new();
+    const uniswap_instance = await UniswapStrategy.new();
+    await uniswap_instance.initialize(PAIRS, stablecoins);
+    await fund_contract(vault_instance.address);
+    await vault_instance.addStrategy(
+      uniswap_instance.address,
+      utils.parseUnits("1", 18)
+    );
+  });
 });

--- a/contracts/test/strategies/truf-based-uniswap-strat.js
+++ b/contracts/test/strategies/truf-based-uniswap-strat.js
@@ -96,7 +96,6 @@ contract("UniswapStrategy", (accounts) => {
         const instance = await UniswapStrategy.new();
         await instance.initialize(PAIRS, stablecoins);
         await fund_contract(instance.address);
-        // 1%
         await instance.deposit_two(
             dai_addr,
             usdc_addr,
@@ -104,8 +103,20 @@ contract("UniswapStrategy", (accounts) => {
             new BigNumber(`${200e6}`).toString()
         );
 
-        // should revert - add the expect
-        // await instance.deposit(usdc_addr, `${1e18}`);
+        await instance.deposit_two(
+            dai_addr,
+            usdc_addr,
+            new BigNumber(`${200e18}`).toString(),
+            new BigNumber(`${200e6}`).toString()
+        );
+
+        await instance.withdraw_two(
+            instance.address,
+            dai_addr,
+            usdc_addr,
+            new BigNumber(`${200e18}`).toString(),
+            new BigNumber(`${200e6}`).toString()
+        );
     });
 
     it("initializes, funds, and runs vault depositing ", async () => {

--- a/contracts/test/strategies/truf-based-uniswap-strat.js
+++ b/contracts/test/strategies/truf-based-uniswap-strat.js
@@ -110,12 +110,18 @@ contract("UniswapStrategy", (accounts) => {
             new BigNumber(`${200e6}`).toString()
         );
 
+        const amts = await instance.check_all_underlying_balances(dai_usdc);
+        console.log(amts);
+        const [dai_amt, usdc_amt] = amts.map((b) => b.toString());
+
+        console.log({ dai_amt, usdc_amt });
+
         await instance.withdraw_two(
             instance.address,
             dai_addr,
             usdc_addr,
-            new BigNumber(`${200e18}`).toString(),
-            new BigNumber(`${200e6}`).toString()
+            dai_amt,
+            usdc_amt
         );
     });
 

--- a/contracts/test/strategies/truf-based-uniswap-strat.js
+++ b/contracts/test/strategies/truf-based-uniswap-strat.js
@@ -92,6 +92,22 @@ contract("UniswapStrategy", (accounts) => {
         // await instance.deposit(usdc_addr, `${1e18}`);
     });
 
+    it("initializes, funds the contract, depositing, removing liquidity", async () => {
+        const instance = await UniswapStrategy.new();
+        await instance.initialize(PAIRS, stablecoins);
+        await fund_contract(instance.address);
+        // 1%
+        await instance.deposit_two(
+            dai_addr,
+            usdc_addr,
+            new BigNumber(`${200e18}`).toString(),
+            new BigNumber(`${200e6}`).toString()
+        );
+
+        // should revert - add the expect
+        // await instance.deposit(usdc_addr, `${1e18}`);
+    });
+
     it("initializes, funds, and runs vault depositing ", async () => {
         const vault_instance = await Vault.new();
         const uniswap_instance = await UniswapStrategy.new();

--- a/contracts/test/strategies/uniswap-standalone.js
+++ b/contracts/test/strategies/uniswap-standalone.js
@@ -1,0 +1,22 @@
+const { uniswapFixture } = require("../_fixture");
+const { loadFixture } = require("../helpers");
+
+describe("Uniswap Strategy Standalone", function () {
+  this.timeout(400000000000000);
+
+  let uniswapStrategy, uniswapStandalone, governor;
+
+  beforeEach(async function () {
+    const fixture = await loadFixture(uniswapFixture);
+    governor = fixture.governor;
+
+    uniswapStandalone = fixture.uniswapStandalone;
+
+    uniswapStrategy = uniswapStandalone.connect(governor);
+  });
+
+  it("should add uniswap strategy", async () => {
+    const result = await uniswapStrategy.sample();
+    console.log("called;", { result: result.toString() });
+  });
+});

--- a/contracts/test/vault/index.js
+++ b/contracts/test/vault/index.js
@@ -414,4 +414,12 @@ describe("Vault", function () {
       "Caller is not the Governor"
     );
   });
+
+  it("Should be able to add uniswap strategy", async () => {
+    const { vault, uniswapStandalone } = await loadFixture(defaultFixture);
+
+    // expect(vault.setRebaseThreshold(ousdUnits("400"))).to.be.revertedWith(
+    //   "Caller is not the Governor"
+    // );
+  });
 });

--- a/contracts/truffle-config.js
+++ b/contracts/truffle-config.js
@@ -18,7 +18,7 @@ module.exports = {
     },
     fork: {
       host: "127.0.0.1",
-      port: 7545,
+      port: 8545,
       network_id: "*",
     },
   },


### PR DESCRIPTION
Current PR presents an alternative flow for deposits of specific strategies - pushed by the need of uniswap today and any in the future. 

I think current approach leaves existing code alone (keeps old APIs - while extending for the special cases as each strategy might want) 

took me a little bit of time to think about how to do it decently elegantly - expect quite a bit more commits coming in pipeline 

