### PR TITLE
Deploy script 012 for contract upgrades

### DIFF
--- a/contracts/contracts/vault/VaultAdmin.sol
+++ b/contracts/contracts/vault/VaultAdmin.sol
@@ -16,7 +16,9 @@ contract VaultAdmin is VaultStorage {
      */
     modifier onlyVaultOrGovernorOrStrategist() {
         require(
-            msg.sender == address(this) || msg.sender == strategistAddr || isGovernor(),
+            msg.sender == address(this) ||
+                msg.sender == strategistAddr ||
+                isGovernor(),
             "Caller is not the Vault, Governor, or Strategist"
         );
         _;

--- a/contracts/deploy/012_upgrades.js
+++ b/contracts/deploy/012_upgrades.js
@@ -35,7 +35,13 @@ const upgrades = async () => {
 
   const cOUSDProxy = await ethers.getContract("OUSDProxy");
   const cVaultProxy = await ethers.getContract("VaultProxy");
-  const cCompoundStrategyProxy = await ethers.getContract("CompoundStrategyProxy");
+  const cVaultCoreProxy = await ethers.getContractAt(
+    "VaultCore",
+    cVaultProxy.address
+  );
+  const cCompoundStrategyProxy = await ethers.getContract(
+    "CompoundStrategyProxy"
+  );
 
   // Deploy a new OUSD contract.
   const dOUSD = await deployWithConfirmation("OUSD");
@@ -46,7 +52,6 @@ const upgrades = async () => {
   // Deploy a new CompooundStrategy contract.
   const dCompoundStrategy = await deployWithConfirmation("CompoundStrategy");
 
-
   // Proposal for the governor to upgrade OUSD.
   const propDescription = "OUSD, VaultAdmin, CompoundStrategy upgrades";
   const propArgs = await proposeArgs([
@@ -56,7 +61,7 @@ const upgrades = async () => {
       args: [dOUSD.address],
     },
     {
-      contract: cVaultProxy,
+      contract: cVaultCoreProxy,
       signature: "setAdminImpl(address)",
       args: [dVaultAdmin.address],
     },

--- a/contracts/deploy/012_upgrades.js
+++ b/contracts/deploy/012_upgrades.js
@@ -1,0 +1,121 @@
+const hre = require("hardhat");
+
+const {
+  isMainnet,
+  isFork,
+  isRinkeby,
+  isMainnetOrRinkebyOrFork,
+} = require("../test/helpers.js");
+const {
+  log,
+  deployWithConfirmation,
+  withConfirmation,
+  executeProposal,
+  sendProposal,
+} = require("../utils/deploy");
+const { proposeArgs } = require("../utils/governor");
+const { getTxOpts } = require("../utils/tx");
+
+const deployName = "012_upgrades";
+
+/**
+ * Deploys an upgrade for the following contracts:
+ *  - OUSD
+ *  - VaultAdmin
+ *  - Compound Strategy
+ * @returns {Promise<boolean>}
+ */
+const upgrades = async () => {
+  console.log(`Running ${deployName} deployment...`);
+
+  const { governorAddr } = await hre.getNamedAccounts();
+
+  // Signers
+  const sGovernor = await ethers.provider.getSigner(governorAddr);
+
+  const cOUSDProxy = await ethers.getContract("OUSDProxy");
+  const cVaultProxy = await ethers.getContract("VaultProxy");
+  const cCompoundStrategyProxy = await ethers.getContract("CompoundStrategyProxy");
+
+  // Deploy a new OUSD contract.
+  const dOUSD = await deployWithConfirmation("OUSD");
+
+  // Deploy a new VaultAdmin contract.
+  const dVaultAdmin = await deployWithConfirmation("VaultAdmin");
+
+  // Deploy a new CompooundStrategy contract.
+  const dCompoundStrategy = await deployWithConfirmation("CompoundStrategy");
+
+
+  // Proposal for the governor to upgrade OUSD.
+  const propDescription = "OUSD, VaultAdmin, CompoundStrategy upgrades";
+  const propArgs = await proposeArgs([
+    {
+      contract: cOUSDProxy,
+      signature: "upgradeTo(address)",
+      args: [dOUSD.address],
+    },
+    {
+      contract: cVaultProxy,
+      signature: "setAdminImpl(address)",
+      args: [dVaultAdmin.address],
+    },
+    {
+      contract: cCompoundStrategyProxy,
+      signature: "upgradeTo(address)",
+      args: [dCompoundStrategy.address],
+    },
+  ]);
+
+  if (isMainnet) {
+    // On Mainnet, only propose. The enqueue and execution are handled manually via multi-sig.
+    log("Sending proposal to governor...");
+    await sendProposal(propArgs, propDescription);
+    log("Proposal sent.");
+  } else if (isFork) {
+    // On Fork we can send the proposal then impersonate the guardian to execute it.
+    log("Sending and executing proposal...");
+    await executeProposal(propArgs, propDescription);
+    log("Proposal executed.");
+  } else {
+    // Hardcoding gas estimate on Rinkeby since it fails for an undetermined reason...
+    const gasLimit = isRinkeby ? 1000000 : null;
+
+    await withConfirmation(
+      cOUSDProxy
+        .connect(sGovernor)
+        .upgradeTo(dOUSD.address, await getTxOpts(gasLimit))
+    );
+    log("Upgraded OUSD to new implementation");
+
+    await withConfirmation(
+      cVaultProxy
+        .connect(sGovernor)
+        .setAdminImpl(dVaultAdmin.address, await getTxOpts(gasLimit))
+    );
+    log("Upgraded VaultAdmin to new implementation");
+
+    await withConfirmation(
+      cCompoundStrategyProxy
+        .connect(sGovernor)
+        .upgradeTo(dCompoundStrategy.address, await getTxOpts(gasLimit))
+    );
+    log("Upgraded CompoundStrategy to new implementation");
+  }
+
+  console.log(`${deployName} deploy done.`);
+  return true;
+};
+
+const main = async () => {
+  console.log(`Running ${deployName} deployment...`);
+  await upgrades();
+  console.log(`${deployName} deploy done.`);
+  return true;
+};
+
+main.id = deployName;
+main.dependencies = ["011_ousd_fix"];
+main.skip = () => !isMainnetOrRinkebyOrFork;
+
+module.exports = main;

--- a/contracts/deploy/012_upgrades.js
+++ b/contracts/deploy/012_upgrades.js
@@ -1,5 +1,3 @@
-const hre = require("hardhat");
-
 const {
   isMainnet,
   isFork,
@@ -25,7 +23,7 @@ const deployName = "012_upgrades";
  *  - Compound Strategy
  * @returns {Promise<boolean>}
  */
-const upgrades = async () => {
+const upgrades = async (hre) => {
   console.log(`Running ${deployName} deployment...`);
 
   const { governorAddr } = await hre.getNamedAccounts();
@@ -108,19 +106,21 @@ const upgrades = async () => {
     log("Upgraded CompoundStrategy to new implementation");
   }
 
-  console.log(`${deployName} deploy done.`);
   return true;
 };
 
-const main = async () => {
+const main = async (hre) => {
   console.log(`Running ${deployName} deployment...`);
-  await upgrades();
+  if (!hre) {
+    hre = require("hardhat");
+  }
+  await upgrades(hre);
   console.log(`${deployName} deploy done.`);
   return true;
 };
 
 main.id = deployName;
 main.dependencies = ["011_ousd_fix"];
-main.skip = () => !isMainnetOrRinkebyOrFork;
+main.skip = () => !(isMainnet || isRinkeby);
 
 module.exports = main;

--- a/contracts/deploy/012_upgrades.js
+++ b/contracts/deploy/012_upgrades.js
@@ -49,10 +49,10 @@ const upgrades = async () => {
   // Deploy a new VaultAdmin contract.
   const dVaultAdmin = await deployWithConfirmation("VaultAdmin");
 
-  // Deploy a new CompooundStrategy contract.
+  // Deploy a new CompoundStrategy contract.
   const dCompoundStrategy = await deployWithConfirmation("CompoundStrategy");
 
-  // Proposal for the governor to upgrade OUSD.
+  // Proposal for the governor to do the upgrades.
   const propDescription = "OUSD, VaultAdmin, CompoundStrategy upgrades";
   const propArgs = await proposeArgs([
     {


### PR DESCRIPTION
Upgrades the following contracts that have had changes since the last mainnet deploy (GH tag [deploy-011](https://github.com/OriginProtocol/origin-dollar/releases/tag/deploy-011)):
 - OUSD
 - VaultAdmin
 -  CompoundStrategy

Here is the diff for all contract changes since deploy-011: https://gist.github.com/franckc/6fcec3a50386bbd38f9aaf1296ea0ea0

Here is the [deploy plan](https://docs.google.com/spreadsheets/d/1phyzOJMmTBPIqTTa0v7HY6XJkjRmbrcdULRZPo_JEoY/edit#gid=1480380618).
