### PR TITLE
Add a minimum stablecoin unit argument to redeem functions (TOB-OUSD-14)

### DIFF
--- a/contracts/contracts/governance/Governor.sol
+++ b/contracts/contracts/governance/Governor.sol
@@ -201,7 +201,6 @@ contract Governor is Timelock {
         queueTransaction(target, value, signature, data, eta);
     }
 
-
     /**
      * @notice Execute a proposal.
      * @param proposalId id of the proposal

--- a/contracts/contracts/interfaces/IVault.sol
+++ b/contracts/contracts/interfaces/IVault.sol
@@ -90,9 +90,9 @@ interface IVault {
         uint256[] calldata _amount
     ) external;
 
-    function redeem(uint256 _amount) external;
+    function redeem(uint256 _amount, uint256 _minimumUnitAmount) external;
 
-    function redeemAll() external;
+    function redeemAll(uint256 _minimumUnitAmount) external;
 
     function allocate() external;
 

--- a/contracts/contracts/mocks/MockNonRebasing.sol
+++ b/contracts/contracts/mocks/MockNonRebasing.sol
@@ -46,7 +46,7 @@ contract MockNonRebasing {
     }
 
     function redeemOusd(address _vaultContract, uint256 _amount) public {
-        IVault(_vaultContract).redeem(_amount);
+        IVault(_vaultContract).redeem(_amount, 0);
     }
 
     function approveFor(

--- a/contracts/contracts/vault/VaultCore.sol
+++ b/contracts/contracts/vault/VaultCore.sol
@@ -10,7 +10,6 @@ pragma solidity 0.5.11;
  * @author Origin Protocol Inc
  */
 
-import "hardhat/console.sol";
 import "./VaultStorage.sol";
 import { IMinMaxOracle } from "../interfaces/IMinMaxOracle.sol";
 import { IVault } from "../interfaces/IVault.sol";

--- a/contracts/test/strategies/3pool.js
+++ b/contracts/test/strategies/3pool.js
@@ -103,13 +103,13 @@ describe("3Pool Strategy", function () {
         "0",
         threePoolToken
       );
-      await vault.connect(anna).redeem(ousdUnits("30000.00"));
+      await vault.connect(anna).redeem(ousdUnits("30000.00"), 0);
     });
 
     it("Should be able to unstake from gauge and return USDT", async function () {
       await expectApproxSupply(ousd, ousdUnits("200"));
       await mint("30000.00", usdt);
-      await vault.connect(anna).redeem(ousdUnits("20000"));
+      await vault.connect(anna).redeem(ousdUnits("20000"), 0);
       await expectApproxSupply(ousd, ousdUnits("10200"));
     });
 
@@ -117,7 +117,7 @@ describe("3Pool Strategy", function () {
       await mint("30000.00", usdt);
       await mint("30000.00", usdc);
       await mint("30000.00", dai);
-      await vault.connect(anna).redeem(ousdUnits("60000.00"));
+      await vault.connect(anna).redeem(ousdUnits("60000.00"), 0);
       // Anna had 1000 of each asset before the mints
       // 200 DAI was already in the Vault
       // 30200 DAI, 30000 USDT, 30000 USDC

--- a/contracts/test/strategies/aave.js
+++ b/contracts/test/strategies/aave.js
@@ -31,8 +31,8 @@ describe("Aave Strategy", function () {
     aaveCoreAddress;
 
   const emptyVault = async () => {
-    await vault.connect(matt).redeemAll();
-    await vault.connect(josh).redeemAll();
+    await vault.connect(matt).redeemAll(0);
+    await vault.connect(josh).redeemAll(0);
   };
 
   const mint = async (amount, asset) => {
@@ -80,7 +80,7 @@ describe("Aave Strategy", function () {
       await mint("30000.00", usdc);
       await expectApproxSupply(ousd, ousdUnits("30000"));
       await expect(aaveStrategy).has.an.approxBalanceOf("0", dai);
-      await vault.connect(anna).redeem(ousdUnits("30000.00"));
+      await vault.connect(anna).redeem(ousdUnits("30000.00"), 0);
     });
 
     it("Should be able to mint and redeem DAI", async function () {
@@ -90,7 +90,7 @@ describe("Aave Strategy", function () {
       await dai.connect(anna).transfer(await matt.getAddress(), startBalance);
 
       await mint("30000.00", dai);
-      await vault.connect(anna).redeem(ousdUnits("20000"));
+      await vault.connect(anna).redeem(ousdUnits("20000"), 0);
       await expectApproxSupply(ousd, ousdUnits("10200"));
       await expect(anna).to.have.a.balanceOf("20000", dai);
       await expect(anna).to.have.a.balanceOf("10000", ousd);
@@ -100,7 +100,7 @@ describe("Aave Strategy", function () {
       await mint("30000.00", usdt);
       await mint("30000.00", usdc);
       await mint("30000.00", dai);
-      await vault.connect(anna).redeem(ousdUnits("60000.00"));
+      await vault.connect(anna).redeem(ousdUnits("60000.00"), 0);
       // Anna had 1000 of each asset before the mints
       // 200 DAI was already in the Vault
       // 30200 DAI, 30000 USDT, 30000 USDC

--- a/contracts/test/vault/redeem.js
+++ b/contracts/test/vault/redeem.js
@@ -25,7 +25,7 @@ describe("Vault Redeem", function () {
     await usdc.connect(anna).approve(vault.address, usdcUnits("50.0"));
     await vault.connect(anna).mint(usdc.address, usdcUnits("50.0"));
     await expect(anna).has.a.balanceOf("50.00", ousd);
-    await vault.connect(anna).redeem(ousdUnits("50.0"));
+    await vault.connect(anna).redeem(ousdUnits("50.0"), 0);
     await expect(anna).has.a.balanceOf("0.00", ousd);
     // Redeem outputs will be 50/250 * 50 USDC and 200/250 * 50 DAI from fixture
     await expect(anna).has.a.balanceOf("960.00", usdc);
@@ -62,7 +62,7 @@ describe("Vault Redeem", function () {
     await expect(matt).has.a.balanceOf("100.00", ousd);
 
     // Anna redeems over the rebase threshold
-    await vault.connect(anna).redeem(ousdUnits("1500.0"));
+    await vault.connect(anna).redeem(ousdUnits("1500.0"), 0);
     await expect(anna).has.a.approxBalanceOf("500.00", ousd);
     await expect(matt).has.a.approxBalanceOf("100.00", ousd);
 
@@ -82,7 +82,7 @@ describe("Vault Redeem", function () {
     await setOracleTokenPriceUsd("DAI", "1.25");
     await vault.rebase();
 
-    await vault.connect(matt).redeem(ousdUnits("2.0"));
+    await vault.connect(matt).redeem(ousdUnits("2.0"), 0);
     await expectApproxSupply(ousd, ousdUnits("198"));
     // Amount of DAI collected is affected by redeem oracles
     await expect(matt).has.a.approxBalanceOf("901.60", dai);
@@ -109,7 +109,7 @@ describe("Vault Redeem", function () {
     await expect(anna).has.a.balanceOf("100.00", ousd);
 
     // Redeem 100 tokens for 100 OUSD
-    await vault.connect(anna).redeem(ousdUnits("100.0"));
+    await vault.connect(anna).redeem(ousdUnits("100.0"), 0);
     await expect(anna).has.a.balanceOf("0.00", ousd);
     // 66.66 would have come back as DAI because there is 100 NST and 200 DAI
     await expect(anna).has.an.approxBalanceOf("933.33", nonStandardToken);
@@ -130,7 +130,7 @@ describe("Vault Redeem", function () {
     await usdc.connect(anna).approve(vault.address, usdcUnits("50.0"));
     await vault.connect(anna).mint(usdc.address, usdcUnits("50.0"));
     await expect(anna).has.a.balanceOf("50.00", ousd);
-    await vault.connect(anna).redeem(ousdUnits("50.0"));
+    await vault.connect(anna).redeem(ousdUnits("50.0"), 0);
     await expect(anna).has.a.balanceOf("0.00", ousd);
     // 45 after redeem fee
     // USDC is 50/250 of total assets, so balance should be 950 + 50/250 * 45 = 959
@@ -148,7 +148,7 @@ describe("Vault Redeem", function () {
 
     // Try to withdraw more than balance
     await expect(
-      vault.connect(anna).redeem(ousdUnits("100.0"))
+      vault.connect(anna).redeem(ousdUnits("100.0"), 0)
     ).to.be.revertedWith("Remove exceeds balance");
   });
 
@@ -175,7 +175,7 @@ describe("Vault Redeem", function () {
     await expect(anna).has.a.balanceOf("250.00", ousd);
 
     // Withdraw all
-    await vault.connect(anna).redeemAll();
+    await vault.connect(anna).redeemAll(0);
 
     // 100 USDC and 350 DAI in contract
     // (1000-100) + 100/450 * 250 USDC
@@ -209,7 +209,7 @@ describe("Vault Redeem", function () {
     await expect(anna).has.an.approxBalanceOf("250.00", ousd);
 
     // Withdraw all
-    await vault.connect(anna).redeemAll();
+    await vault.connect(anna).redeemAll(0);
 
     // OUSD to Withdraw	250
     // Total Vault Coins	450
@@ -260,7 +260,7 @@ describe("Vault Redeem", function () {
 
     // Withdraw all
     await ousd.connect(anna).approve(vault.address, ousdUnits("500"));
-    await vault.connect(anna).redeemAll();
+    await vault.connect(anna).redeemAll(0);
 
     // OUSD to Withdraw	250
     // Total Vault Coins	450
@@ -310,7 +310,7 @@ describe("Vault Redeem", function () {
             (startBalance + amount).toString(),
             ousd
           );
-          await vault.connect(user).redeem(ousdUnits(amount.toString()));
+          await vault.connect(user).redeem(ousdUnits(amount.toString()), 0);
           await expect(user).has.an.approxBalanceOf(
             startBalance.toString(),
             ousd
@@ -366,7 +366,7 @@ describe("Vault Redeem", function () {
             );
             await vault
               .connect(user)
-              .redeem(ousdUnits(ousdToReceive.toString()));
+              .redeem(ousdUnits(ousdToReceive.toString()), 0);
             await expect(user).has.an.approxBalanceOf(
               userBalance.toString(),
               ousd
@@ -397,7 +397,7 @@ describe("Vault Redeem", function () {
     // Vault has 1000 USDC and 200 DAI
     await expect(anna).has.an.approxBalanceOf("1000.00", ousd);
 
-    await vault.connect(anna).redeemAll();
+    await vault.connect(anna).redeemAll(0);
 
     // OUSD to Withdraw	1000
     // Total Vault Coins	1200
@@ -426,9 +426,9 @@ describe("Vault Redeem", function () {
     //peturb the oracle a slight bit.
     await setOracleTokenPriceUsd("USDC", "1.000001");
     //redeem without rebasing (not over threshold)
-    await vault.connect(anna).redeem(ousdUnits("200.00"));
+    await vault.connect(anna).redeem(ousdUnits("200.00"), 0);
     //redeem with rebasing (over threshold)
-    await vault.connect(anna).redeemAll();
+    await vault.connect(anna).redeemAll(0);
 
     await expect(anna).has.a.balanceOf("0.00", ousd);
   });
@@ -458,7 +458,7 @@ describe("Vault Redeem", function () {
     await setOracleTokenPriceUsdMinMax("DAI", "0.9", "1");
     await vault.connect(governor).rebase();
 
-    await vault.connect(anna).redeemAll();
+    await vault.connect(anna).redeemAll(0);
 
     dai.connect(josh).approve(vault.address, daiUnits("50"));
     vault.connect(josh).mint(dai.address, daiUnits("50"));
@@ -471,7 +471,35 @@ describe("Vault Redeem", function () {
     await vault.connect(anna).mint(usdc.address, newBalance);
     await dai.connect(anna).approve(vault.address, newDaiBalance);
     await vault.connect(anna).mint(dai.address, newDaiBalance);
-    await vault.connect(anna).redeemAll();
+    await vault.connect(anna).redeemAll(0);
     await expect(anna).has.a.balanceOf("0.00", ousd);
+  });
+
+  it("Should respect minimum unit amount argument in redeem", async () => {
+    const { ousd, vault, usdc, anna, dai } = await loadFixture(defaultFixture);
+    await expect(anna).has.a.balanceOf("1000.00", usdc);
+    await expect(anna).has.a.balanceOf("1000.00", dai);
+    await usdc.connect(anna).approve(vault.address, usdcUnits("100.0"));
+    await vault.connect(anna).mint(usdc.address, usdcUnits("50.0"));
+    await expect(anna).has.a.balanceOf("50.00", ousd);
+    await vault.connect(anna).redeem(ousdUnits("50.0"), ousdUnits("50"));
+    await vault.connect(anna).mint(usdc.address, usdcUnits("50.0"));
+    await expect(
+      vault.connect(anna).redeem(ousdUnits("50.0"), ousdUnits("51"))
+    ).to.be.revertedWith("Redeem amount lower than minimum");
+  });
+
+  it("Should respect minimum unit amount argument in redeemAll", async () => {
+    const { ousd, vault, usdc, anna, dai } = await loadFixture(defaultFixture);
+    await expect(anna).has.a.balanceOf("1000.00", usdc);
+    await expect(anna).has.a.balanceOf("1000.00", dai);
+    await usdc.connect(anna).approve(vault.address, usdcUnits("100.0"));
+    await vault.connect(anna).mint(usdc.address, usdcUnits("50.0"));
+    await expect(anna).has.a.balanceOf("50.00", ousd);
+    await vault.connect(anna).redeemAll(ousdUnits("50"));
+    await vault.connect(anna).mint(usdc.address, usdcUnits("50.0"));
+    await expect(
+      vault.connect(anna).redeemAll(ousdUnits("51"))
+    ).to.be.revertedWith("Redeem amount lower than minimum");
   });
 });

--- a/contracts/test/vault/z_compound.js
+++ b/contracts/test/vault/z_compound.js
@@ -115,7 +115,7 @@ describe("Vault with Compound strategy", function () {
     // Note Anna will have slightly less than 50 due to deposit to Compound
     // according to the MockCToken implementation
     await ousd.connect(anna).approve(vault.address, ousdUnits("40.0"));
-    await vault.connect(anna).redeem(ousdUnits("40.0"));
+    await vault.connect(anna).redeem(ousdUnits("40.0"), 0);
 
     await expect(anna).has.an.approxBalanceOf("10", ousd);
     // Vault has 200 DAI and 50 USDC, 50/250 * 40 USDC will come back
@@ -607,7 +607,7 @@ describe("Vault with Compound strategy", function () {
             (startBalance + amount).toString(),
             ousd
           );
-          await vault.connect(user).redeem(ousdUnits(amount.toString()));
+          await vault.connect(user).redeem(ousdUnits(amount.toString()), 0);
           await expect(user).has.an.approxBalanceOf(
             startBalance.toString(),
             ousd

--- a/contracts/test/vault/z_multistrategy.js
+++ b/contracts/test/vault/z_multistrategy.js
@@ -281,14 +281,14 @@ describe("Vault with two strategies", function () {
       daiUnits("200")
     );
 
-    await vault.connect(josh).redeem(ousdUnits("20"));
+    await vault.connect(josh).redeem(ousdUnits("20"), 0);
 
     // Should withdraw from the heaviest strategy first
     expect(await compoundStrategy.checkBalance(dai.address)).to.equal(
       daiUnits("190")
     );
 
-    await vault.connect(josh).redeem(ousdUnits("20"));
+    await vault.connect(josh).redeem(ousdUnits("20"), 0);
 
     expect(await strategyTwo.checkBalance(dai.address)).to.equal(
       daiUnits("180")
@@ -334,7 +334,7 @@ describe("Vault with two strategies", function () {
       daiUnits("200")
     );
 
-    await vault.connect(josh).redeem(ousdUnits("20"));
+    await vault.connect(josh).redeem(ousdUnits("20"), 0);
 
     // Although compoundStrategy is the heaviest strategy, we don't withdraw
     // the full amount because the outputs calculation dictates we must withdraw
@@ -344,7 +344,7 @@ describe("Vault with two strategies", function () {
       usdcUnits("199.756098")
     );
 
-    await vault.connect(josh).redeem(ousdUnits("20"));
+    await vault.connect(josh).redeem(ousdUnits("20"), 0);
   });
 
   it(

--- a/dapp/src/components/buySell/SellWidget.js
+++ b/dapp/src/components/buySell/SellWidget.js
@@ -182,9 +182,9 @@ const SellWidget = ({
     if (sellAllActive || forceSellAll) {
       try {
         mobileMetaMaskHack()
-        gasEstimate = (await vaultContract.estimateGas.redeemAll()).toNumber()
+        gasEstimate = (await vaultContract.estimateGas.redeemAll(0)).toNumber()
         gasLimit = parseInt(gasEstimate * (1 + percentGasLimitBuffer))
-        result = await vaultContract.redeemAll({ gasLimit })
+        result = await vaultContract.redeemAll(0, { gasLimit })
         storeTransaction(result, `redeem`, returnedCoins, coinData)
         setSellWidgetState('waiting-network')
 
@@ -203,10 +203,10 @@ const SellWidget = ({
       try {
         mobileMetaMaskHack()
         gasEstimate = (
-          await vaultContract.estimateGas.redeem(redeemAmount)
+          await vaultContract.estimateGas.redeem(redeemAmount, 0)
         ).toNumber()
         gasLimit = parseInt(gasEstimate * (1 + percentGasLimitBuffer))
-        result = await vaultContract.redeem(redeemAmount, { gasLimit })
+        result = await vaultContract.redeem(redeemAmount, 0, { gasLimit })
         storeTransaction(result, `redeem`, returnedCoins, coinData)
         setSellWidgetState('waiting-network')
 


### PR DESCRIPTION
Add an argument to redeem and redeemAll to allow setting of a minimum amount of stablecoins (in unit terms, not price wise).

@sparrowDom I think I caught all the spots in the dapp where this needs to be added to function calls. I just set it to 0 (i.e. don't care how many) but we may want to expose this in the UI later.