### PR TITLE
🏰  Simplification of _isNonRebasingAccount()

### DIFF
--- a/contracts/contracts/token/OUSD.sol
+++ b/contracts/contracts/token/OUSD.sol
@@ -361,44 +361,18 @@ contract OUSD is Initializable, InitializableERC20Detailed, Governable {
     }
 
     /**
-     * @dev Is an account's balance non-rebasing, i.e. does not alter with rebases.
-     *      By default contracts are non-rebasing and EOA's are rebasing.
-     *      Or the address could have chosen to override this.
+     * @dev Is an account using rebasing accounting or non-rebasing accounting?
+     *      Also, ensure contracts are non-rebasing if they have not opted in.
      * @param _account Address of the account.
      */
     function _isNonRebasingAccount(address _account) internal returns (bool) {
-        RebaseOptions accountRebaseState = rebaseState[_account];
-        if (accountRebaseState == RebaseOptions.OptIn) {
-            // The address has chosen to be rebasing.
-            return false;
-        } else if (accountRebaseState == RebaseOptions.OptOut) {
-            // The address has chosen to be non-rebasing.
-            return true;
-        } else {
-            // The address has not chosen explicitly, so use the default
-            // for its type.
-            if (Address.isContract(_account)) {
-                // Contracts default to be non-rebasing.
-
-                // Migrate if needed, making sure the rebasing/non-rebasing
-                // supply is updated and fixed credits per token is set
-                // for this account.
-                _ensureRebasingMigration(_account);
-                return true;
-            } else {
-                // User accounts default to be rebasing.
-
-                // Disallow contracts from interacting with OUSD if the following
-                // sequence has occurred: The contract has self-destructed, been
-                // recreated at the same address with CREATE2, and then is interacting
-                // with OUSD again from the contract's constructor.
-                require(
-                    nonRebasingCreditsPerToken[_account] == 0,
-                    "Previous Contract"
-                );
-                return false;
-            }
+        if (
+            Address.isContract(_account) &&
+            rebaseState[_account] == RebaseOptions.NotSet
+        ) {
+            _ensureRebasingMigration(_account);
         }
+        return nonRebasingCreditsPerToken[_account] > 0;
     }
 
     /**

--- a/contracts/contracts/token/OUSD.sol
+++ b/contracts/contracts/token/OUSD.sol
@@ -366,10 +366,8 @@ contract OUSD is Initializable, InitializableERC20Detailed, Governable {
      * @param _account Address of the account.
      */
     function _isNonRebasingAccount(address _account) internal returns (bool) {
-        if (
-            Address.isContract(_account) &&
-            rebaseState[_account] == RebaseOptions.NotSet
-        ) {
+        bool isContract = Address.isContract(_account);
+        if (isContract && rebaseState[_account] == RebaseOptions.NotSet) {
             _ensureRebasingMigration(_account);
         }
         return nonRebasingCreditsPerToken[_account] > 0;


### PR DESCRIPTION
After some thought, there's an **epic simplification** of `_isNonRebasingAccount()`. The reason functions call `_isNonRebasingAccount()` is to figure out what kind of accounting the account is using so that the calling function can do the correct accounting operations.

Getting the returned accounting style wrong nukes OUSD. It's absolutely important that the value returned from this function matches the actual accounting style used by the address.

In the past, `_isNonRebasingAccount()` has used two bools and one three-value, for twelve total possible states, and with those attempts to predict what `_isNonRebasingAccount()` has done in the past, and what the rest of the contract has done in the past, in order to return the current accounting style to for the account. This is complicated.

It is also very brittle - if logic elsewhere chances, or if something unexpected happens _*cough, CREATE2*_, then this function can  be disastrously wrong.

In reality, this method is super simple. To always correctly return the current accounting style.... we just need to return the current accounting style!

(Plus a little extra if statement to migrate newly interacting contracts to be non-rebasing.)

Contract change checklist:
  - [x] Code reviewed by 2 reviewers
  - [x] Unit tests pass
  - [x] Slither tests pass with no warning
  - [x] Echidna tests pass (not automated, run manually on local)