### PR TITLE
Adds token oracle getters to MixOracle

### DIFF
--- a/contracts/contracts/oracle/MixOracle.sol
+++ b/contracts/contracts/oracle/MixOracle.sol
@@ -199,4 +199,46 @@ contract MixOracle is IMinMaxOracle, Governable {
         require(price >= minDrift, "Price below minDrift");
         require(price != 0, "None of our oracles returned a valid max price!");
     }
+
+    /**
+     * @notice Returns the length of the usdOracles array for a given token
+     * @param symbol Asset symbol. Example: "DAI"
+     * @return length of the USD oracles array
+     **/
+    function getTokenUSDOraclesLength(string calldata symbol) external view returns (uint256) {
+      MixConfig storage config = configs[keccak256(abi.encodePacked(symbol))];
+      return config.usdOracles.length;
+    }
+
+    /**
+     * @notice Returns the address of a specific USD oracle
+     * @param symbol Asset symbol. Example: "DAI"
+     * @param idx Index of the array value to return
+     * @return address of the oracle
+     **/
+    function getTokenUSDOracle(string calldata symbol, uint256 idx) external view returns (address) {
+      MixConfig storage config = configs[keccak256(abi.encodePacked(symbol))];
+      return config.usdOracles[idx];
+    }
+
+    /**
+     * @notice Returns the length of the ethOracles array for a given token
+     * @param symbol Asset symbol. Example: "DAI"
+     * @return length of the ETH oracles array
+     **/
+    function getTokenETHOraclesLength(string calldata symbol) external view returns (uint256) {
+      MixConfig storage config = configs[keccak256(abi.encodePacked(symbol))];
+      return config.ethOracles.length;
+    }
+
+    /**
+     * @notice Returns the address of a specific ETH oracle
+     * @param symbol Asset symbol. Example: "DAI"
+     * @param idx Index of the array value to return
+     * @return address of the oracle
+     **/
+    function getTokenETHOracle(string calldata symbol, uint256 idx) external view returns (address) {
+      MixConfig storage config = configs[keccak256(abi.encodePacked(symbol))];
+      return config.ethOracles[idx];
+    }
 }

--- a/contracts/test/oracle.js
+++ b/contracts/test/oracle.js
@@ -3,6 +3,7 @@ const { defaultFixture } = require("./_fixture");
 const { isFork, loadFixture } = require("./helpers");
 
 const { parseUnits } = require("ethers").utils;
+const { Zero, One, Two } = require("ethers").constants;
 
 // Note: we set decimals to match what the Mainnet feeds use.
 const feedDecimals = {
@@ -160,5 +161,25 @@ describe("Oracle", function () {
 
     await expect(mixOracle.ethUsdOracles(1)).to.be.reverted;
     expect(await mixOracle.ethUsdOracles(0)).to.eq(oldOracle);
+  });
+
+  it("Register a random USD token oracle", async () => {
+    const { governor, mockOracle } = await loadFixture(defaultFixture);
+
+    const mixOracle = await ethers.getContract("MixOracle");
+
+    await expect(mixOracle.getTokenUSDOracle("TEST", 0)).to.be.reverted;
+
+    // Should have the original fixture oracles
+    expect(await mixOracle.getTokenETHOraclesLength("TEST")).to.eq(Zero);
+    expect(await mixOracle.getTokenUSDOraclesLength("TEST")).to.eq(Zero);
+
+    mixOracle.connect(governor).registerTokenOracles("TEST", [], [mockOracle.address]);
+
+    expect(await mixOracle.getTokenETHOraclesLength("TEST")).to.eq(Zero);
+    expect(await mixOracle.getTokenUSDOraclesLength("TEST")).to.eq(One);
+
+    expect(await mixOracle.getTokenUSDOracle("TEST", 0)).to.eq(mockOracle.address);
+    await expect(mixOracle.getTokenUSDOracle("TEST", 1)).to.be.reverted;
   });
 });


### PR DESCRIPTION
Adds getters to `MixOracle` so token oracles can be retrieved for verification.

Contract change checklist:
  - [x] Code reviewed by 2 reviewers
  - [x] Unit tests pass
  - [x] Slither tests pass with no warning
  - [ ] Echidna tests pass (not automated, run manually on local)