### PR TITLE
FIx hardhat timeouts

### DIFF
--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -176,6 +176,9 @@ module.exports = {
         mnemonic,
       },
     },
+    localhost: {
+      timeout: 60000
+    },
     rinkeby: {
       url: `${process.env.PROVIDER_URL}`,
       accounts: [

--- a/contracts/node.sh
+++ b/contracts/node.sh
@@ -12,7 +12,8 @@ then
         params+=(--fork-block-number ${BLOCK_NUMBER})
     fi
     cp -r deployments/mainnet deployments/localhost
-    FORK=true npx hardhat node --export '../dapp/network.json' ${params[@]}
+    # the --no-install is here so npx doesn't download some package on its own if it can not find one in the repo
+    FORK=true npx --no-install hardhat node --export '../dapp/network.json' ${params[@]}
 else
-    npx hardhat node --export '../dapp/network.json'
+    npx --no-install hardhat node --export '../dapp/network.json'
 fi


### PR DESCRIPTION
Fixes the timeout problem with hardhat fork network. The interesting thing is that if `localhost` network config is not passed to `hardhat.config.js` default config values are created with 20s timeout -> [see here](https://www.dropbox.com/s/l7vfp0qjbut029q/Screenshot%202021-02-10%20at%2001.22.55.png?dl=0). Increasing this to 60 seconds solves timeouts for me. If it is not enough it can be increased even further. 

It is good to keep in mind that these are the timeouts of http client providers that connect to the local running node. If node takes more than 20 seconds to respond, the client retries. And (I think) after 3 retries times out. There is another timeout that is relevant. If node happens to timeout when reaching its provider we would need to change [this setting](https://github.com/nomiclabs/hardhat/blob/4532f4c742ca9d5055c1aa83346306354ebf1eed/packages/hardhat-core/src/internal/hardhat-network/provider/utils/makeForkClient.ts#L18). Though this timeout should be spotted in the node's terminal. 

Note: I think this PR ranks the lowest score in `time requred / code produced` rating 😃 


Contract change checklist:
  - [ ] Code reviewed by 2 reviewers. See [template](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) and [example](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md).
  - [ ] Unit tests pass
  - [ ] Slither tests pass with no warning
  - [ ] Echidna tests pass if PR includes changes to OUSD contract (not automated, run manually on local)
