### PR TITLE
remember locale settings

### DIFF
--- a/dapp/pages/_app.js
+++ b/dapp/pages/_app.js
@@ -103,9 +103,10 @@ function App({ Component, pageProps, err }) {
     }
   }, [])
 
-	useEffect(() => {
-		if (localStorage.locale) {
-			setLocale(localStorage.locale)
+  useEffect(() => {
+    if (localStorage.locale) {
+      setLocale(localStorage.locale)
+      setUtilLocale(localStorage.locale)
 		}
   }, [])
   

--- a/dapp/pages/_app.js
+++ b/dapp/pages/_app.js
@@ -106,7 +106,7 @@ function App({ Component, pageProps, err }) {
   useEffect(() => {
     if (localStorage.locale) {
       setLocale(localStorage.locale)
-      setUtilLocale(localStorage.locale)
+      setUtilLocale(localStorage.locale, true)
 		}
   }, [])
   

--- a/dapp/src/utils/setLocale.js
+++ b/dapp/src/utils/setLocale.js
@@ -2,7 +2,7 @@ import { IntlViewerContext, init } from 'fbt-runtime'
 import Languages from 'constants/Languages'
 import analytics from './analytics'
 
-export default async function setLocale(newLocale) {
+export default async function setLocale(newLocale, initialise = false) {
   const existingLocale = localStorage.getItem('locale')
 
   let userLocale = newLocale || existingLocale
@@ -32,10 +32,12 @@ export default async function setLocale(newLocale) {
     }
   }
 
-  analytics.track('Locale Change', {
-    fromLocale: existingLocale,
-    toLocale: newLocale,
-  })
+  if (!initialise) {
+    analytics.track('Locale Change', {
+      fromLocale: existingLocale,
+      toLocale: newLocale,
+    })
+  }
 
   IntlViewerContext.locale = locale
   return locale


### PR DESCRIPTION
PR for https://github.com/OriginProtocol/origin-dollar/issues/260

The reason of this issue is that it was not re-initialize the translation after fetching saved locale infos from local storage.
