### PR TITLE
Remove unused internal _min function from AAVE strategy contract

### DIFF
--- a/contracts/contracts/strategies/AaveStrategy.sol
+++ b/contracts/contracts/strategies/AaveStrategy.sol
@@ -164,8 +164,4 @@ contract AaveStrategy is InitializableAbstractStrategy {
         );
         return lendingPoolCore;
     }
-
-    function _min(uint256 x, uint256 y) internal pure returns (uint256) {
-        return x > y ? y : x;
-    }
 }


### PR DESCRIPTION
The AAVE contract has a `_min` function which is not currently being used. Looking at the commit logs, it looks like it was present from the contract start, but was not used at that time either.

I've removed it.

Contract change checklist:
  - [ ] Code reviewed by 2 reviewers
  - [x] Unit tests pass
  - [x] Slither tests pass with no warning
  - [x] Echidna tests pass (not automated, run manually on local)