### PR TITLE
New hardhat task to show governance proposal status

### DIFF
--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -855,6 +855,23 @@ task("executeProposalOnFork", "Enqueue and execute a proposal on the Fork")
     await executeProposalOnFork(proposalId);
   });
 
+task("proposal", "Dumps the state of a proposal")
+  .addParam("id", "Id of the proposal")
+  .setAction(async (taskArguments, hre) => {
+    const proposalId = Number(taskArguments.id);
+    const governor = await hre.ethers.getContract("Governor");
+    const proposal = await governor["proposals(uint256)"](proposalId);
+    const actions = await governor.getActions(proposalId);
+
+    console.log(`Governor at ${governor.address}`)
+    console.log(`Proposal ${proposal.id}`);
+    console.log("===========");
+    console.log(`  executed: ${proposal.executed}`);
+    console.log(`  eta:      ${proposal.eta}`);
+    console.log(`  proposer: ${proposal.proposer}`);
+    console.log("  actions:  ", JSON.stringify(actions, null, 2));
+  });
+
 module.exports = {
   solidity: {
     version: "0.5.11",


### PR DESCRIPTION
Can be used against mainnet or fork to get the current status of a proposal based on its id.

Example:
```
FORK=TRUE npx hardhat proposal --id 5 --network localhost
Governor at 0x8e7bDFeCd1164C46ad51b58e49A611F954D23377
Proposal 5
===========
  executed: true
  eta:      1609802586
  proposer: 0x71F78361537A6f7B6818e7A760c8bC0146D93f50
  actions:   [
  [
    "0x2A8e1E676Ec238d8A992307B495b45B3fEAa5e86",
    "0x2A8e1E676Ec238d8A992307B495b45B3fEAa5e86",
    "0x2A8e1E676Ec238d8A992307B495b45B3fEAa5e86",
    "0x2A8e1E676Ec238d8A992307B495b45B3fEAa5e86"
  ],
  [
    "upgradeTo(address)",
    "reset()",
    "setVaultAddress(address)",
    "upgradeTo(address)"
  ],
  [
    "0x00000000000000000000000078b107e4c3192e225e6bc2bc10e28de9866d39de",
    "0x",
    "0x000000000000000000000000e75d77b1865ae93c7eaa3040b038d7aa7bc02f70",
    "0x000000000000000000000000159ea2fa3a92dae6b9f21d6753aa6a8ea5bf77ba"
  ]
]
```