### PR TITLE
Update timelock's constants

### DIFF
--- a/contracts/contracts/timelock/Timelock.sol
+++ b/contracts/contracts/timelock/Timelock.sol
@@ -43,9 +43,9 @@ contract Timelock {
         uint256 eta
     );
 
-    uint256 public constant GRACE_PERIOD = 14 days;
-    uint256 public constant MINIMUM_DELAY = 2 days;
-    uint256 public constant MAXIMUM_DELAY = 30 days;
+    uint256 public constant GRACE_PERIOD = 3 days;
+    uint256 public constant MINIMUM_DELAY = 1 minutes;
+    uint256 public constant MAXIMUM_DELAY = 2 days;
 
     address public admin;
     address public pendingAdmin;


### PR DESCRIPTION
On Mainnet, we currently use the MinuteTimelock.
With the recent changes, the governor contract now derives off the Timelock contract (see [code](https://github.com/OriginProtocol/origin-dollar/blob/master/contracts/contracts/governance/Governor.sol#L8))

This PR updates the Timelock's constants to match what we have for the MinuteTimelock (see [code](https://github.com/OriginProtocol/origin-dollar/blob/master/contracts/contracts/timelock/MinuteTimelock.sol#L42))


=====
If you made a contract change, make sure to complete the checklist below before merging it in master.

Refer to our [documentation](https://github.com/OriginProtocol/security) for more details about contract security best practices.

Contract change checklist:
  - [x] Code reviewed by 2 reviewers
  - [x] Unit tests pass
  - [x] Slither tests pass with no warning
  - [ ] Echidna tests pass (not automated, run manually on local)