### PR TITLE
Gas Limits with Estimates

### DIFF
--- a/dapp/src/components/buySell/SellWidget.js
+++ b/dapp/src/components/buySell/SellWidget.js
@@ -12,7 +12,6 @@ import ContractStore from 'stores/ContractStore'
 import AccountStore from 'stores/AccountStore'
 import AnimatedOusdStore from 'stores/AnimatedOusdStore'
 import DisclaimerTooltip from 'components/buySell/DisclaimerTooltip'
-import { gasLimits } from 'constants/Contract'
 import { isMobileMetaMask } from 'utils/device'
 
 import mixpanel from 'utils/mixpanel'
@@ -176,24 +175,32 @@ const SellWidget = ({
       ousdToSell.toString(),
       await ousdContract.decimals()
     )
-    const aboveRebaseThreshold = redeemAmount.gte(
-      // include 4% buffer so that gas limit is high enough to handle rebase if the oracles move enough to trigger it
-      rebaseThreshold.mul(96).div(100)
-    )
-    const gasLimit = aboveRebaseThreshold
-      ? gasLimits.REDEEM_REBASE_GAS_LIMIT
-      : gasLimits.REDEEM_GAS_LIMIT
+    // include 4% buffer so that gas limit is high enough to handle rebase if the oracles move enough to trigger it
+    const thresholdBuffer = 96
+    const nearRebaseThreshold =
+      redeemAmount.lte(rebaseThreshold) &&
+      redeemAmount.gte(rebaseThreshold.mul(thresholdBuffer).div(100))
+    const percentGasLimitBuffer = 0.25
+    const rebaseGasMultiplier = 2.5
+    let gasEstimate, gasLimit, receipt, result
 
     setSellWidgetState('waiting-user')
 
     if (sellAllActive || forceSellAll) {
       try {
         mobileMetaMaskHack()
-        const result = await vaultContract.redeemAll({ gasLimit })
+        gasEstimate = (await vaultContract.estimateGas.redeemAll()).toNumber()
+
+        if (nearRebaseThreshold) {
+          gasEstimate *= rebaseGasMultiplier
+        }
+
+        gasLimit = parseInt(gasEstimate * (1 + percentGasLimitBuffer))
+        result = await vaultContract.redeemAll({ gasLimit })
         storeTransaction(result, `redeem`, returnedCoins, coinData)
         setSellWidgetState('waiting-network')
 
-        const receipt = await rpcProvider.waitForTransaction(result.hash)
+        receipt = await rpcProvider.waitForTransaction(result.hash)
         onSellSuccess(ousdToSell)
       } catch (e) {
         // 4001 code happens when a user rejects the transaction
@@ -207,11 +214,20 @@ const SellWidget = ({
     } else {
       try {
         mobileMetaMaskHack()
-        const result = await vaultContract.redeem(redeemAmount, { gasLimit })
+        gasEstimate = (
+          await vaultContract.estimateGas.redeem(redeemAmount)
+        ).toNumber()
+
+        if (nearRebaseThreshold) {
+          gasEstimate *= rebaseGasMultiplier
+        }
+
+        gasLimit = parseInt(gasEstimate * (1 + percentGasLimitBuffer))
+        result = await vaultContract.redeem(redeemAmount, { gasLimit })
         storeTransaction(result, `redeem`, returnedCoins, coinData)
         setSellWidgetState('waiting-network')
 
-        const receipt = await rpcProvider.waitForTransaction(result.hash)
+        receipt = await rpcProvider.waitForTransaction(result.hash)
         onSellSuccess(ousdToSell)
       } catch (e) {
         // 4001 code happens when a user rejects the transaction

--- a/dapp/src/constants/Contract.js
+++ b/dapp/src/constants/Contract.js
@@ -9,22 +9,3 @@ export const currencies = {
     localStorageSettingKey: 'usdc-manual-setting',
   },
 }
-
-export const gasLimits = {
-  // simple mint involving a single coin
-  MINT_GAS_LIMIT: 201806,
-  // simple mint involving multiple coins
-  MINT_MULTIPLE_GAS_LIMIT: 475906,
-  // when the amount minted using a single coin triggers the rebase function and not the allocate function
-  MINT_REBASE_GAS_LIMIT: 749536,
-  // when the amount minted using multiple coins triggers the rebase function and not the allocate function
-  MINT_MULTIPLE_REBASE_GAS_LIMIT: 1039374,
-  // when the amount minted using a single coin triggers the allocate function
-  MINT_ALLOCATE_GAS_LIMIT: 3052725,
-  // when the amount minted using multiple coins triggers the allocate function
-  MINT_MULTIPLE_ALLOCATE_GAS_LIMIT: 3152725,
-  // redeem/redeemAll gas limit
-  REDEEM_GAS_LIMIT: 901968,
-  // when the amount redeemed triggers the rebase function
-  REDEEM_REBASE_GAS_LIMIT: 2028934,
-}


### PR DESCRIPTION
This moves away from hardcoded default gas limits for most transactions in favor of using `estimateGas` + one of a few different buffer implementations.

**Mints**
Most gas limits for `mint` and `mintMultiple` transactions are padded by the greater of `20000` or 10%. In cases where the mint amount (or combined amounts) is within 4% of the thresholds, a hardcoded amount is added to accommodate the possibility of `rebase` or `autoAllocate` when the estimate did not account for this. These cases should be rare. And, at least currently, this addition results in a higher gas limit than we would otherwise have if the estimate had been calculated with an amount that exceeded the threshold.

**Redeems**
Since we're less concerned about gas conservation when OUSD is burned, a higher buffer of 25% is used for `redeem` and `redeemAll` transactions. Similarly to the mint scenarios, rare cases of the amount approaching the `rebase` threshold are handled by increasing the gas limit, this time using a multiplier instead of adding a specific amount.

I have gone ahead and deployed this branch to the production environment since we're seeing a lot of users run out of gas with the hardcoded amounts. I've also tested the calculations for natural gas limit, near-threshold increases, and buffers for all predictable scenarios and [recorded a subset of the most common transactions to compare actual gas usage to the resulting defaults](https://docs.google.com/spreadsheets/d/1A512Y0SmpI7lHKbsIi_poOWrGp_wnSnxwuze3lOlkt0/edit#gid=1264639928).

Areas that have not been thoroughly tested are real-world transactions above the `autoAllocate` threshold, and those that involve liquidating from strategies due to an insufficient buffer.