### PR TITLE
add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 /dapp @sparrowDom @shahthepro
-/contracts @tomlinton @DanielVF @franck
+/contracts @tomlinton @DanielVF @franckc

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-/dapp @sparrowDom @shahthepro @micahalcorn
+/dapp @sparrowDom @shahthepro
 /contracts @tomlinton @DanielVF @franck

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+/dapp @sparrowDom @shahthepro @micahalcorn
+/contracts @tomlinton @DanielVF @franck


### PR DESCRIPTION
After looking at the various options GitHub offers for enforcing review, here is my lightweight proposal.

- We add a CODEOWNERS file with the the following rules:
  - Automatically add domen, shah as reviewers for any PR that has a code change in the /dapp directory 
  - Automatically add dvf, tom, franck as reviewers for any PR that has a change to the /contracts directory
- This way anytime a PR gets created, those folks will get notified by email (since they get added as reviewer).
- Do not enforce X reviews before a PR is merged as a GitHub setting. This would slow us down too much for the dapp development and for non-risky changes on the contracts side (for example tests/hardhat tasks, etc...).
- For the dapp directory, code reviews are encouragde but not mandatory. Use your best judgement.
- For contracts directory, it is up to the developer and the code reviewers to enforce the rule that any solidity contract change gets reviewed by 2 engineers before getting merged.

In the future we should move the dapp to a separate repo so that we can enforce X reviews before a PR is merged.  But I don't think it is high priority to do so, since our team is small and as long as we remain diligent as a team and help each other enforcing the implicit rules stated above.