### PR TITLE
Sparrow dom/tracking

### DIFF
--- a/dapp/pages/_app.js
+++ b/dapp/pages/_app.js
@@ -124,6 +124,11 @@ function App({ Component, pageProps, err }) {
       if (utmSource) {
         setUserSource(utmSource)
       }
+    } else {
+      /* if first page load is not equipped with the 'utm_source' we permanently mark
+       * user source as unknown
+       */
+      setUserSource('unknown')
     }
   }
 

--- a/dapp/pages/_app.js
+++ b/dapp/pages/_app.js
@@ -12,6 +12,7 @@ import UserActivityListener from 'components/UserActivityListener'
 import TransactionListener from 'components/TransactionListener'
 import withWeb3Provider from 'hoc/withWeb3Provider'
 import setUtilLocale from 'utils/setLocale'
+import { setUserSource } from 'utils/user'
 import { useEagerConnect } from 'utils/hooks'
 import { logout, login } from 'utils/account'
 import LoginModal from 'components/LoginModal'
@@ -106,17 +107,50 @@ function App({ Component, pageProps, err }) {
 		}
   }, [])
   
+  const trackPageView = (url, lastURL) => {
+    const data = {
+      toURL: url
+    }
+
+    if (lastURL) {
+      data.fromURL = lastURL
+    }
+
+    mixpanel.track('Page View', data)
+
+    if (url.indexOf('?') > 0) {
+      const searchParams = new URLSearchParams(url.substr(url.indexOf("?") + 1))
+      const utmSource = searchParams.get('utm_source')
+      if (utmSource) {
+        setUserSource(utmSource)
+      }
+    }
+  }
+
   useEffect(() => {
-    let lastURL = window.location.pathname
+    let lastURL = window.location.pathname + window.location.search
 
-    router.events.on('routeChangeComplete', (url) => {
-      mixpanel.track('Page View', {
-        fromURL: lastURL,
-        toURL: url
-      })
+    // track initial page load
+    trackPageView(lastURL)
 
+    const handleRouteChange = url => {
+      /* There is this weird behaviour with react router where `routeChangeComplete` gets triggered
+       * on initial load only if URL contains search parameters. And without this check and search 
+       * parameters present the inital page view would be tracked twice.
+       */
+      if (url === lastURL){
+        return 
+      }
+      // track when user navigates to a new page
+      trackPageView(url, lastURL)
       lastURL = url
-    })
+    }
+
+    router.events.on('routeChangeComplete', handleRouteChange)
+
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange)
+    }
   }, [])
 
   const onLocale = async newLocale => {

--- a/dapp/src/components/buySell/BuySellWidget.js
+++ b/dapp/src/components/buySell/BuySellWidget.js
@@ -20,6 +20,7 @@ import { providersNotAutoDetectingOUSD, providerName } from 'utils/web3'
 import withRpcProvider from 'hoc/withRpcProvider'
 import BuySellModal from 'components/buySell/BuySellModal'
 import { isMobileMetaMask } from 'utils/device'
+import { getUserSource } from 'utils/user'
 
 import mixpanel from 'utils/mixpanel'
 import { truncateDecimals } from '../../utils/math'
@@ -305,6 +306,8 @@ const BuySellWidget = ({
       const receipt = await rpcProvider.waitForTransaction(result.hash)
       mixpanel.track('Mint tx succeeded', {
         coins: mintedCoins.join(','),
+        // we already store utm_source as user property. This is for easier analytics
+        utm_source: getUserSource(),
       })
       if (localStorage.getItem('addOUSDModalShown') !== 'true') {
         AccountStore.update((s) => {

--- a/dapp/src/components/buySell/SellWidget.js
+++ b/dapp/src/components/buySell/SellWidget.js
@@ -13,6 +13,7 @@ import AccountStore from 'stores/AccountStore'
 import AnimatedOusdStore from 'stores/AnimatedOusdStore'
 import DisclaimerTooltip from 'components/buySell/DisclaimerTooltip'
 import { isMobileMetaMask } from 'utils/device'
+import { getUserSource } from 'utils/user'
 
 import mixpanel from 'utils/mixpanel'
 
@@ -143,7 +144,11 @@ const SellWidget = ({
       mixpanel.track('Redeem tx failed', { amount })
     }
     const onSellSuccess = (amount) => {
-      mixpanel.track('Redeem tx succeeded', { amount })
+      mixpanel.track('Redeem tx succeeded', {
+        amount,
+        // we already store utm_source as user property. This is for easier analytics
+        utm_source: getUserSource(),
+      })
       setOusdToSellValue('')
       setSellWidgetCoinSplit([])
     }

--- a/dapp/src/utils/user.js
+++ b/dapp/src/utils/user.js
@@ -1,0 +1,17 @@
+import mixpanel from 'utils/mixpanel'
+const localStorageUserSourceKey = 'utm_source'
+
+let source
+export function getUserSource() {
+  return localStorage.getItem(localStorageUserSourceKey)
+}
+
+export function setUserSource(userSource) {
+  const currentSource = getUserSource()
+  if (!currentSource && userSource) {
+    localStorage.setItem(localStorageUserSourceKey, userSource)
+
+    // set once doesn't override the already set values
+    mixpanel.people.set_once('utm_source', userSource)
+  }
+}


### PR DESCRIPTION
- Add ability to track on per user basis their origin (like from a promotional campaign) using `utm_source` URL param
- fix a bug where initial Page load would not track a `page view` event


Contract change checklist:
  - [ ] Code reviewed by 2 reviewers
  - [ ] Unit tests pass
  - [ ] Slither tests pass with no warning
  - [ ] Echidna tests pass (not automated, run manually on local)