### PR TITLE
🏰  Certora-02 Don’t allow transfer out of non-supported assets.

### DIFF
--- a/contracts/contracts/vault/VaultAdmin.sol
+++ b/contracts/contracts/vault/VaultAdmin.sol
@@ -283,6 +283,7 @@ contract VaultAdmin is VaultStorage {
         external
         onlyGovernor
     {
+        require(!assets[_asset].isSupported, "Only unsupported assets");
         IERC20(_asset).safeTransfer(governor(), _amount);
     }
 

--- a/contracts/test/vault/index.js
+++ b/contracts/test/vault/index.js
@@ -240,6 +240,16 @@ describe("Vault", function () {
     ).to.be.revertedWith("Caller is not the Governor");
   });
 
+  it("Should not allow transfer of supported token by governor", async () => {
+    const { vault, usdc, governor } = await loadFixture(defaultFixture);
+    // Matt puts USDC in vault
+    await usdc.transfer(vault.address, usdcUnits("8.0"));
+    // Governor cannot move USDC because it is a supported token.
+    await expect(
+      vault.connect(governor).transferToken(usdc.address, ousdUnits("8.0"))
+    ).to.be.revertedWith("Only unsupported assets");
+  });
+
   it("Should allow Governor to add Strategy", async () => {
     const { vault, governor, ousd } = await loadFixture(defaultFixture);
     // Pretend OUSD is a strategy and add its address


### PR DESCRIPTION
This prevents the governance/timelock from transferring out supported tokens from the vault. While there certainly are other ways governance could be malicious, we might was well have this one closed.

Flagged by Certora human auditing.

Contract change checklist:
  - [ ] Code reviewed by 2 reviewers
  - [x] Unit tests pass
  - [x] Slither tests pass with no warning
  - [x] Echidna tests pass (not automated, run manually on local)