### PR TITLE
Daniel vf/caching and static pages

### DIFF
--- a/dapp/deploy.sh
+++ b/dapp/deploy.sh
@@ -12,10 +12,12 @@ if [ $branch != "master" ]; then
   fi
 fi
 
-# .next folder is only needed for local development. Deleting it circumvents the following error:
+# .next/cache is only needed for local development. Deleting it circumvents the following error:
 # Error Response: [3] The directory [.next/cache/next-babel-loader] has too many files (greater than 1000)..
+# The actual .next folder is useful because it contains pre-rendered static versions of all pages that
+# can be staticly rendered, which is most of OUSD.com
 echo "Deleting .next folder..."
-rm -rf .next
+rm -rf .next/cache
 
 echo "Decrypting secrets..."
 yarn run decrypt-secrets-deploy:$mode

--- a/dapp/next.config.js
+++ b/dapp/next.config.js
@@ -74,6 +74,13 @@ module.exports = {
           {
             key: 'X-Frame-Options',
             value: 'SAMEORIGIN',
+          },
+          {
+            // Cache all pages for 10 minutes, give server an extra 2 minutes
+            // to regenerate the content in the background during which the
+            // cache can still keep serving the content it has.
+            key: 'Cache-Control',
+            value: 'public, max-age=600, stale-while-revalidate=120',
           }
         ]
       }

--- a/dapp/src/utils/analytics.js
+++ b/dapp/src/utils/analytics.js
@@ -12,18 +12,27 @@ if (isProduction && !isStaging) {
   mixpanelId = MIXPANEL_ID
 }
 
-const analytics = Analytics({
-  app: 'origin-dollar-dapp',
-  version: 1,
-  plugins: [
+const plugins = []
+
+if (process.env.GA_ID || !isStaging) {
+  plugins.push(
     googleAnalytics({
       trackingId: process.env.GA_ID,
       debug: isDevelopment ? true : false,
-    }),
-    mixpanel({
-      token: mixpanelId,
-    }),
-  ],
+    })
+  )
+}
+
+plugins.push(
+  mixpanel({
+    token: mixpanelId,
+  })
+)
+
+const analytics = Analytics({
+  app: 'origin-dollar-dapp',
+  version: 1,
+  plugins: plugins,
 })
 
 export default analytics


### PR DESCRIPTION
- Don't strip our precompiled pages from the deploy
- Add cache control headers to allow pages to cached by both GAE and Clouldfront.
- Allow deploying to staging without a Google Analytics ID