### PR TITLE
🏰 Only allow governor to unpause

### DIFF
--- a/contracts/contracts/vault/VaultAdmin.sol
+++ b/contracts/contracts/vault/VaultAdmin.sol
@@ -264,7 +264,7 @@ contract VaultAdmin is VaultStorage {
     /**
      * @dev Set the deposit paused flag to false to enable capital movement.
      */
-    function unpauseCapital() external onlyGovernorOrStrategist {
+    function unpauseCapital() external onlyGovernor {
         capitalPaused = false;
         emit CapitalUnpaused();
     }

--- a/contracts/test/vault/deposit.js
+++ b/contracts/test/vault/deposit.js
@@ -18,7 +18,7 @@ describe("Vault deposit pausing", async () => {
   it("Non-governor cannot unpause", async () => {
     const { anna, vault } = await loadFixture(defaultFixture);
     await expect(vault.connect(anna).unpauseCapital()).to.be.revertedWith(
-      "Caller is not the Strategist or Governor"
+      "Caller is not the Governor"
     );
   });
 


### PR DESCRIPTION
Currently we allow the strategist role to unpause capital. While this pause/unpause permission is nice and symmetrical, we may want to change it.

The strategist role is used for asset allocations and rapid response. It is likely to be one of the first actions to go to community governance. One of the core design requirements of the strategist is that it not be able to harm the contract funds. The methods that the strategist can call  should always be safe or reletively safe.

`unpauseCapital` is safe - most of the time. But consider the initial steps followed if a bug is found:

1. We find a bug.
2. We pause capital.
3. We discuss the bug and its fix publicly in GitHub.

At this time, `unpauseCapital` is an unsafe method since unpausing would allow the contract to be attacked - perhaps even with attack code we wrote ourselves and published to GitHub.

----

The downside to this change is that unpausing slows down to the speed of the governor + timelock. In the future this could be two days.

This should not affect normal contract upgrades, since the unpause can be queue immediately after the upgrade. However this does increase the consequences of a false-alarm contract pause to having the contract paused for the duration of the timelock.

----

Contract change checklist:
  - [x] Code reviewed by 2 reviewers
  - [x] Unit tests pass
  - [x] Slither tests pass with no warning
  - [x] Echidna tests pass (not automated, run manually on local)