### PR TITLE
Timelock: make queueTransaction and executeTransaction internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,18 @@ When freshly starting a node it is usually nedessary to also reset Metamask Acco
 
 ### Runnning on Mainnet fork
 
-This repository also supports running a local node via the HardhatEVM fork implementation.
+This repository also supports running a local node via the Hardhat EVM fork implementation.
 
 Set PROVIDER_URL to point to Mainnet.
+
 `export PROVIDER_URL="https://eth-mainnet.alchemyapi.io/v2/...`
 
 Setting BLOCK_NUMBER in your environment before running the fork will aid performance due to better caching. It is recommended to set it to something that hast at least 6 confirmations.
+
 `export BLOCK_NUMBER=...`
 
 Start the Fork node:
+
 `cd contracts`
 
 `yarn install`

--- a/contracts/contracts/governance/Governor.sol
+++ b/contracts/contracts/governance/Governor.sol
@@ -19,9 +19,6 @@ contract Governor is Timelock {
         uint256 eta;
         // @notice the ordered list of target addresses for calls to be made
         address[] targets;
-        // @notice The ordered list of values (i.e. msg.value) to be passed
-        // to the calls to be made
-        uint256[] values;
         // @notice The ordered list of function signatures to be called
         string[] signatures;
         // @notice The ordered list of calldata to be passed to each call
@@ -38,7 +35,6 @@ contract Governor is Timelock {
         uint256 id,
         address proposer,
         address[] targets,
-        uint256[] values,
         string[] signatures,
         bytes[] calldatas,
         string description
@@ -78,7 +74,6 @@ contract Governor is Timelock {
     /**
      * @notice Propose Governance call(s)
      * @param targets Ordered list of targeted addresses
-     * @param values Ordered list of values (i.e. msg.value) to pass
      * @param signatures Orderd list of function signatures to be called
      * @param calldatas Orderded list of calldata to be passed with each call
      * @param description Description of the governance
@@ -86,7 +81,6 @@ contract Governor is Timelock {
      */
     function propose(
         address[] memory targets,
-        uint256[] memory values,
         string[] memory signatures,
         bytes[] memory calldatas,
         string memory description
@@ -94,8 +88,7 @@ contract Governor is Timelock {
         // Allow anyone to propose for now, since only admin can queue the
         // transaction it should be harmless, you just need to pay the gas
         require(
-            targets.length == values.length &&
-                targets.length == signatures.length &&
+            targets.length == signatures.length &&
                 targets.length == calldatas.length,
             "Governor::propose: proposal function information arity mismatch"
         );
@@ -118,7 +111,6 @@ contract Governor is Timelock {
             proposer: msg.sender,
             eta: 0,
             targets: targets,
-            values: values,
             signatures: signatures,
             calldatas: calldatas,
             executed: false
@@ -130,7 +122,6 @@ contract Governor is Timelock {
             newProposal.id,
             msg.sender,
             targets,
-            values,
             signatures,
             calldatas,
             description
@@ -153,7 +144,6 @@ contract Governor is Timelock {
         for (uint256 i = 0; i < proposal.targets.length; i++) {
             _queueOrRevert(
                 proposal.targets[i],
-                proposal.values[i],
                 proposal.signatures[i],
                 proposal.calldatas[i],
                 proposal.eta
@@ -187,25 +177,18 @@ contract Governor is Timelock {
 
     function _queueOrRevert(
         address target,
-        uint256 value,
         string memory signature,
         bytes memory data,
         uint256 eta
     ) internal {
         require(
             !queuedTransactions[keccak256(
-                abi.encode(target, value, signature, data, eta)
+                abi.encode(target, signature, data, eta)
             )],
             "Governor::_queueOrRevert: proposal action already queued at eta"
         );
         require(
-            queuedTransactions[queueTransaction(
-                target,
-                value,
-                signature,
-                data,
-                eta
-            )],
+            queuedTransactions[queueTransaction(target, signature, data, eta)],
             "Governor::_queueOrRevert: failed to queue transaction"
         );
     }
@@ -214,7 +197,7 @@ contract Governor is Timelock {
      * @notice Execute a proposal.
      * @param proposalId id of the proposal
      */
-    function execute(uint256 proposalId) public payable {
+    function execute(uint256 proposalId) public {
         require(
             state(proposalId) == ProposalState.Queued,
             "Governor::execute: proposal can only be executed if it is queued"
@@ -224,7 +207,6 @@ contract Governor is Timelock {
         for (uint256 i = 0; i < proposal.targets.length; i++) {
             executeTransaction(
                 proposal.targets[i],
-                proposal.values[i],
                 proposal.signatures[i],
                 proposal.calldatas[i],
                 proposal.eta
@@ -250,7 +232,6 @@ contract Governor is Timelock {
         for (uint256 i = 0; i < proposal.targets.length; i++) {
             cancelTransaction(
                 proposal.targets[i],
-                proposal.values[i],
                 proposal.signatures[i],
                 proposal.calldatas[i],
                 proposal.eta
@@ -268,13 +249,12 @@ contract Governor is Timelock {
         view
         returns (
             address[] memory targets,
-            uint256[] memory values,
             string[] memory signatures,
             bytes[] memory calldatas
         )
     {
         Proposal storage p = proposals[proposalId];
-        return (p.targets, p.values, p.signatures, p.calldatas);
+        return (p.targets, p.signatures, p.calldatas);
     }
 
     function add256(uint256 a, uint256 b) internal pure returns (uint256) {

--- a/contracts/contracts/timelock/Timelock.sol
+++ b/contracts/contracts/timelock/Timelock.sol
@@ -114,7 +114,7 @@ contract Timelock {
         string memory signature,
         bytes memory data,
         uint256 eta
-    ) public returns (bytes32) {
+    ) internal returns (bytes32) {
         require(
             msg.sender == admin,
             "Timelock::queueTransaction: Call must come from admin."
@@ -139,7 +139,7 @@ contract Timelock {
         string memory signature,
         bytes memory data,
         uint256 eta
-    ) public {
+    ) internal {
         require(
             msg.sender == admin,
             "Timelock::cancelTransaction: Call must come from admin."
@@ -159,7 +159,7 @@ contract Timelock {
         string memory signature,
         bytes memory data,
         uint256 eta
-    ) public payable returns (bytes memory) {
+    ) internal returns (bytes memory) {
         require(
             msg.sender == admin,
             "Timelock::executeTransaction: Call must come from admin."

--- a/contracts/test/compensation/compensationClaims.js
+++ b/contracts/test/compensation/compensationClaims.js
@@ -101,7 +101,7 @@ describe("Compensation Claims", async () => {
     });
     it("should allow a user to withdraw their funds just before the end of the claim period", async () => {
       await compensationClaims.connect(governor).start(1000);
-      advanceTime(990);
+      await advanceTime(990);
       await compensationClaims.connect(anna).claim(await anna.getAddress());
       await expect(anna).to.have.a.balanceOf("0", compensationClaims);
       await expect(anna).to.have.a.balanceOf("4.000000000072189", ousd);
@@ -114,7 +114,7 @@ describe("Compensation Claims", async () => {
     });
     it("should not allow a user to withdraw their funds after the claim period", async () => {
       await compensationClaims.connect(governor).start(1000);
-      advanceTime(1002);
+      await advanceTime(1002);
       const tx = compensationClaims
         .connect(anna)
         .claim(await anna.getAddress());

--- a/contracts/test/governor.js
+++ b/contracts/test/governor.js
@@ -1,27 +1,7 @@
 const { expect } = require("chai");
 const { defaultFixture } = require("./_fixture");
-const { loadFixture, advanceTime } = require("./helpers");
+const { loadFixture, propose, proposeAndExecute } = require("./helpers");
 const { proposeArgs } = require("../utils/governor");
-
-async function propose(fixture, governorArgsArray, description) {
-  const { governorContract, governor } = fixture;
-  const lastProposalId = await governorContract.proposalCount();
-  await governorContract
-    .connect(governor)
-    .propose(...(await proposeArgs(governorArgsArray)), description);
-  const proposalId = await governorContract.proposalCount();
-  expect(proposalId).not.to.be.equal(lastProposalId);
-  return proposalId;
-}
-
-async function proposeAndExecute(fixture, governorArgsArray, description) {
-  const { governorContract, governor } = fixture;
-  const proposalId = await propose(fixture, governorArgsArray, description);
-  await governorContract.connect(governor).queue(proposalId);
-  // go forward 3 days
-  advanceTime(3 * 24 * 60 * 60);
-  await governorContract.connect(governor).execute(proposalId);
-}
 
 describe("Can claim governance with Governor contract and govern", () => {
   it("Can claim governance and call governance methods", async () => {

--- a/contracts/test/helpers.js
+++ b/contracts/test/helpers.js
@@ -328,26 +328,24 @@ const getAssetAddresses = async (deployments) => {
   }
 };
 
-async function governorArgs({ contract, value = 0, signature, args = [] }) {
+async function governorArgs({ contract, signature, args = [] }) {
   const method = signature.split("(")[0];
   const tx = await contract.populateTransaction[method](...args);
   const data = "0x" + tx.data.slice(10);
-  return [tx.to, value, signature, data];
+  return [tx.to, signature, data];
 }
 
 async function proposeArgs(governorArgsArray) {
   const targets = [],
-    values = [],
     sigs = [],
     datas = [];
   for (const g of governorArgsArray) {
-    const [t, v, s, d] = await governorArgs(g);
+    const [t, s, d] = await governorArgs(g);
     targets.push(t);
-    values.push(v);
     sigs.push(s);
     datas.push(d);
   }
-  return [targets, values, sigs, datas];
+  return [targets, sigs, datas];
 }
 
 async function propose(fixture, governorArgsArray, description) {

--- a/contracts/test/timelock.js
+++ b/contracts/test/timelock.js
@@ -58,7 +58,7 @@ describe("Governor's Timelock controls mockOracle", function () {
   });
 
   it("Admin should be able to execute the transaction after two days", async () => {
-    advanceTime(2.2 * DAY);
+    await advanceTime(2.2 * DAY);
     await governorContract.connect(governor).execute(proposalId);
   });
 

--- a/contracts/test/timelock.js
+++ b/contracts/test/timelock.js
@@ -1,25 +1,24 @@
 const { expect } = require("chai");
 const { defaultFixture } = require("./_fixture");
-const { isFork, oracleUnits, loadFixture, advanceTime } = require("./helpers");
+const {
+  isFork,
+  oracleUnits,
+  loadFixture,
+  advanceTime,
+  propose,
+  proposeAndExecute,
+} = require("./helpers");
 
 const DAY = 24 * 60 * 60;
 
-async function timelockArgs({ contract, value = 0, signature, args, eta }) {
-  const method = signature.split("(")[0];
-  const tx = await contract.populateTransaction[method](...args);
-  const data = "0x" + tx.data.slice(10);
-  return [tx.to, value, signature, data, eta];
-}
-
-describe("Timelock controls mockOracle", function () {
-  let timelock, oracle, anna, governor;
-  let args;
+describe("Governor's Timelock controls mockOracle", function () {
+  let oracle, governor, governorContract, fixture, proposalId, anna;
 
   before(async () => {
-    const fixture = await loadFixture(defaultFixture);
-    timelock = fixture.timelock;
+    fixture = await loadFixture(defaultFixture);
     oracle = fixture.mockOracle;
     governor = fixture.governor;
+    governorContract = fixture.governorContract;
     anna = fixture.anna;
   });
 
@@ -32,32 +31,35 @@ describe("Timelock controls mockOracle", function () {
     expect(await oracle.price("DAI")).to.eq(oracleUnits("1.32"));
   });
 
-  it("Should prepare a transaction for the timelock to execute", async () => {
-    const eta = Math.floor(new Date() / 1000 + 2.1 * DAY);
-    args = await timelockArgs({
-      contract: oracle,
-      signature: "setPrice(string,uint256)",
-      args: ["DAI", oracleUnits("1.02")],
-      eta,
-    });
-  });
-
   it("Should not have changed the oracle price", async () => {
     expect(await oracle.price("DAI")).to.eq(oracleUnits("1.32"));
   });
 
   it("Should add the transaction to the queue", async () => {
-    await timelock.connect(governor).queueTransaction(...args);
+    const args = [
+      {
+        contract: oracle,
+        signature: "setPrice(string,uint256)",
+        args: ["DAI", oracleUnits("1.02")],
+      },
+    ];
+    proposalId = await propose(fixture, args, "Change DAI price");
+    await governorContract.connect(governor).queue(proposalId);
   });
 
-  it("Should not be able to execute the transaction", async () => {
-    const tx = timelock.connect(governor).executeTransaction(...args);
+  it("Should not be able to execute the transaction before the delay", async () => {
+    const tx = governorContract.connect(governor).execute(proposalId);
     await expect(tx).to.be.reverted;
   });
 
-  it("Admin can execute the transaction after two days", async () => {
+  it("Non-admin should not be able to execute the transaction after delayy", async () => {
+    const tx = governorContract.connect(anna).execute(proposalId);
+    await expect(tx).to.be.reverted;
+  });
+
+  it("Admin should be able to execute the transaction after two days", async () => {
     advanceTime(2.2 * DAY);
-    await timelock.connect(governor).executeTransaction(...args);
+    await governorContract.connect(governor).execute(proposalId);
   });
 
   it("Should have changed the oracle price", async () => {
@@ -65,53 +67,48 @@ describe("Timelock controls mockOracle", function () {
   });
 });
 
-describe("Timelock can instantly pause deposits", () => {
-  let timelock, vault, governor, anna;
+describe("Governor can instantly pause deposits", () => {
+  let vault, governor, governorContract, anna;
 
   before(async () => {
     const fixture = await loadFixture(defaultFixture);
-    timelock = fixture.timelock;
     vault = fixture.vault;
     governor = fixture.governor;
+    governorContract = fixture.governorContract;
     anna = fixture.anna;
-    // Vault is governance is transfered to the timelock
-    await vault.connect(governor).transferGovernance(timelock.address);
 
-    //actually claim the governance
-    const eta = Math.floor(new Date() / 1000 + 2.1 * DAY);
-    const claimArgs = await timelockArgs({
-      contract: vault,
-      signature: "claimGovernance()",
-      args: [],
-      eta,
-    });
-
-    await timelock.connect(governor).queueTransaction(...claimArgs);
-    advanceTime(2.2 * DAY);
-    await timelock.connect(governor).executeTransaction(...claimArgs);
+    // Transfer Vault's governance to the Governor contract.
+    await vault.connect(governor).transferGovernance(governorContract.address);
+    const args = [
+      {
+        contract: vault,
+        signature: "claimGovernance()",
+      },
+    ];
+    await proposeAndExecute(fixture, args, "Claim vault governance");
   });
 
   it("Should allow pausing deposits immediately", async () => {
-    await timelock.connect(governor).unpauseDeposits(vault.address);
-    await timelock.connect(governor).pauseDeposits(vault.address);
+    await governorContract.connect(governor).unpauseDeposits(vault.address);
+    await governorContract.connect(governor).pauseDeposits(vault.address);
     expect(await vault.depositPaused()).to.be.true;
   });
 
   it("Should allow unpausing deposits immediately", async () => {
-    await timelock.connect(governor).pauseDeposits(vault.address);
-    await timelock.connect(governor).unpauseDeposits(vault.address);
+    await governorContract.connect(governor).pauseDeposits(vault.address);
+    await governorContract.connect(governor).unpauseDeposits(vault.address);
     expect(await vault.depositPaused()).to.be.false;
   });
 
   it("Should not allow a non-admin to pause deposits", async () => {
     await expect(
-      timelock.connect(anna).pauseDeposits(vault.address)
+      governorContract.connect(anna).pauseDeposits(vault.address)
     ).to.be.revertedWith("Timelock::pauseDeposits: Call must come from admin.");
   });
 
   it("Should not allow a non-admin to unpause deposits", async () => {
     await expect(
-      timelock.connect(anna).unpauseDeposits(vault.address)
+      governorContract.connect(anna).unpauseDeposits(vault.address)
     ).to.be.revertedWith(
       "Timelock::unpauseDeposits: Call must come from admin."
     );

--- a/contracts/utils/governor.js
+++ b/contracts/utils/governor.js
@@ -1,9 +1,9 @@
 
-async function _governorArgs({ contract, value = 0, signature, args=[]}) {
+async function _governorArgs({ contract, signature, args=[]}) {
   const method = signature
   const tx = await contract.populateTransaction[method](...args);
   const data = "0x" + tx.data.slice(10) ;
-  return [tx.to, value, signature, data];
+  return [tx.to, signature, data];
 }
 
 /**
@@ -12,15 +12,14 @@ async function _governorArgs({ contract, value = 0, signature, args=[]}) {
  * @returns {Promise<*[]>}
  */
 async function proposeArgs(governorArgsArray) {
-  const targets=[], values=[], sigs=[], datas=[];
+  const targets=[], sigs=[], datas=[];
   for (const g of governorArgsArray) {
-    const [t, v, s, d] = await _governorArgs(g);
+    const [t, s, d] = await _governorArgs(g);
     targets.push(t);
-    values.push(v);
     sigs.push(s);
     datas.push(d);
   }
-  return [targets, values, sigs, datas];
+  return [targets, sigs, datas];
 }
 
 module.exports = {


### PR DESCRIPTION
There does not seem to be a reason to keep Timelock.queueTransaction and Timelock.executeTransaction public.
These actions should never be called directly but rather should be initiated via the Governor.queue and Governor.execute methods.

Note:
  1. In order to make Timelock.executeTransaction internal, I also had to remove its payable modifier. I can't think of a use case where a proposal would require calling a method that receives ETH. But please do double-check me on this.
  1. Per suggestion from @tomlinton I also removed the ability for a proposal to send ETH


Contract change checklist:
  - [ ] Code reviewed by 2 reviewers
  - [X] Unit tests pass
  - [ ] Slither tests pass with no warning
  - [ ] Echidna tests pass (not automated, run manually on local)