### PR TITLE
Deploy script for upgrading the SingleAssetStaking contract

### DIFF
--- a/contracts/contracts/oracle/MixOracle.sol
+++ b/contracts/contracts/oracle/MixOracle.sol
@@ -205,9 +205,13 @@ contract MixOracle is IMinMaxOracle, Governable {
      * @param symbol Asset symbol. Example: "DAI"
      * @return length of the USD oracles array
      **/
-    function getTokenUSDOraclesLength(string calldata symbol) external view returns (uint256) {
-      MixConfig storage config = configs[keccak256(abi.encodePacked(symbol))];
-      return config.usdOracles.length;
+    function getTokenUSDOraclesLength(string calldata symbol)
+        external
+        view
+        returns (uint256)
+    {
+        MixConfig storage config = configs[keccak256(abi.encodePacked(symbol))];
+        return config.usdOracles.length;
     }
 
     /**
@@ -216,9 +220,13 @@ contract MixOracle is IMinMaxOracle, Governable {
      * @param idx Index of the array value to return
      * @return address of the oracle
      **/
-    function getTokenUSDOracle(string calldata symbol, uint256 idx) external view returns (address) {
-      MixConfig storage config = configs[keccak256(abi.encodePacked(symbol))];
-      return config.usdOracles[idx];
+    function getTokenUSDOracle(string calldata symbol, uint256 idx)
+        external
+        view
+        returns (address)
+    {
+        MixConfig storage config = configs[keccak256(abi.encodePacked(symbol))];
+        return config.usdOracles[idx];
     }
 
     /**
@@ -226,9 +234,13 @@ contract MixOracle is IMinMaxOracle, Governable {
      * @param symbol Asset symbol. Example: "DAI"
      * @return length of the ETH oracles array
      **/
-    function getTokenETHOraclesLength(string calldata symbol) external view returns (uint256) {
-      MixConfig storage config = configs[keccak256(abi.encodePacked(symbol))];
-      return config.ethOracles.length;
+    function getTokenETHOraclesLength(string calldata symbol)
+        external
+        view
+        returns (uint256)
+    {
+        MixConfig storage config = configs[keccak256(abi.encodePacked(symbol))];
+        return config.ethOracles.length;
     }
 
     /**
@@ -237,8 +249,12 @@ contract MixOracle is IMinMaxOracle, Governable {
      * @param idx Index of the array value to return
      * @return address of the oracle
      **/
-    function getTokenETHOracle(string calldata symbol, uint256 idx) external view returns (address) {
-      MixConfig storage config = configs[keccak256(abi.encodePacked(symbol))];
-      return config.ethOracles[idx];
+    function getTokenETHOracle(string calldata symbol, uint256 idx)
+        external
+        view
+        returns (address)
+    {
+        MixConfig storage config = configs[keccak256(abi.encodePacked(symbol))];
+        return config.ethOracles[idx];
     }
 }

--- a/contracts/deploy/007_upgrade_single_asset_staking.js
+++ b/contracts/deploy/007_upgrade_single_asset_staking.js
@@ -12,6 +12,7 @@ const {
   executeProposal,
 } = require("../utils/deploy");
 const { proposeArgs } = require("../utils/governor");
+const { getTxOpts } = require("../utils/tx");
 
 const deployName = "007_upgrade_single_asset_staking";
 
@@ -54,9 +55,9 @@ const upgradeSingleAssetStaking = async ({ getNamedAccounts }) => {
     await executeProposal(propArgs, propDescription);
   } else {
     // Local testing environment. Upgrade via the governor account directly.
-    await cOGNStakingProxy
+    const tx = await cOGNStakingProxy
       .connect(sGovernor)
-      .upgradeTo(dSingleAssetStaking.address);
+      .upgradeTo(dSingleAssetStaking.address, await getTxOpts());
     log(`Upgraded OGNStaking to ${dSingleAssetStaking.address}`);
   }
 

--- a/contracts/deploy/007_upgrade_single_asset_staking.js
+++ b/contracts/deploy/007_upgrade_single_asset_staking.js
@@ -2,14 +2,10 @@
 // Script to upgrade the Single Asset Staking contract.
 //
 const {
-  getAssetAddresses,
   isMainnet,
-  isRinkeby,
   isFork,
-  isTest,
   isMainnetOrRinkebyOrFork,
 } = require("../test/helpers.js");
-const { utils } = require("ethers");
 const {
   log,
   deployWithConfirmation,
@@ -19,14 +15,10 @@ const { proposeArgs } = require("../utils/governor");
 
 const deployName = "007_upgrade_single_asset_staking";
 
-const upgradeSingleAssetStaking = async ({ getNamedAccounts, deployments }) => {
+const upgradeSingleAssetStaking = async ({ getNamedAccounts }) => {
   console.log(`Running ${deployName} deployment...`);
 
-  const { governorAddr, deployerAddr } = await getNamedAccounts();
-
-  const assetAddresses = await getAssetAddresses(deployments);
-
-  const sDeployer = ethers.provider.getSigner(deployerAddr);
+  const { governorAddr } = await getNamedAccounts();
   const sGovernor = ethers.provider.getSigner(governorAddr);
 
   //

--- a/contracts/deploy/007_upgrade_single_asset_staking.js
+++ b/contracts/deploy/007_upgrade_single_asset_staking.js
@@ -1,0 +1,82 @@
+//
+// Script to upgrade the Single Asset Staking contract.
+//
+const {
+  getAssetAddresses,
+  isMainnet,
+  isRinkeby,
+  isFork,
+  isTest,
+  isMainnetOrRinkebyOrFork,
+} = require("../test/helpers.js");
+const { utils } = require("ethers");
+const {
+  log,
+  deployWithConfirmation,
+  executeProposal,
+} = require("../utils/deploy");
+const { proposeArgs } = require("../utils/governor");
+
+const deployName = "007_upgrade_single_asset_staking";
+
+const upgradeSingleAssetStaking = async ({ getNamedAccounts, deployments }) => {
+  console.log(`Running ${deployName} deployment...`);
+
+  const { governorAddr, deployerAddr } = await getNamedAccounts();
+
+  const assetAddresses = await getAssetAddresses(deployments);
+
+  const sDeployer = ethers.provider.getSigner(deployerAddr);
+  const sGovernor = ethers.provider.getSigner(governorAddr);
+
+  //
+  // Deploy the new implementation.
+  //
+  const dSingleAssetStaking = await deployWithConfirmation(
+    "SingleAssetStaking"
+  );
+
+  //
+  // Upgrade.
+  //
+  const cOGNStakingProxy = await ethers.getContract("OGNStakingProxy");
+  const propDescription = "OGNStaking upgrade";
+  const propArgs = await proposeArgs([
+    {
+      contract: cOGNStakingProxy,
+      signature: "upgradeTo(address)",
+      args: [dSingleAssetStaking.address],
+    },
+  ]);
+
+  if (isMainnet) {
+    // On Mainnet upgrade has to be handled manually via a multi-sig tx.
+    log(
+      "Next step: propose, enqueue and execute a governance proposal to upgrade."
+    );
+    log(`Governor address: ${governorAddr}`);
+    log(`Proposal [targets, values, sigs, datas]:`);
+    log(JSON.stringify(propArgs, null, 2));
+  } else if (isFork) {
+    // On Fork, simulate the governance proposal and execution flow that takes place on Mainnet.
+    await executeProposal(propArgs, propDescription);
+  } else {
+    // Local testing environment. Upgrade via the governor account directly.
+    await cOGNStakingProxy
+      .connect(sGovernor)
+      .upgradeTo(dSingleAssetStaking.address);
+    log(`Upgraded OGNStaking to ${dSingleAssetStaking.address}`);
+  }
+
+  console.log(`${deployName} deploy done.`);
+  return true;
+};
+
+upgradeSingleAssetStaking.id = deployName;
+upgradeSingleAssetStaking.dependencies = ["core"];
+
+// No need to execute on dev and test network since the contract already gets
+// deployed with the latest code by the 004_single_asset_staking script.
+upgradeSingleAssetStaking.skip = () => !isMainnetOrRinkebyOrFork;
+
+module.exports = upgradeSingleAssetStaking;

--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -54,10 +54,10 @@ task(
       }
     }
 
-    if (process.env.GAS_MULTIPLIER) {
-      const value = Number(process.env.GAS_MULTIPLIER);
-      if (value < 0 || value > 2) {
-        throw new Error(`Check GAS_MULTIPLIER. Value out of range.`);
+    if (process.env.GAS_PRICE_MULTIPLIER) {
+      const value = Number(process.env.GAS_PRICE_MULTIPLIER);
+      if (value < 1 || value > 2) {
+        throw new Error(`Check GAS_PRICE_MULTIPLIER. Value out of range.`);
       }
     }
     console.log("All good. Deploy away!");
@@ -794,7 +794,6 @@ module.exports = {
         process.env.DEPLOYER_PK || privateKeys[1],
         process.env.GOVERNOR_PK || privateKeys[1],
       ],
-      gasMultiplier: Number(process.env.GAS_MULTIPLIER) || 1,
     },
     mainnet: {
       url: `${process.env.PROVIDER_URL}`,
@@ -802,7 +801,6 @@ module.exports = {
         process.env.DEPLOYER_PK || privateKeys[0],
         process.env.GOVERNOR_PK || privateKeys[0],
       ],
-      gasMultiplier: Number(process.env.GAS_MULTIPLIER) || 1,
     },
   },
   mocha: {

--- a/contracts/scripts/etherscan/etherscanVerify.js
+++ b/contracts/scripts/etherscan/etherscanVerify.js
@@ -154,8 +154,8 @@ async function verifyContract(name, config, deployment) {
 
   const optimizer = metadata.settings.optimizer;
   const licenseType = getLicenseType(config.license);
-  let version = metadata.compiler.version
-  if (version.slice(-4) == '.mod') {
+  let version = metadata.compiler.version;
+  if (version.slice(-4) == ".mod") {
     version = version.slice(0, -4);
   }
   const postData = {

--- a/contracts/scripts/governor/propose.js
+++ b/contracts/scripts/governor/propose.js
@@ -6,7 +6,7 @@
 //  - Setup your environment
 //      export HARDHAT_NETWORK=mainnet
 //      export DEPLOYER_PK=<pk>
-//      export GAS_MULTIPLIER=<multiplier> e.g. 1.1
+//      export GAS_PRICE_MULTIPLIER=<multiplier> e.g. 1.1
 //      export PROVIDER_URL=<url>
 //  - Run:
 //      node propose.js --<action>

--- a/contracts/scripts/governor/propose.js
+++ b/contracts/scripts/governor/propose.js
@@ -23,6 +23,22 @@ const addresses = require("../../utils/addresses");
 // Wait for 3 blocks confirmation on Mainnet/Rinkeby.
 const NUM_CONFIRMATIONS = isMainnet || isRinkeby ? 3 : 0;
 
+// Returns the argument to use for sending a proposal to upgrade OUSD.
+async function proposeUpgradeStakingArgs() {
+  const stakingProxy = await ethers.getContract("OGNStakingProxy");
+  const staking = await ethers.getContract("OGNStaking");
+
+  const args = await proposeArgs([
+    {
+      contract: stakingProxy,
+      signature: "upgradeTo(address)",
+      args: [staking.address],
+    },
+  ]);
+  const description = "Upgrade OGNStaking";
+  return { args, description };
+}
+
 async function proposeClaimOGNStakingGovernance() {
   const proxy = await ethers.getContract("OGNStakingProxy");
 
@@ -585,6 +601,9 @@ async function main(config) {
   } else if (config.claimOGNStakingGovernance) {
     console.log("proposeClaimOGNStakingGovernance");
     argsMethod = proposeClaimOGNStakingGovernance;
+  } else if (config.upgradeStaking) {
+    console.log("upgradeStaking");
+    argsMethod = proposeUpgradeStakingArgs;
   } else {
     console.error("An action must be specified on the command line.");
     return;
@@ -655,6 +674,7 @@ const config = {
   prop17: args["--prop17"],
   pauseCapital: args["--pauseCapital"],
   claimOGNStakingGovernance: args["--claimOGNStakingGovernance"],
+  upgradeStaking: args["--upgradeStaking"],
 };
 console.log("Config:");
 console.log(config);

--- a/contracts/test/oracle.js
+++ b/contracts/test/oracle.js
@@ -174,12 +174,16 @@ describe("Oracle", function () {
     expect(await mixOracle.getTokenETHOraclesLength("TEST")).to.eq(Zero);
     expect(await mixOracle.getTokenUSDOraclesLength("TEST")).to.eq(Zero);
 
-    mixOracle.connect(governor).registerTokenOracles("TEST", [], [mockOracle.address]);
+    mixOracle
+      .connect(governor)
+      .registerTokenOracles("TEST", [], [mockOracle.address]);
 
     expect(await mixOracle.getTokenETHOraclesLength("TEST")).to.eq(Zero);
     expect(await mixOracle.getTokenUSDOraclesLength("TEST")).to.eq(One);
 
-    expect(await mixOracle.getTokenUSDOracle("TEST", 0)).to.eq(mockOracle.address);
+    expect(await mixOracle.getTokenUSDOracle("TEST", 0)).to.eq(
+      mockOracle.address
+    );
     await expect(mixOracle.getTokenUSDOracle("TEST", 1)).to.be.reverted;
   });
 });

--- a/contracts/utils/tx.js
+++ b/contracts/utils/tx.js
@@ -6,15 +6,15 @@ const ethers = require('ethers')
  * Calculates an above average gas price.
  * Can be used to submit a transaction for faster than average mining time.
  *
- * @param {Number} extra: Percentage to apply on top of the current gas price.
+ * @param {Number} mutliplier: Multiplier applied to the current gas price. For ex 1.15 gives an extra 15%.
  * @returns {Promise<BigNumber>}
  */
-async function premiumGasPrice(extra=10) {
-  const gasPriceMultiplier = ethers.BigNumber.from(100 + Number(extra))
+async function premiumGasPrice(multiplier) {
+  const gasPriceMultiplier = ethers.BigNumber.from(100 * Number(multiplier))
   const gasPriceDivider = ethers.BigNumber.from(100)
 
-  if (gasPriceMultiplier.lt(0) || gasPriceMultiplier.gt(130)) {
-    throw new Error(`premiumGasPrice called with extra out of range`)
+  if (gasPriceMultiplier.lt(100) || gasPriceMultiplier.gt(200)) {
+    throw new Error(`premiumGasPrice called with multiplier out of range`)
   }
 
   // Get current gas price from the network.
@@ -35,14 +35,12 @@ async function premiumGasPrice(extra=10) {
 
 /**
  * Returns extra options to use when sending a tx to the network.
- * TODO: Investigate why Harhat gasMultipler options we set in hardhat.config.js
- * does not seem to get applied when running deploys and standalone script against Mainnet.
  *
- * @returns {Promise<{gasPrice: *}|{}>}
+ * @returns {Promise<{gasPrice: ethers.BigNumber}|{}>}
  */
 async function getTxOpts() {
-  if (process.env.PREMIUM_GAS) {
-    const gasPrice = await premiumGasPrice(process.env.GAS_MULTIPLIER);
+  if (process.env.GAS_PRICE_MULTIPLIER) {
+    const gasPrice = await premiumGasPrice(process.env.GAS_PRICE_MULTIPLIER);
     return { gasPrice };
   }
   return {};


### PR DESCRIPTION
For deploying to Mainnet the latest changes to the contract.

Also includes a fix to have the ability to apply a multiplier to the gas price (this is handy to speed up deployments on mainnet).
We thought hardhat supports it via the gasMultiplier option in the config but that actually applies to the gas limit, not the gas price. So I removed that option in the config and replace it with customer code that is enabled via the GAS_PRICE_MULTIPLER env variable.