### PR TITLE
Simplified Gas Limits with Estimates

### DIFF
--- a/dapp/src/components/buySell/BuySellWidget.js
+++ b/dapp/src/components/buySell/BuySellWidget.js
@@ -13,7 +13,7 @@ import AddOUSDModal from 'components/buySell/AddOUSDModal'
 import ErrorModal from 'components/buySell/ErrorModal'
 import DisclaimerTooltip from 'components/buySell/DisclaimerTooltip'
 import ApproveCurrencyInProgressModal from 'components/buySell/ApproveCurrencyInProgressModal'
-import { currencies, gasLimits } from 'constants/Contract'
+import { currencies } from 'constants/Contract'
 import { formatCurrency } from 'utils/math'
 import { sleep } from 'utils/utils'
 import { providersNotAutoDetectingOUSD, providerName } from 'utils/web3'
@@ -237,47 +237,39 @@ const BuySellWidget = ({
 
       await addMintableToken(dai, daiContract, 'dai')
 
-      let gasLimit
+      const absoluteGasLimitBuffer = 20000
+      const percentGasLimitBuffer = 0.1
 
-      const [allocateThreshold, rebaseThreshold] = await Promise.all([
-        vaultContract.autoAllocateThreshold(),
-        vaultContract.rebaseThreshold(),
-      ])
-      const involvingMultipleCoins = mintAddresses.length > 1
-      // include 4% buffer so that gas limit is high enough to handle rebase/allocate if the oracles move enough to trigger it
-      const thresholdBuffer = 96
-      const aboveAllocateThreshold = totalMintAmount.gte(
-        allocateThreshold.mul(thresholdBuffer).div(100)
-      )
-      const aboveRebaseThreshold = totalMintAmount.gte(
-        rebaseThreshold.mul(thresholdBuffer).div(100)
-      )
-
-      if (involvingMultipleCoins) {
-        if (aboveAllocateThreshold) {
-          gasLimit = gasLimits.MINT_MULTIPLE_ALLOCATE_GAS_LIMIT
-        } else if (aboveRebaseThreshold) {
-          gasLimit = gasLimits.MINT_MULTIPLE_REBASE_GAS_LIMIT
-        } else {
-          gasLimit = gasLimits.MINT_MULTIPLE_GAS_LIMIT
-        }
-      } else {
-        if (aboveAllocateThreshold) {
-          gasLimit = gasLimits.MINT_ALLOCATE_GAS_LIMIT
-        } else if (aboveRebaseThreshold) {
-          gasLimit = gasLimits.MINT_REBASE_GAS_LIMIT
-        } else {
-          gasLimit = gasLimits.MINT_GAS_LIMIT
-        }
-      }
-
-      let result
+      let gasEstimate, gasLimit, result
       mobileMetaMaskHack(prependStage)
       if (mintAddresses.length === 1) {
+        gasEstimate = (
+          await vaultContract.estimateGas.mint(mintAddresses[0], mintAmounts[0])
+        ).toNumber()
+        gasLimit = parseInt(
+          gasEstimate +
+            Math.max(
+              absoluteGasLimitBuffer,
+              gasEstimate * percentGasLimitBuffer
+            )
+        )
         result = await vaultContract.mint(mintAddresses[0], mintAmounts[0], {
           gasLimit,
         })
       } else {
+        gasEstimate = (
+          await vaultContract.estimateGas.mintMultiple(
+            mintAddresses,
+            mintAmounts
+          )
+        ).toNumber()
+        gasLimit = parseInt(
+          gasEstimate +
+            Math.max(
+              absoluteGasLimitBuffer,
+              gasEstimate * percentGasLimitBuffer
+            )
+        )
         result = await vaultContract.mintMultiple(mintAddresses, mintAmounts, {
           gasLimit,
         })

--- a/dapp/src/constants/Contract.js
+++ b/dapp/src/constants/Contract.js
@@ -9,22 +9,3 @@ export const currencies = {
     localStorageSettingKey: 'usdc-manual-setting',
   },
 }
-
-export const gasLimits = {
-  // simple mint involving a single coin
-  MINT_GAS_LIMIT: 201806,
-  // simple mint involving multiple coins
-  MINT_MULTIPLE_GAS_LIMIT: 475906,
-  // when the amount minted using a single coin triggers the rebase function and not the allocate function
-  MINT_REBASE_GAS_LIMIT: 749536,
-  // when the amount minted using multiple coins triggers the rebase function and not the allocate function
-  MINT_MULTIPLE_REBASE_GAS_LIMIT: 1039374,
-  // when the amount minted using a single coin triggers the allocate function
-  MINT_ALLOCATE_GAS_LIMIT: 3052725,
-  // when the amount minted using multiple coins triggers the allocate function
-  MINT_MULTIPLE_ALLOCATE_GAS_LIMIT: 3152725,
-  // redeem/redeemAll gas limit
-  REDEEM_GAS_LIMIT: 901968,
-  // when the amount redeemed triggers the rebase function
-  REDEEM_REBASE_GAS_LIMIT: 2028934,
-}


### PR DESCRIPTION
This moves away from hardcoded default gas limits in favor of using `estimateGas` + a buffer.

**Mints**
`mint` and `mintMultiple` transactions are padded by the greater of `20000` or 10%.

**Redeems**
`redeem` and `redeemAll` transactions are padded with a higher buffer of 25% since we're less concerned about gas conservation when tokens are going to be burned.

There is still one possible extreme edge case that will knowingly result in an "out of gas" error. If a user were to call `redeemAll` with a balance slightly under the `rebaseThreshold` (or if rebase is paused) and end up with >= 1,000 OUSD as a result of a rebase that happens before the transaction is mined, the estimated gas will be far too low. This could be avoided by removing [the conditions](https://github.com/OriginProtocol/origin-dollar/blob/master/contracts/contracts/vault/VaultCore.sol#L196) and rebasing prior to every redeem.

I've tested a handful of Mainnet transactions with this branch on staging, so I'll go ahead and merge+deploy this instead of waiting for comments. 🤞