### PR TITLE
Tomlinton/rebasestate tweak

### DIFF
--- a/contracts/contracts/token/OUSD.sol
+++ b/contracts/contracts/token/OUSD.sol
@@ -362,7 +362,7 @@ contract OUSD is Initializable, InitializableToken, Governable {
             nonRebasingCredits = nonRebasingCredits.sub(creditAmount);
             nonRebasingSupply = nonRebasingSupply.sub(_amount);
         } else {
-            rebasingCredits.sub(creditAmount);
+            rebasingCredits = rebasingCredits.sub(creditAmount);
         }
 
         emit Transfer(_account, address(0), _amount);

--- a/contracts/contracts/token/OUSD.sol
+++ b/contracts/contracts/token/OUSD.sol
@@ -45,9 +45,9 @@ contract OUSD is Initializable, InitializableToken, Governable {
     uint256 public nonRebasingCredits;
     uint256 public nonRebasingSupply;
     mapping(address => uint256) public nonRebasingCreditsPerToken;
-    // Uint8 represents opt in state
+    // int8 represents opt in state
     // -1 explicit opt out
-    // 0 (default) not set (contracts by default opt on, EOAs by default opt in)
+    // 0 (default) not set (contracts by default opt out, EOAs by default opt in)
     // 1 explicit opt in
     mapping(address => int8) public rebaseState;
 

--- a/contracts/contracts/token/OUSD.sol
+++ b/contracts/contracts/token/OUSD.sol
@@ -49,7 +49,8 @@ contract OUSD is Initializable, InitializableToken, Governable {
     // -1 explicit opt out
     // 0 (default) not set (contracts by default opt out, EOAs by default opt in)
     // 1 explicit opt in
-    mapping(address => int8) public rebaseState;
+    enum RebaseOptions { NotSet, OptOut, OptIn }
+    mapping(address => RebaseOptions) public rebaseState;
 
     function initialize(
         string calldata _nameArg,
@@ -398,11 +399,11 @@ contract OUSD is Initializable, InitializableToken, Governable {
         if (Address.isContract(_account)) {
             // Contracts by default opt out
             // Check for explicit opt in
-            return rebaseState[_account] != 1;
+            return rebaseState[_account] != RebaseOptions.OptIn;
         } else {
             // EOAs by default opt in
             // Check for explicit opt out
-            return rebaseState[_account] == -1;
+            return rebaseState[_account] == RebaseOptions.OptOut;
         }
     }
 
@@ -422,7 +423,7 @@ contract OUSD is Initializable, InitializableToken, Governable {
             _creditBalances[msg.sender]
         );
         _creditBalances[msg.sender] = newCreditBalance;
-        rebaseState[msg.sender] = 1;
+        rebaseState[msg.sender] = RebaseOptions.OptIn;
         delete nonRebasingCreditsPerToken[msg.sender];
     }
 
@@ -436,7 +437,7 @@ contract OUSD is Initializable, InitializableToken, Governable {
         );
         nonRebasingSupply = nonRebasingSupply.add(balanceOf(msg.sender));
         nonRebasingCreditsPerToken[msg.sender] = rebasingCreditsPerToken;
-        rebaseState[msg.sender] = -1;
+        rebaseState[msg.sender] = RebaseOptions.OptOut;
     }
 
     /**

--- a/contracts/contracts/token/OUSD.sol
+++ b/contracts/contracts/token/OUSD.sol
@@ -45,10 +45,7 @@ contract OUSD is Initializable, InitializableToken, Governable {
     uint256 public nonRebasingCredits;
     uint256 public nonRebasingSupply;
     mapping(address => uint256) public nonRebasingCreditsPerToken;
-    // int8 represents opt in state
-    // -1 explicit opt out
-    // 0 (default) not set (contracts by default opt out, EOAs by default opt in)
-    // 1 explicit opt in
+    //  0=NotSet, 1=OptOut, 2=OptIn
     enum RebaseOptions { NotSet, OptOut, OptIn }
     mapping(address => RebaseOptions) public rebaseState;
 

--- a/contracts/test/token.js
+++ b/contracts/test/token.js
@@ -327,17 +327,32 @@ describe("Token", function () {
     expect(await ousd.totalSupply()).to.equal(totalSupplyBefore);
   });
 
-  it("Should not allow calling rebaseOptIn when already opted in to rebasing", async () => {
+  it("Should not allow EOA to call rebaseOptIn when already opted in to rebasing", async () => {
     let { ousd, matt } = await loadFixture(defaultFixture);
     await expect(ousd.connect(matt).rebaseOptIn()).to.be.revertedWith(
       "Account has not opted out"
     );
   });
 
-  it("Should not allow calling rebaseOptOut when already opted out of rebasing", async () => {
+  it("Should not allow EOA to call rebaseOptOut when already opted out of rebasing", async () => {
     let { ousd, matt } = await loadFixture(defaultFixture);
     await ousd.connect(matt).rebaseOptOut();
     await expect(ousd.connect(matt).rebaseOptOut()).to.be.revertedWith(
+      "Account has not opted in"
+    );
+  });
+
+  it("Should not allow contract to call rebaseOptIn when already opted in to rebasing", async () => {
+    let { mockNonRebasing } = await loadFixture(defaultFixture);
+    await mockNonRebasing.rebaseOptIn();
+    await expect(mockNonRebasing.rebaseOptIn()).to.be.revertedWith(
+      "Account has not opted out"
+    );
+  });
+
+  it("Should not allow contract to call rebaseOptOut when already opted out of rebasing", async () => {
+    let { mockNonRebasing } = await loadFixture(defaultFixture);
+    await expect(mockNonRebasing.rebaseOptOut()).to.be.revertedWith(
       "Account has not opted in"
     );
   });

--- a/contracts/test/vault/redeem.js
+++ b/contracts/test/vault/redeem.js
@@ -44,32 +44,33 @@ describe("Vault Redeem", function () {
     await expect(anna).has.a.balanceOf("0.00", ousd);
     await expect(matt).has.a.balanceOf("100.00", ousd);
 
+    // Anna mints OUSD with USDC
     await usdc.connect(anna).approve(vault.address, usdcUnits("1000.00"));
     await vault.connect(anna).mint(usdc.address, usdcUnits("1000.00"));
-
     await expect(anna).has.a.balanceOf("1000.00", ousd);
     await expect(matt).has.a.balanceOf("100.00", ousd);
 
+    // Anna mints OUSD with DAI
     await dai.connect(anna).approve(vault.address, daiUnits("1000.00"));
     await vault.connect(anna).mint(dai.address, daiUnits("1000.00"));
-
     await expect(anna).has.a.balanceOf("2000.00", ousd);
     await expect(matt).has.a.balanceOf("100.00", ousd);
 
+    // Rebase should do nothing
     await vault.rebase();
-
     await expect(anna).has.a.balanceOf("2000.00", ousd);
     await expect(matt).has.a.balanceOf("100.00", ousd);
 
-    await vault.connect(anna).redeem(ousdUnits("2000.0"));
+    // Anna redeems over the rebase threshold
+    await vault.connect(anna).redeem(ousdUnits("1500.0"));
+    await expect(anna).has.a.approxBalanceOf("500.00", ousd);
+    await expect(matt).has.a.approxBalanceOf("100.00", ousd);
 
-    await expect(anna).has.a.balanceOf("0.00", ousd);
+    // Redeem outputs will be 1000/2200 * 1500 USDC and 1200/2200 * 1500 DAI from fixture
+    await expect(anna).has.an.approxBalanceOf("681.8181", usdc);
+    await expect(anna).has.a.approxBalanceOf("818.1818", dai);
 
-    // Redeem outputs will be 1000/2200 * 2000 USDC and 1200/2200 * 2000 DAI from fixture
-    await expect(anna).has.an.approxBalanceOf("909.0909", usdc);
-    await expect(anna).has.a.approxBalanceOf("1090.9090", dai);
-
-    await expectApproxSupply(ousd, ousdUnits("200.0"));
+    await expectApproxSupply(ousd, ousdUnits("700.0"));
   });
 
   it("Changing an asset price affects a redeem", async () => {

--- a/playground/src/world.js
+++ b/playground/src/world.js
@@ -369,6 +369,12 @@ export const SCENARIOS = [
     `,
   },
   {
+    name: "Redeem OUSD",
+    actions: `
+    Sofi Vault redeem 50OUSD
+    `,
+  },
+  {
     name: "Rebase Contract Opt-In",
     actions: `
     Sofi OUSD transfer GenericContract 1000.97OUSD


### PR DESCRIPTION
Adds more tests to rebaseOptIn/rebaseOptOut PR.

`rebaseOptInList` has been replaced with `rebsaseState` because I needed to be able to represent not set/opt in/opt out which a bool couldn't do because of no null defaults.