### PR TITLE
Allow strategist to call harvest

### DIFF
--- a/contracts/contracts/vault/VaultAdmin.sol
+++ b/contracts/contracts/vault/VaultAdmin.sol
@@ -12,12 +12,12 @@ import { IUniswapV2Router } from "../interfaces/uniswap/IUniswapV2Router02.sol";
 
 contract VaultAdmin is VaultStorage {
     /**
-     * @dev Verifies that the caller is the Vault or Governor.
+     * @dev Verifies that the caller is the Vault, Governor, or Strategist.
      */
-    modifier onlyVaultOrGovernor() {
+    modifier onlyVaultOrGovernorOrStrategist() {
         require(
-            msg.sender == address(this) || isGovernor(),
-            "Caller is not the Vault or Governor"
+            msg.sender == address(this) || msg.sender == strategistAddr || isGovernor(),
+            "Caller is not the Vault, Governor, or Strategist"
         );
         _;
     }
@@ -304,7 +304,7 @@ contract VaultAdmin is VaultStorage {
      */
     function harvest(address _strategyAddr)
         external
-        onlyVaultOrGovernor
+        onlyVaultOrGovernorOrStrategist
         returns (uint256[] memory)
     {
         return _harvest(_strategyAddr);

--- a/contracts/contracts/vault/VaultAdmin.sol
+++ b/contracts/contracts/vault/VaultAdmin.sol
@@ -291,7 +291,7 @@ contract VaultAdmin is VaultStorage {
      * @dev Collect reward tokens from all strategies and swap for supported
      *      stablecoin via Uniswap
      */
-    function harvest() external onlyGovernor {
+    function harvest() external onlyGovernorOrStrategist {
         for (uint256 i = 0; i < allStrategies.length; i++) {
             _harvest(allStrategies[i]);
         }
@@ -299,7 +299,7 @@ contract VaultAdmin is VaultStorage {
 
     /**
      * @dev Collect reward tokens for a specific strategy and swap for supported
-     *      stablecoin via Uniswap
+     *      stablecoin via Uniswap. Called from the vault.
      * @param _strategyAddr Address of the strategy to collect rewards from
      */
     function harvest(address _strategyAddr)

--- a/contracts/test/strategies/3pool.js
+++ b/contracts/test/strategies/3pool.js
@@ -143,22 +143,25 @@ describe("3Pool Strategy", function () {
       ).to.be.revertedWith("Caller is not the Governor");
     });
 
+    it("Should allow the strategist to call harvest", async () => {
+      // Mint of MockCRVMinter mints a fixed 2e18
+      await crvMinter.connect(governor).mint(curveUSDCStrategy.address);
+      await vault.connect(governor).setStrategistAddr(anna.address);
+      await vault.connect(anna)["harvest()"]();
+    });
+
+    it("Should allow the strategist to call harvest for a specific strategy", async () => {
+      // Mint of MockCRVMinter mints a fixed 2e18
+      await crvMinter.connect(governor).mint(curveUSDCStrategy.address);
+      await vault.connect(governor).setStrategistAddr(anna.address);
+      await vault.connect(anna)["harvest(address)"](curveUSDTStrategy.address);
+    });
+
     it("Should collect reward tokens using collect rewards on all strategies", async () => {
       // Mint of MockCRVMinter mints a fixed 2e18
       await crvMinter.connect(governor).mint(curveUSDCStrategy.address);
       await crvMinter.connect(governor).mint(curveUSDTStrategy.address);
       await vault.connect(governor)["harvest()"]();
-      await expect(await crv.balanceOf(vault.address)).to.be.equal(
-        utils.parseUnits("4", 18)
-      );
-    });
-
-    it("Should allow the strategist to call harvest", async () => {
-      // Mint of MockCRVMinter mints a fixed 2e18
-      await crvMinter.connect(governor).mint(curveUSDCStrategy.address);
-      await crvMinter.connect(governor).mint(curveUSDTStrategy.address);
-      await vault.connect(governor).setStrategistAddr(anna.address);
-      await vault.connect(anna)["harvest()"]();
       await expect(await crv.balanceOf(vault.address)).to.be.equal(
         utils.parseUnits("4", 18)
       );

--- a/contracts/test/strategies/3pool.js
+++ b/contracts/test/strategies/3pool.js
@@ -153,6 +153,17 @@ describe("3Pool Strategy", function () {
       );
     });
 
+    it("Should allow the strategist to call harvest", async () => {
+      // Mint of MockCRVMinter mints a fixed 2e18
+      await crvMinter.connect(governor).mint(curveUSDCStrategy.address);
+      await crvMinter.connect(governor).mint(curveUSDTStrategy.address);
+      await vault.connect(governor).setStrategistAddr(anna.address);
+      await vault.connect(anna)["harvest()"]();
+      await expect(await crv.balanceOf(vault.address)).to.be.equal(
+        utils.parseUnits("4", 18)
+      );
+    });
+
     it("Should collect reward tokens using collect rewards on a specific strategy", async () => {
       // Mint of MockCRVMinter mints a fixed 2e18
       await crvMinter.connect(governor).mint(curveUSDCStrategy.address);


### PR DESCRIPTION
The harvest() method on vaultCore should also be able to be called by the strategist role. This a method that should not be able to cause the contract to lose current funds, and it something that occasionally needs to be called and does not need to go through the entire governance process.

Contract change checklist:
  - [ ] Code reviewed by 2 reviewers. See [template](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) and [example](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md).
  - [x] Unit tests pass
  - [x] Slither tests pass with no warning
  - [x] Echidna tests pass if PR includes changes to OUSD contract (not automated, run manually on local)
