### PR TITLE
Prevent ambiguous proposal transaction hash

### DIFF
--- a/contracts/contracts/governance/Governor.sol
+++ b/contracts/contracts/governance/Governor.sol
@@ -194,7 +194,7 @@ contract Governor is Timelock {
     ) internal {
         require(
             !queuedTransactions[keccak256(
-                abi.encode(target, value, signature, data, eta)
+                abi.encode(target, value, signature, keccak256(data), eta)
             )],
             "Governor::_queueOrRevert: proposal action already queued at eta"
         );

--- a/contracts/contracts/timelock/MinuteTimelock.sol
+++ b/contracts/contracts/timelock/MinuteTimelock.sol
@@ -129,7 +129,7 @@ contract MinuteTimelock is Initializable {
         );
 
         bytes32 txHash = keccak256(
-            abi.encode(target, value, signature, data, eta)
+            abi.encode(target, value, signature, keccak256(data), eta)
         );
         queuedTransactions[txHash] = true;
 
@@ -150,7 +150,7 @@ contract MinuteTimelock is Initializable {
         );
 
         bytes32 txHash = keccak256(
-            abi.encode(target, value, signature, data, eta)
+            abi.encode(target, value, signature, keccak256(data), eta)
         );
         queuedTransactions[txHash] = false;
 
@@ -165,7 +165,7 @@ contract MinuteTimelock is Initializable {
         uint256 eta
     ) public payable returns (bytes memory) {
         bytes32 txHash = keccak256(
-            abi.encode(target, value, signature, data, eta)
+            abi.encode(target, value, signature, keccak256(data), eta)
         );
         require(
             queuedTransactions[txHash],

--- a/contracts/contracts/timelock/Timelock.sol
+++ b/contracts/contracts/timelock/Timelock.sol
@@ -125,7 +125,7 @@ contract Timelock {
         );
 
         bytes32 txHash = keccak256(
-            abi.encode(target, value, signature, data, eta)
+            abi.encode(target, value, signature, keccak256(data), eta)
         );
         queuedTransactions[txHash] = true;
 
@@ -146,7 +146,7 @@ contract Timelock {
         );
 
         bytes32 txHash = keccak256(
-            abi.encode(target, value, signature, data, eta)
+            abi.encode(target, value, signature, keccak256(data), eta)
         );
         queuedTransactions[txHash] = false;
 

--- a/contracts/contracts/timelock/Timelock.sol
+++ b/contracts/contracts/timelock/Timelock.sol
@@ -166,7 +166,7 @@ contract Timelock {
         );
 
         bytes32 txHash = keccak256(
-            abi.encode(target, value, signature, data, eta)
+            abi.encode(target, value, signature, keccak256(data), eta)
         );
         require(
             queuedTransactions[txHash],

--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -22,8 +22,7 @@ const MAINNET_DEPLOYER = "0xAed9fDc9681D61edB5F8B8E421f5cEe8D7F4B04f";
 const MAINNET_MINUTE_TIMELOCK = "0x52BEBd3d7f37EC4284853Fd5861Ae71253A7F428";
 // V2 Mainnet contracts are governed by the Governor contract (which derives off Timelock).
 // TODO(franck): update this address once the governor contract is deployed.
-//const MAINNET_GOVERNOR = "placeholder";
-const MAINNET_GOVERNOR = "0xaB5E7B701B605f74AaC1b749Fd50715f0DEd7Bc5"; // FOR TESTING ONLY
+const MAINNET_GOVERNOR = "placeholder";
 const MAINNET_MULTISIG = "0xe011fa2a6df98c69383457d87a056ed0103aa352";
 const MAINNET_CLAIM_ADJUSTER = MAINNET_DEPLOYER;
 

--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -22,7 +22,8 @@ const MAINNET_DEPLOYER = "0xAed9fDc9681D61edB5F8B8E421f5cEe8D7F4B04f";
 const MAINNET_MINUTE_TIMELOCK = "0x52BEBd3d7f37EC4284853Fd5861Ae71253A7F428";
 // V2 Mainnet contracts are governed by the Governor contract (which derives off Timelock).
 // TODO(franck): update this address once the governor contract is deployed.
-const MAINNET_GOVERNOR = "placeholder";
+//const MAINNET_GOVERNOR = "placeholder";
+const MAINNET_GOVERNOR = "0xaB5E7B701B605f74AaC1b749Fd50715f0DEd7Bc5"; // FOR TESTING ONLY
 const MAINNET_MULTISIG = "0xe011fa2a6df98c69383457d87a056ed0103aa352";
 const MAINNET_CLAIM_ADJUSTER = MAINNET_DEPLOYER;
 


### PR DESCRIPTION
Implement recommendation #3 from the Solidified report.

Hash one of the value before calculating the transaction hash in order to prevent any possibility of a transaction hash collision. 

Contract change checklist:
  - [ ] Code reviewed by 2 reviewers
  - [ ] Unit tests pass
  - [ ] Slither tests pass with no warning
  - [ ] Echidna tests pass (not automated, run manually on local)