### PR TITLE
Claim OGN fork test

### DIFF
--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -1,6 +1,4 @@
 const ethers = require("ethers");
-const { utils } = require("ethers");
-const { formatUnits } = utils;
 
 require("@nomiclabs/hardhat-waffle");
 require("@nomiclabs/hardhat-solhint");
@@ -16,10 +14,10 @@ const { balance } = require("./tasks/ousd");
 const {
   isAdjusterLocked,
   fundCompAccountsWithEth,
-  claimAllAsUser,
+  claimOGN,
+  claimOUSD,
   checkOUSDBalances,
   supplyStakingContractWithOGN,
-  claimAllOGNAsUser
 } = require("./tasks/compensation");
 const {
   allocate,
@@ -106,22 +104,21 @@ task(
   "Fund compensation accounts with minimal eth"
 ).setAction(fundCompAccountsWithEth);
 task(
-  "claimAll",
-  "Claim compensation as each user in the reimbursements"
-).setAction(claimAllAsUser);
+  "claimOUSD",
+  "Claim the OUSD part of the compensation plan for all eligible users"
+).setAction(claimOUSD);
 task(
   "checkOUSDBalances",
   "Check ousd balances of contract and accounts"
 ).setAction(checkOUSDBalances);
 task(
   "supplyStakingWithOGN",
-  "Supplies a great amount of ogn to staking contract",
-  claimAllOGNAsUser
+  "Supplies a great amount of ogn to staking contract"
 ).setAction(supplyStakingContractWithOGN);
 task(
-  "claimOgnAsAUser",
-  "claims compensation OGN by staking it for 365 days"
-).setAction(claimAllOGNAsUser);
+  "claimOGN",
+  "Claims the OGN part of the compensation plan for all eligible users"
+).setAction(claimOGN);
 
 module.exports = {
   solidity: {

--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -18,6 +18,8 @@ const {
   fundCompAccountsWithEth,
   claimAllAsUser,
   checkOUSDBalances,
+  supplyStakingContractWithOGN,
+  claimAllOGNAsUser
 } = require("./tasks/compensation");
 const {
   allocate,
@@ -111,6 +113,15 @@ task(
   "checkOUSDBalances",
   "Check ousd balances of contract and accounts"
 ).setAction(checkOUSDBalances);
+task(
+  "supplyStakingWithOGN",
+  "Supplies a great amount of ogn to staking contract",
+  claimAllOGNAsUser
+).setAction(supplyStakingContractWithOGN);
+task(
+  "claimOgnAsAUser",
+  "claims compensation OGN by staking it for 365 days"
+).setAction(claimAllOGNAsUser);
 
 module.exports = {
   solidity: {

--- a/contracts/scripts/compensation/compensationSync.js
+++ b/contracts/scripts/compensation/compensationSync.js
@@ -31,7 +31,7 @@ async function verify(expectedAccounts, dataFileLocation) {
     const walletAmount = await ousdContract.balanceOf(account.address);
     const contractStateCorrect = actual.eq(expected);
 
-    // Beause of rebasing logic of OUSD the amounts are not going to be completely exact
+    // Because of rebasing logic of OUSD the amounts are not going to be completely exact
     const walletStateExact = walletAmount
       .sub(expected)
       .abs()

--- a/contracts/scripts/compensation/forkDeployment.js
+++ b/contracts/scripts/compensation/forkDeployment.js
@@ -63,15 +63,10 @@ const { extractOGNAmount, computeRootHash } = require("./utils/stake");
 
 const cOGNStakingProxy = await ethers.getContract("OGNStakingProxy");
 // Initialize the SingleAssetStaking contract.
-const cOGNStaking = await ethers.getContractAt(
-  "SingleAssetStaking",
-  cOGNStakingProxy.address
-);
+const cOGNStaking = await ethers.getContractAt("SingleAssetStaking", cOGNStakingProxy.address);
+// Ran agains mainnet fork using command `compute-merkle-proofs-local` and saved in top comment: contracts/tasks/compensation.js
+const root = { hash: "0x304013b1a650e205f3210663cdea44d1af2785d275268276a299c663ee2e4615", depth: 10 }
 
-const payouts = await parseCsv(reimbursementsLocation);
-const payoutList = {...compensationData, rate: ethers.utils.parseUnits((compensationData.rate / 100.0).toString(), 18).toString(), payouts};
-const root = computeRootHash(cOGNStaking.address, extractOGNAmount(payoutList));
-
-const propArgsSetRoot = await proposeArgs([{ contract: cOGNStaking, signature: "setAirDropRoot(uint8,bytes32,uint256)", args: [compensationData.type, root.hash, root.depth]}]);
+const propArgsSetRoot = await proposeArgs([{ contract: cOGNStaking, signature: "setAirDropRoot(uint8,bytes32,uint256)", args: [1, root.hash, root.depth]}]);
 await sendProposal(propArgsSetRoot, "Set airdrop root hash");
 // End OF OGN compensation

--- a/contracts/scripts/compensation/forkDeployment.js
+++ b/contracts/scripts/compensation/forkDeployment.js
@@ -34,9 +34,7 @@ await sendProposal(propResetArgs, "Unlock the adjuster");
 await compensationSync(compensationClaims, reimbursementsLocation, true, adjusterSigner);
 
 // Locks adjuster
-const propResetArgsLock = await proposeArgs([
-  { contract: compensationClaims, signature: "lockAdjuster()" },
-]);
+const propResetArgsLock = await proposeArgs([{ contract: compensationClaims, signature: "lockAdjuster()" }]);
 await sendProposal(propResetArgsLock, "Lock the adjuster");
 
 //verify compensation data

--- a/contracts/scripts/staking/airDrop.js
+++ b/contracts/scripts/staking/airDrop.js
@@ -56,7 +56,7 @@ async function main() {
   }
 
   const contractAddress = (await ethers.getContract("OGNStakingProxy")).address;
-  console.log(`Contract address used to generate proofs: ${contractAddress}`)
+  console.log(`Contract address used to generate proofs: ${contractAddress}`);
 
   const payouts = await parseCsv("./scripts/staking/reimbursements.csv");
   const payoutList = {

--- a/contracts/tasks/compensation.js
+++ b/contracts/tasks/compensation.js
@@ -1,4 +1,6 @@
-/* Output analysis 15.1. by sparrowDom reimbursements hash: 0x7be111312b7921a476d7428f6f43555684ac06739acfc01341649dfbc5f4bac3
+/* Reimbursements csv: https://docs.google.com/spreadsheets/d/1lCzDmmLV73rwRSnAKVGdsUkhuelxBvH4fxYNAUAd69U/edit?usp=sharing
+ * 
+ * Output analysis 1.15.2021 by sparrowDom reimbursements hash: 0x7be111312b7921a476d7428f6f43555684ac06739acfc01341649dfbc5f4bac3
  * OUSD required by contract: 1696579.792469218771921386 OUSD
  * OUSD transfered to contract: 1696590
  * OUSD remaining in the contract after all claims: 84.554630679871612032
@@ -31,9 +33,14 @@
  * 0xf9303877F107F5cd2cB0654b6d7A6D749FA03856 -> 14936 OUSD
  * 0xFD9E6005187F448957a0972a7d0C0A6dA2911236 -> 1.5 OUSD
  *
+ * OGN reimbursements on 1.18.2021 by sparrowDom
  * Mainnet fork merkle tree root & hash:
  *  - Merkle tree root hash: 0x304013b1a650e205f3210663cdea44d1af2785d275268276a299c663ee2e4615
  *  - Merkle tree root depth: 10
+ * 
+ * 188 accounts successfully claimed OGN. 539 accounts skipped (not eligible for OGN staking).
+ * Total amount staked 29099982.12286332060661575 OGN exactly as expected.
+ *
  *
  */
 const reimbursementsLocation = "./scripts/staking/reimbursements.csv";

--- a/contracts/tasks/compensation.js
+++ b/contracts/tasks/compensation.js
@@ -58,22 +58,26 @@ async function checkOUSDBalances() {
   await compensationSync(compensationClaims, reimbursementsLocation);
 }
 
-async function claimAllAsUser(taskArguments, hre) {
+/**
+ * Claim the OUSD part of the compensation for all eligible users.
+ */
+async function claimOUSD(taskArguments, hre) {
   const { parseCsv } = require("../utils/fileSystem");
-  const ethers = hre.ethers
   const compensationClaims = await hre.ethers.getContract("CompensationClaims");
   const csv = await parseCsv(reimbursementsLocation);
+
+  // Expected failures. Those accounts do not have ETH to pay for gas fees to claim.
+  const problematicAccounts = [
+    '0x4853c9A7CB8f42a87dF28148F3380E35d8728043',
+    '0x4b5b754032d442831F32643f04cD6e4571865189',
+    '0x6Ffe8F6d47afb19F12f46e5499a182a99C4D3BEf',
+    '0x6684977bBED67e101BB80Fc07fCcfba655c0a64F'
+  ]
 
   let claimed = 0;
   let errored = 0;
   for (let i = 0; i < csv.length; i++) {
     const account = csv[i].address
-    /* Failed because accounts not funded
-     * - 0x4853c9A7CB8f42a87dF28148F3380E35d8728043
-     * - 0x4b5b754032d442831F32643f04cD6e4571865189
-     * - 0x6Ffe8F6d47afb19F12f46e5499a182a99C4D3BEf
-     * - 0x6684977bBED67e101BB80Fc07fCcfba655c0a64F
-     */
     try {
       await hre.network.provider.request({method: "hardhat_impersonateAccount",params: [account]});
       const accountSigner = await hre.ethers.provider.getSigner(account);
@@ -83,7 +87,6 @@ async function claimAllAsUser(taskArguments, hre) {
       }
       claimed++;
     } catch (e) {
-      const problematicAccounts = ['0x4853c9A7CB8f42a87dF28148F3380E35d8728043','0x4b5b754032d442831F32643f04cD6e4571865189','0x6Ffe8F6d47afb19F12f46e5499a182a99C4D3BEf','0x6684977bBED67e101BB80Fc07fCcfba655c0a64F']
       errored++;
       if (problematicAccounts.includes(account)) {
         console.log(`Expected failure of ${account}`)
@@ -93,15 +96,20 @@ async function claimAllAsUser(taskArguments, hre) {
     } 
   }
 
-  console.log(`Claimed accounts: ${claimed}, errros: ${errored}`);
+  console.log(`Claimed accounts: ${claimed}, errors: ${errored}`);
 }
 
-async function claimAllOGNAsUser(taskArguments, { ethers, network }) {
+/**
+ * Claim the OGN part of the compensation for all eligible users.
+ */
+async function claimOGN(taskArguments, { ethers, network }) {
   const OGNStakingProxy = await ethers.getContract("OGNStakingProxy");
   const OGNStaking = await ethers.getContractAt("SingleAssetStaking", OGNStakingProxy.address);
-  const ogn = new ethers.Contract(addresses.mainnet.OGN, erc20Abi);
 
   const compensationDataList = Object.values(require("../../dapp/src/constants/merkleProofedAccountsToBeCompensated.json"));
+
+  const problematicAccounts = []
+
   let amountStaked = ethers.BigNumber.from("0")
 
   let claimed = 0;
@@ -129,7 +137,6 @@ async function claimAllOGNAsUser(taskArguments, { ethers, network }) {
         compensationData.proof
       )
       const stakes = await OGNStaking.connect(accountSigner).getAllStakes(account)
-      const compensationClaimed = await OGNStaking.connect(accountSigner).airDroppedStakeClaimed(account, 1)
 
       const expectedAmount = ethers.BigNumber.from(compensationData.ogn_compensation)
       const compensationStake = stakes.filter(stake => stake.stakeType === 1)[0]
@@ -142,7 +149,6 @@ async function claimAllOGNAsUser(taskArguments, { ethers, network }) {
       }
       claimed++;
     } catch (e) {
-      const problematicAccounts = []
       errored++;
       if (problematicAccounts.includes(account)) {
         console.log(`Expected failure of ${account}`)
@@ -151,7 +157,7 @@ async function claimAllOGNAsUser(taskArguments, { ethers, network }) {
       }
     }
   }
-  console.log(`Claimed accounts: ${claimed}, errros: ${errored}, skipped: ${skipped}, totalStaked: ${ethers.utils.formatUnits(amountStaked, 18)}`);
+  console.log(`Claimed accounts: ${claimed}, errors: ${errored}, skipped: ${skipped}, totalStaked: ${ethers.utils.formatUnits(amountStaked, 18)}`);
 }
 
 async function supplyStakingContractWithOGN(taskArguments, { ethers, network }) {
@@ -160,7 +166,6 @@ async function supplyStakingContractWithOGN(taskArguments, { ethers, network }) 
   const foundationSigner = await ethers.provider.getSigner(ognFoundationReserveAddress);
 
   const cOGNStakingProxy = await ethers.getContract("OGNStakingProxy");
-  const cOGNStaking = await ethers.getContractAt("SingleAssetStaking", cOGNStakingProxy.address);
 
   const ogn = new ethers.Contract(addresses.mainnet.OGN, erc20Abi);
   await ogn.connect(foundationSigner).transfer(cOGNStakingProxy.address, ethers.utils.parseUnits("29099990", 18));
@@ -209,8 +214,8 @@ async function fundCompAccountsWithEth(taskArguments, hre) {
 module.exports = {
   isAdjusterLocked,
   fundCompAccountsWithEth,
-  claimAllAsUser,
+  claimOUSD,
+  claimOGN,
   checkOUSDBalances,
   supplyStakingContractWithOGN,
-  claimAllOGNAsUser
 }

--- a/contracts/test/_fixture.js
+++ b/contracts/test/_fixture.js
@@ -71,7 +71,12 @@ async function defaultFixture() {
     (await ethers.getContract("OGNStakingProxy")).address
   );
 
-  const signedPayouts = await airDropPayouts(ognStaking.address, testPayouts);
+  const testPayoutsModified = {
+    ...testPayouts,
+    payouts: testPayouts.payouts.map(each => {return {address: each[0], ogn_compensation: each[1]}})
+  }
+
+  const signedPayouts = await airDropPayouts(ognStaking.address, testPayoutsModified);
 
   const compensationClaims = await ethers.getContract("CompensationClaims");
 

--- a/contracts/test/staking/airdrop-staking.js
+++ b/contracts/test/staking/airdrop-staking.js
@@ -23,7 +23,6 @@ describe("Airdropped Staking", function () {
     const annaStartBalance = await ogn.balanceOf(anna.address);
 
     const payoutEntry = signedPayouts[anna.address];
-
     expect(
       await ognStaking.airDroppedStakeClaimed(anna.address, payoutEntry.type)
     ).to.equal(false);
@@ -35,7 +34,7 @@ describe("Airdropped Staking", function () {
         payoutEntry.type,
         payoutEntry.duration,
         payoutEntry.rate,
-        payoutEntry.amount,
+        payoutEntry.ogn_compensation,
         payoutEntry.proof
       );
 
@@ -49,7 +48,7 @@ describe("Airdropped Staking", function () {
       )
     ).to.equal(false);
 
-    const amount = BigNumber.from(payoutEntry.amount);
+    const amount = BigNumber.from(payoutEntry.ogn_compensation);
     const expectedReward = amount
       .mul(payoutEntry.rate)
       .div("1000000000000000000");
@@ -111,13 +110,13 @@ describe("Airdropped Staking", function () {
           payoutEntry.type,
           payoutEntry.duration,
           payoutEntry.rate,
-          payoutEntry.amount,
+          payoutEntry.ogn_compensation,
           payoutEntry.proof
         );
-      const expectedReward = BigNumber.from(payoutEntry.amount)
+      const expectedReward = BigNumber.from(payoutEntry.ogn_compensation)
         .mul(payoutEntry.rate)
         .div("1000000000000000000");
-      totalAmount = totalAmount.add(payoutEntry.amount).add(expectedReward);
+      totalAmount = totalAmount.add(payoutEntry.ogn_compensation).add(expectedReward);
     }
 
     expect(await ognStaking.totalOutstanding()).to.equal(totalAmount);
@@ -146,7 +145,7 @@ describe("Airdropped Staking", function () {
           payoutEntry.type,
           payoutEntry.duration,
           payoutEntry.rate,
-          BigNumber.from(payoutEntry.amount).add(1),
+          BigNumber.from(payoutEntry.ogn_compensation).add(1),
           [...payoutEntry.proof, payoutEntry.proof[0]]
         )
     ).to.be.revertedWith("Invalid proof");
@@ -174,7 +173,7 @@ describe("Airdropped Staking", function () {
           payoutEntry.type,
           payoutEntry.duration,
           payoutEntry.rate,
-          BigNumber.from(payoutEntry.amount).add(1),
+          BigNumber.from(payoutEntry.ogn_compensation).add(1),
           payoutEntry.proof
         )
     ).to.be.revertedWith("Invalid index");
@@ -187,7 +186,7 @@ describe("Airdropped Staking", function () {
           payoutEntry.type,
           payoutEntry.duration,
           payoutEntry.rate,
-          BigNumber.from(payoutEntry.amount).add(1),
+          BigNumber.from(payoutEntry.ogn_compensation).add(1),
           payoutEntry.proof
         )
     ).to.be.revertedWith("Stake not approved");
@@ -202,7 +201,7 @@ describe("Airdropped Staking", function () {
           payoutEntry.type,
           payoutEntry.duration,
           payoutEntry.rate,
-          BigNumber.from(payoutEntry.amount).add(1),
+          BigNumber.from(payoutEntry.ogn_compensation).add(1),
           payoutEntry.proof
         )
     ).to.be.revertedWith("Stake not approved");
@@ -214,7 +213,7 @@ describe("Airdropped Staking", function () {
           payoutEntry.type,
           payoutEntry.duration,
           BigNumber.from(payoutEntry.rate).add(1),
-          payoutEntry.amount,
+          payoutEntry.ogn_compensation,
           payoutEntry.proof
         )
     ).to.be.revertedWith("Stake not approved");
@@ -226,7 +225,7 @@ describe("Airdropped Staking", function () {
           payoutEntry.type,
           BigNumber.from(payoutEntry.duration).sub(1),
           payoutEntry.rate,
-          payoutEntry.amount,
+          payoutEntry.ogn_compensation,
           payoutEntry.proof
         )
     ).to.be.revertedWith("Stake not approved");
@@ -238,7 +237,7 @@ describe("Airdropped Staking", function () {
         payoutEntry.type,
         payoutEntry.duration,
         payoutEntry.rate,
-        payoutEntry.amount,
+        payoutEntry.ogn_compensation,
         payoutEntry.proof
       );
 
@@ -250,7 +249,7 @@ describe("Airdropped Staking", function () {
           payoutEntry.type,
           payoutEntry.duration,
           payoutEntry.rate,
-          payoutEntry.amount,
+          payoutEntry.ogn_compensation,
           payoutEntry.proof
         )
     ).to.be.revertedWith("Already staked");


### PR DESCRIPTION
Claim OGN as each of the compensation users. 

**To claim OGN as each compensation users:**
 - supply claiming users with ETH (if not done yet) `FORK=true npx hardhat fundCompAccountsWithEth --network localhost`
 - [ set root hash and depth](https://github.com/OriginProtocol/origin-dollar/commit/beabcbc0089a94e029b467b29848220aae180257#diff-2e966c1950d3dbbd52a3d3d366ebe453da3d32c1bceb8fc15f33c37f26ec00dfR66-R71) in hardhat console.
 - execute the root hash and depth proposal: `FORK=true npx hardhat executeOnFork --id <id> --network localhost`
 - claim & stake OGN as each of the users: `FORK=true npx hardhat claimOGN --network localhost`

**To claim OUSD as each compensation users:**
 - [execute these lines](https://github.com/OriginProtocol/origin-dollar/blob/sparrowDom/compensationForkTesting/contracts/scripts/compensation/forkDeployment.js#L1-L26) to setup variables in the console
 - if adjuster is not yet unlocked run `FORK=true npx hardhat executeOnFork --id 12 --network localhost` to unlock it. (if a more recent eth block number is used to run the fork adjuster is already unlocked)
 - execute [compensation sync command](https://github.com/OriginProtocol/origin-dollar/blob/sparrowDom/compensationForkTesting/contracts/scripts/compensation/forkDeployment.js#L34) so OUSD compensation amount is set for each user on the contract. When the command is done all the 727 accounts should have an orange circle in front of them
 - [send the proposal](https://github.com/OriginProtocol/origin-dollar/blob/sparrowDom/compensationForkTesting/contracts/scripts/compensation/forkDeployment.js#L37-L38) to lock the adjuster
 - confirm the newly created proposal
 - fund a signer with stablecoins: `FORK=true npx hardhat fund --num 1 --amount 2010000 --network localhost`. If it fails after on the third stablecoin mint don't worry about it
 - mint OUSD as that signer: `FORK=true npx hardhat mint --num 1 --amount 2000000 --network localhost`
 - [supply compensationClaims contract](https://github.com/OriginProtocol/origin-dollar/blob/sparrowDom/compensationForkTesting/contracts/scripts/compensation/forkDeployment.js#L49-L52) with OUSD as that signer
 - create a proposal call to [start OUSD claim period](https://github.com/OriginProtocol/origin-dollar/blob/sparrowDom/compensationForkTesting/contracts/scripts/compensation/forkDeployment.js#L55-L57)
 - confirm the above proposal
 - claim OUSD as each of the users: `FORK=true npx hardhat claimOUSD --network localhost`. Results should be: Claimed accounts: 723, errros: 4
 - check contract balances: `FORK=true npx hardhat checkOUSDBalances --network localhost`. Compare with results in `contracts/tasks/compensation.js`. In my case 84 OUSD was left in staking contract. 

Test results as top comment here: `contracts/tasks/compensation.js`
