### PR TITLE
🏰 Certora-03 Zero amount burn should not change state

### DIFF
--- a/contracts/contracts/token/OUSD.sol
+++ b/contracts/contracts/token/OUSD.sol
@@ -312,6 +312,9 @@ contract OUSD is Initializable, InitializableERC20Detailed, Governable {
      */
     function _burn(address _account, uint256 _amount) internal nonReentrant {
         require(_account != address(0), "Burn from the zero address");
+        if (_amount == 0) {
+            return;
+        }
 
         bool isNonRebasingAccount = _isNonRebasingAccount(_account);
         uint256 creditAmount = _amount.mulTruncate(_creditsPerToken(_account));


### PR DESCRIPTION
A zero amount burn combined the anti-dust code in burn can result in the user's balance decreasing. While the numbers involved would need to be crazy tiny, it makes sense to keep this clean and make sure a zero burn does nothing.

Found by Certora's automated prover.

Contract change checklist:
  - [ ] Code reviewed by 2 reviewers
  - [x] Unit tests pass
  - [x] Slither tests pass with no warning
  - [x] Echidna tests pass (not automated, run manually on local)