### PR TITLE
🏰 Certora-01 Remove unneeded returns from mint/burn.

### DIFF
--- a/contracts/contracts/token/OUSD.sol
+++ b/contracts/contracts/token/OUSD.sol
@@ -256,7 +256,7 @@ contract OUSD is Initializable, InitializableERC20Detailed, Governable {
      * @dev Mints new tokens, increasing totalSupply.
      */
     function mint(address _account, uint256 _amount) external onlyVault {
-        return _mint(_account, _amount);
+        _mint(_account, _amount);
     }
 
     /**
@@ -296,7 +296,7 @@ contract OUSD is Initializable, InitializableERC20Detailed, Governable {
      * @dev Burns tokens, decreasing totalSupply.
      */
     function burn(address account, uint256 amount) external onlyVault {
-        return _burn(account, amount);
+        _burn(account, amount);
     }
 
     /**


### PR DESCRIPTION
OUSD's mint and burn functions do not return anything, nor do the backing internal _mint and _burn methods. This means it's not really doing anything return the value passed back.

Flagged by Certora human auditing.

Contract change checklist:
  - [x] Code reviewed by 2 reviewers
  - [x] Unit tests pass
  - [x] Slither tests pass with no warning
  - [x] Echidna tests pass (not automated, run manually on local)