### PR TITLE
bug fixes

### DIFF
--- a/dapp/src/components/buySell/BalanceHeader.js
+++ b/dapp/src/components/buySell/BalanceHeader.js
@@ -179,7 +179,7 @@ const BalanceHeader = () => {
         if (animateCancel) animateCancel()
       }
     }
-  }, [ousdBalance])
+  }, [ousdBalance, apy])
 
   const displayedBalance = formatCurrency(animatedOusdBalance || 0, 6)
   const displayedBalanceNum = parseFloat(displayedBalance)

--- a/dapp/src/components/buySell/SellWidget.js
+++ b/dapp/src/components/buySell/SellWidget.js
@@ -15,7 +15,6 @@ import UtilsStore from 'stores/UtilsStore'
 import DisclaimerTooltip from 'components/buySell/DisclaimerTooltip'
 import { gasLimits } from 'constants/Contract'
 import { isMobileMetaMask } from 'utils/device'
-import { sleep } from 'utils/utils'
 
 import mixpanel from 'utils/mixpanel'
 

--- a/dapp/src/components/buySell/SellWidget.js
+++ b/dapp/src/components/buySell/SellWidget.js
@@ -228,8 +228,6 @@ const SellWidget = ({
   let calculateItTimeout
   const calculateSplits = async (sellAmount) => {
     const calculateIt = async (calculateSplitsTime) => {
-      setSellWidgetIsCalculating(true)
-
       try {
         const assetAmounts = await viewVault.calculateRedeemOutputs(
           ethers.utils.parseUnits(
@@ -259,23 +257,17 @@ const SellWidget = ({
           })
         )
 
-        if (
-          calculateSplitsTime === latestCalculateSplits.current
-        ) {
+        if (calculateSplitsTime === latestCalculateSplits.current) {
           setSellWidgetCoinSplit(assets)
         }
       } catch (err) {
         console.error(err)
-        if (
-          calculateSplitsTime === latestCalculateSplits.current
-        ) {
+        if (calculateSplitsTime === latestCalculateSplits.current) {
           setSellWidgetCoinSplit([])
         }
       }
 
-      if (
-        calculateSplitsTime === latestCalculateSplits.current
-      ) {
+      if (calculateSplitsTime === latestCalculateSplits.current) {
         setSellWidgetIsCalculating(false)
       }
     }
@@ -286,6 +278,7 @@ const SellWidget = ({
 
     calculateItTimeout = setTimeout(async () => {
       const currentTime = Date.now()
+      setSellWidgetIsCalculating(true)
       /* Need this to act as a mutable obeject, so no matter the order in which the multiple
        * "calculateIt" calls execute / update state. Only the one invoked the last is allowed
        * to update state.
@@ -503,6 +496,7 @@ const SellWidget = ({
                 !(ousdToSellNumber > 0) ||
                 // wait for the coins splits to load up before enabling button otherwise transaction in history UI breaks
                 !(positiveCoinSplitCurrencies.length > 0) ||
+                sellWidgetIsCalculating ||
                 sellWidgetState !== 'sell now'
               }
               className="btn-blue"

--- a/dapp/src/stores/UtilsStore.js
+++ b/dapp/src/stores/UtilsStore.js
@@ -1,0 +1,9 @@
+import { Store } from 'pullstate'
+/*
+ * Random stuff in here
+ */
+const UtilsStore = new Store({
+  latestCalculateSplits: null,
+})
+
+export default UtilsStore

--- a/dapp/src/stores/UtilsStore.js
+++ b/dapp/src/stores/UtilsStore.js
@@ -1,9 +1,0 @@
-import { Store } from 'pullstate'
-/*
- * Random stuff in here
- */
-const UtilsStore = new Store({
-  latestCalculateSplits: null,
-})
-
-export default UtilsStore


### PR DESCRIPTION
- possible fix for OUSD balance animation
- fix for sell input field doesn't have the persistent "0" number
- fix for sometimes wrong redeeming stablecoin values
- fix a bug where:
  - user already had an ousd value to sell and stable coin redeem info present
  - would rapidly alter the ousd to sell and quickly press the sell button
  - transaction detail would show the old stable coin info (before the latest change)
  - fix for this: sell button is disabled as long as the latest stable coin info is not displayed

**Connected issue:** https://github.com/OriginProtocol/origin-dollar/issues/328