### PR TITLE
Update PR template with Echidna note

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -7,4 +7,4 @@ Contract change checklist:
   - [ ] Code reviewed by 2 reviewers
   - [ ] Unit tests pass
   - [ ] Slither tests pass with no warning
-  - [ ] Echidna tests pass (not automated, run manually on local)
+  - [ ] Echidna tests pass if PR includes changes to OUSD contract (not automated, run manually on local)


### PR DESCRIPTION
Added some wording to the PR template. We only have Echidna properties for OUSD right now, so any changes that aren't to that contract won't change the Echidna test results.