### PR TITLE
Smoke test fix

### DIFF
--- a/contracts/deploy/012_upgrades.js
+++ b/contracts/deploy/012_upgrades.js
@@ -2,6 +2,7 @@ const {
   isMainnet,
   isFork,
   isRinkeby,
+  isSmokeTest,
   isMainnetOrRinkebyOrFork,
 } = require("../test/helpers.js");
 const {
@@ -121,6 +122,6 @@ const main = async (hre) => {
 
 main.id = deployName;
 main.dependencies = ["011_ousd_fix"];
-main.skip = () => !(isMainnet || isRinkeby);
+main.skip = () => !(isMainnet || isRinkeby || isFork) || isSmokeTest;
 
 module.exports = main;

--- a/contracts/scripts/compensation/README.md
+++ b/contracts/scripts/compensation/README.md
@@ -16,6 +16,16 @@ The contract goveror **must**  have called `unlockAdjuster` on the contract befo
     export DEPLOYER_PK=<pk>
     node scripts/compensation/compensationSync.js --data-file=scripts/staking/reimbursements.csv --do-it
 
+### Running Smoke Tests
+
+Smoke tests can be ran in 2 modes: 
+- Run `scripts/test/smokeTest.sh` to launch interactive mode. All the "before contract changes" parts of tests
+  will execute and wait for the user to manually using a console performs contract changes. Once those are done
+  hit "Enter" in the smoke test console and the second part of the tests shall be ran that validate that contract
+  changes haven't broken basic functionality.
+- Run `scripts/test/smokeTest.sh --deployid [numeric_id_of_deploy]` will run smoke tests against a specific
+  deployid. Validating that that deploy didn't break basic functionality.
+
 ### Sample output  
 
     Reading file sample_amounts.csv

--- a/contracts/scripts/test/smokeTest.sh
+++ b/contracts/scripts/test/smokeTest.sh
@@ -33,7 +33,7 @@ main()
     fi
 
     nodeOutput=$(mktemp "${TMPDIR:-/tmp/}$(basename 0).XXX")
-    yarn run node:fork &> $nodeOutput &
+    SMOKE_TEST=true yarn run node:fork &> $nodeOutput &
     NODE_PID=$!
 
     echo "Node output: $nodeOutput"

--- a/contracts/test/helpers.js
+++ b/contracts/test/helpers.js
@@ -116,6 +116,7 @@ const isLocalhost = !isFork && hre.network.name === "localhost";
 const isRinkeby = hre.network.name === "rinkeby";
 const isMainnet = hre.network.name === "mainnet";
 const isTest = process.env.IS_TEST === "true";
+const isSmokeTest = process.env.SMOKE_TEST === "true";
 const isMainnetOrFork = isMainnet || isFork;
 const isMainnetOrRinkebyOrFork = isMainnetOrFork || isRinkeby;
 
@@ -403,6 +404,7 @@ module.exports = {
   isRinkeby,
   isFork,
   isTest,
+  isSmokeTest,
   isLocalhost,
   isMainnetOrFork,
   isMainnetOrRinkebyOrFork,


### PR DESCRIPTION
Make it possible so that node ran in forked mode automatically applies all the contract deployments. But not while executing the smoke tests. 


Contract change checklist:
  - [ ] Code reviewed by 2 reviewers. See [template](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) and [example](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md).
  - [ ] Unit tests pass
  - [ ] Slither tests pass with no warning
  - [ ] Echidna tests pass if PR includes changes to OUSD contract (not automated, run manually on local)
