### PR TITLE
Reduce number of Alchemy calls

### DIFF
--- a/dapp/src/components/AccountListener.js
+++ b/dapp/src/components/AccountListener.js
@@ -149,13 +149,17 @@ const AccountListener = (props) => {
 
       if (response.ok) {
         const response = await response.json()
-        const balanceData = {}[
-          ({ name: 'ousd', contract: ousd },
+        const balanceData = {}
+
+        const allContractData = [
+          { name: 'ousd', contract: ousd },
           { name: 'usdt', contract: usdt },
           { name: 'dai', contract: dai },
           { name: 'usdc', contract: usdc },
-          { name: 'ogn', contract: ogn })
-        ].forEach((contractData) => {
+          { name: 'ogn', contract: ogn },
+        ]
+
+        allContractData.forEach((contractData) => {
           const balance = response.result.tokenBalances.filter(
             (balance) =>
               balance.contractAddress.toLowerCase() ===

--- a/dapp/src/components/AccountListener.js
+++ b/dapp/src/components/AccountListener.js
@@ -130,7 +130,7 @@ const AccountListener = (props) => {
           account,
           [ousd.address, usdt.address, dai.address, usdc.address, ogn.address],
         ],
-        id: jsonCallId.toString()
+        id: jsonCallId.toString(),
       }
       jsonCallId++
 
@@ -140,7 +140,7 @@ const AccountListener = (props) => {
           'Content-Type': 'application/json',
         },
         referrerPolicy: 'no-referrer',
-        body: JSON.stringify(data)
+        body: JSON.stringify(data),
       })
 
       if (response.ok) {
@@ -148,28 +148,34 @@ const AccountListener = (props) => {
         const balanceData = {}
 
         const allContractData = [
-          { name: 'ousd', contract: ousd },
-          { name: 'usdt', contract: usdt },
-          { name: 'dai', contract: dai },
-          { name: 'usdc', contract: usdc },
-          { name: 'ogn', contract: ogn },
+          { name: 'ousd', decimals: 18, contract: ousd },
+          { name: 'usdt', decimals: 6, contract: usdt },
+          { name: 'dai', decimals: 18, contract: dai },
+          { name: 'usdc', decimals: 6, contract: usdc },
+          { name: 'ogn', decimals: 18, contract: ogn },
         ]
 
-        await Promise.all(
-          allContractData.map(async (contractData) => {
-            const balanceResponseData = responseJson.result.tokenBalances.filter(
-              (tokenBalanceData) =>
-                tokenBalanceData.contractAddress.toLowerCase() ===
-                contractData.contract.address.toLowerCase()
-            )[0]
+        allContractData.forEach((contractData) => {
+          const balanceResponseData = responseJson.result.tokenBalances.filter(
+            (tokenBalanceData) =>
+              tokenBalanceData.contractAddress.toLowerCase() ===
+              contractData.contract.address.toLowerCase()
+          )[0]
 
-            if (balanceResponseData.error === null) {
-              balanceData[contractData.name] = balanceResponseData.tokenBalance === '0x' ? '0' : await displayCurrency(balanceResponseData.tokenBalance, contractData.contract)
-            } else {
-              console.error(`Can not load balance for ${contractData.name} reason: ${balanceResponseData.error}`)
-            }
-          })
-        )
+          if (balanceResponseData.error === null) {
+            balanceData[contractData.name] =
+              balanceResponseData.tokenBalance === '0x'
+                ? '0'
+                : ethers.utils.formatUnits(
+                    balanceResponseData.tokenBalance,
+                    contractData.decimals
+                  )
+          } else {
+            console.error(
+              `Can not load balance for ${contractData.name} reason: ${balanceResponseData.error}`
+            )
+          }
+        })
 
         AccountStore.update((s) => {
           s.balances = balanceData


### PR DESCRIPTION
This PR utilizes Alchemy's special api calls that allow for [multiple coin balance lookups](https://docs.alchemyapi.io/alchemy/documentation/alchemy-api-reference/token-api) within a single API call. Interestingly this functionality is not extended to token allowances.

This PR should help us achieve further reduction in Alchemy calls and possibly improve the situation where Alchemy in rare cases starts blocking clients: https://github.com/OriginProtocol/origin-dollar/issues/509 Also initial load of account balance data should now be faster.


Contract change checklist:
  - [ ] Code reviewed by 2 reviewers. See [template](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) and [example](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md).
  - [ ] Unit tests pass
  - [ ] Slither tests pass with no warning
  - [ ] Echidna tests pass if PR includes changes to OUSD contract (not automated, run manually on local)
