### PR TITLE
🏰 Allow strategist to pause rebasing

### DIFF
--- a/contracts/contracts/vault/VaultAdmin.sol
+++ b/contracts/contracts/vault/VaultAdmin.sol
@@ -240,7 +240,7 @@ contract VaultAdmin is VaultStorage {
     /**
      * @dev Set the deposit paused flag to true to prevent rebasing.
      */
-    function pauseRebase() external onlyGovernor {
+    function pauseRebase() external onlyGovernorOrStrategist {
         rebasePaused = true;
         emit RebasePaused();
     }

--- a/contracts/test/vault/rebase.js
+++ b/contracts/test/vault/rebase.js
@@ -31,14 +31,38 @@ describe("Vault rebase pausing", async () => {
     await vault.rebase();
   });
 
-  it("Should not allow non-governor to pause or unpause rebase", async () => {
+  it("Should not allow the public to pause or unpause rebasing", async () => {
     let { vault, anna } = await loadFixture(defaultFixture);
     await expect(vault.connect(anna).pauseRebase()).to.be.revertedWith(
-      "Caller is not the Governor"
+      "Caller is not the Strategist or Governor"
     );
     await expect(vault.connect(anna).unpauseRebase()).to.be.revertedWith(
       "Caller is not the Governor"
     );
+  });
+
+  it("Should allow strategist to pause rebasing", async () => {
+    let { vault, governor, josh } = await loadFixture(defaultFixture);
+    await vault.connect(governor).setStrategistAddr(josh.address);
+    await vault.connect(josh).pauseRebase();
+  });
+
+  it("Should allow strategist to unpause rebasing", async () => {
+    let { vault, governor, josh } = await loadFixture(defaultFixture);
+    await vault.connect(governor).setStrategistAddr(josh.address);
+    await expect(vault.connect(josh).unpauseRebase()).to.be.revertedWith(
+      "Caller is not the Governor"
+    );
+  });
+
+  it("Should allow governor tonpause rebasing", async () => {
+    let { vault, governor } = await loadFixture(defaultFixture);
+    await vault.connect(governor).pauseRebase();
+  });
+
+  it("Should allow governor to unpause rebasing", async () => {
+    let { vault, governor } = await loadFixture(defaultFixture);
+    await vault.connect(governor).unpauseRebase();
   });
 
   it("Rebase pause status can be read", async () => {


### PR DESCRIPTION
Pausing rebasing may be needed to secure the contract against certain kinds of vulnerabilities. This should be a rapid strategist action, rather than a deliberative governor action.

The change allow strategist to pause rebasing. It does not allow the strategist to unpause rebasing, following the line of thinking on #494. 

----

Contract change checklist:
  - [x] Code reviewed by 2 reviewers
  - [x] Unit tests pass
  - [x] Slither tests pass with no warning
  - [x] Echidna tests pass (not automated, run manually on local)