### PR TITLE
Mathis/input restrict

### DIFF
--- a/dapp/src/components/buySell/CoinRow.js
+++ b/dapp/src/components/buySell/CoinRow.js
@@ -11,6 +11,7 @@ import {
   formatCurrency,
   formatCurrencyMinMaxDecimals,
   truncateDecimals,
+  checkValidInputForCoin
 } from 'utils/math'
 
 const CoinRow = ({
@@ -150,10 +151,12 @@ const CoinRow = ({
                 if (active) {
                   const value = truncateDecimals(e.target.value)
                   const valueNoCommas = value.replace(/,/g, '')
-                  setCoinValue(valueNoCommas)
-                  setDisplayedCoinValue(value)
-                  setTotal(truncateDecimals(valueNoCommas * exchangeRate))
-                  localStorage[localStorageKey] = valueNoCommas
+                  if(checkValidInputForCoin(value, coin)) {
+                    setCoinValue(valueNoCommas)
+                    setDisplayedCoinValue(value)
+                    setTotal(truncateDecimals(valueNoCommas * exchangeRate))
+                    localStorage[localStorageKey] = valueNoCommas
+                  }
                 }
               }}
               onBlur={(e) => {

--- a/dapp/src/components/buySell/CoinRow.js
+++ b/dapp/src/components/buySell/CoinRow.js
@@ -11,7 +11,7 @@ import {
   formatCurrency,
   formatCurrencyMinMaxDecimals,
   truncateDecimals,
-  checkValidInputForCoin
+  checkValidInputForCoin,
 } from 'utils/math'
 
 const CoinRow = ({
@@ -151,7 +151,7 @@ const CoinRow = ({
                 if (active) {
                   const value = truncateDecimals(e.target.value)
                   const valueNoCommas = value.replace(/,/g, '')
-                  if(checkValidInputForCoin(valueNoCommas, coin)) {
+                  if (checkValidInputForCoin(valueNoCommas, coin)) {
                     setCoinValue(valueNoCommas)
                     setDisplayedCoinValue(valueNoCommas)
                     setTotal(truncateDecimals(valueNoCommas * exchangeRate))

--- a/dapp/src/components/buySell/CoinRow.js
+++ b/dapp/src/components/buySell/CoinRow.js
@@ -151,9 +151,9 @@ const CoinRow = ({
                 if (active) {
                   const value = truncateDecimals(e.target.value)
                   const valueNoCommas = value.replace(/,/g, '')
-                  if(checkValidInputForCoin(value, coin)) {
+                  if(checkValidInputForCoin(valueNoCommas, coin)) {
                     setCoinValue(valueNoCommas)
-                    setDisplayedCoinValue(value)
+                    setDisplayedCoinValue(valueNoCommas)
                     setTotal(truncateDecimals(valueNoCommas * exchangeRate))
                     localStorage[localStorageKey] = valueNoCommas
                   }

--- a/dapp/src/utils/math.js
+++ b/dapp/src/utils/math.js
@@ -103,7 +103,7 @@ export function checkValidInputForCoin(amount, coin) {
   }
 
   const COIN = coin.toLowerCase()
-  let decimals = 18
+  let decimals
 
   switch (coin) {
     case 'usdc':
@@ -112,9 +112,11 @@ export function checkValidInputForCoin(amount, coin) {
     case 'usdt':
       decimals = 6
       break
-    default:
+    case 'dai':
       decimals = 18
       break
+    default:
+      throw new Exception(`Unexpected stablecoin: ${coin}`)
   }
 
   var regex = new RegExp(

--- a/dapp/src/utils/math.js
+++ b/dapp/src/utils/math.js
@@ -98,6 +98,10 @@ export async function displayCurrency(balance, contract) {
 }
 
 export function checkValidInputForCoin(amount, coin) {
+  if(amount === '') {
+    amount = '0.00'
+  }
+
   const COIN = coin.toLowerCase()
   let decimals = 18
 
@@ -113,8 +117,6 @@ export function checkValidInputForCoin(amount, coin) {
     break;
   }
 
-  // var regex = new RegExp(`^((\d{1,3})(?:,[0-9]{3}){0,1}|(\d{1})(?:,[0-9]{3}){0,2}|(\d{1,18}))(\.\d{1,${decimals}})?$`, "g");
-  // return regex.test(AMOUNT)
-  //return /^((\d{1,3})(?:,[0-9]{3}){0,1}|(\d{1})(?:,[0-9]{3}){0,2}|(\d{1,18}))(\.\d{1,18)?$/.test(AMOUNT)
-  return /[^0-9.,]/.test(amount) == false
+  var regex = new RegExp(`^((\\d{1,3})(?:[0-9]{3}){0,1}|(\\d{1})(?:[0-9]{3}){0,2}|(\\d{1,18}))((\\.)|(\\.\\d{1,${decimals}}))?$`, "g");
+  return regex.test(amount)
 }

--- a/dapp/src/utils/math.js
+++ b/dapp/src/utils/math.js
@@ -116,7 +116,7 @@ export function checkValidInputForCoin(amount, coin) {
       decimals = 18
       break
     default:
-      throw new Exception(`Unexpected stablecoin: ${coin}`)
+      throw new Error(`Unexpected stablecoin: ${coin}`)
   }
 
   var regex = new RegExp(

--- a/dapp/src/utils/math.js
+++ b/dapp/src/utils/math.js
@@ -98,25 +98,28 @@ export async function displayCurrency(balance, contract) {
 }
 
 export function checkValidInputForCoin(amount, coin) {
-  if(amount === '') {
+  if (amount === '') {
     amount = '0.00'
   }
 
   const COIN = coin.toLowerCase()
   let decimals = 18
 
-  switch(coin){
-    case "usdc":
+  switch (coin) {
+    case 'usdc':
       decimals = 6
-    break;
-    case "usdt":
+      break
+    case 'usdt':
       decimals = 6
-    break;
-    default: 
+      break
+    default:
       decimals = 18
-    break;
+      break
   }
 
-  var regex = new RegExp(`^((\\d{1,3})(?:[0-9]{3}){0,1}|(\\d{1})(?:[0-9]{3}){0,2}|(\\d{1,18}))((\\.)|(\\.\\d{1,${decimals}}))?$`, "g");
+  var regex = new RegExp(
+    `^((\\d{1,3})(?:[0-9]{3}){0,1}|(\\d{1})(?:[0-9]{3}){0,2}|(\\d{1,18}))((\\.)|(\\.\\d{1,${decimals}}))?$`,
+    'g'
+  )
   return regex.test(amount)
 }

--- a/dapp/src/utils/math.js
+++ b/dapp/src/utils/math.js
@@ -96,3 +96,25 @@ export async function displayCurrency(balance, contract) {
   if (!balance) return
   return ethers.utils.formatUnits(balance, await contract.decimals())
 }
+
+export function checkValidInputForCoin(amount, coin) {
+  const COIN = coin.toLowerCase()
+  let decimals = 18
+
+  switch(coin){
+    case "usdc":
+      decimals = 6
+    break;
+    case "usdt":
+      decimals = 6
+    break;
+    default: 
+      decimals = 18
+    break;
+  }
+
+  // var regex = new RegExp(`^((\d{1,3})(?:,[0-9]{3}){0,1}|(\d{1})(?:,[0-9]{3}){0,2}|(\d{1,18}))(\.\d{1,${decimals}})?$`, "g");
+  // return regex.test(AMOUNT)
+  //return /^((\d{1,3})(?:,[0-9]{3}){0,1}|(\d{1})(?:,[0-9]{3}){0,2}|(\d{1,18}))(\.\d{1,18)?$/.test(AMOUNT)
+  return /[^0-9.,]/.test(amount) == false
+}


### PR DESCRIPTION
**Issue:**
resolves #114 

**Summary**:
- Regex allows only [0-9] and .
- Allows 18 digits to the left and 6-18 to the right of the decimal - depending on the coin.
- The current formatting does not allow more than 6 decimals and I didn't want to wade into that
- I did not see any `tests` in the dApp so I didn't add one for the regex





