### PR TITLE
Upgrade governor and send proposal to transfer governance to it for all contracts

### DIFF
--- a/contracts/deploy/018_upgrade_governor.js
+++ b/contracts/deploy/018_upgrade_governor.js
@@ -98,7 +98,7 @@ const runDeployment = async (hre) => {
       contract: cCompensationClaim,
       signature: "transferGovernance(address)",
       args: [dGovernor.address],
-    }
+    },
   ]);
 
   if (isMainnet) {
@@ -144,10 +144,9 @@ const runDeployment = async (hre) => {
     log("Called transferGovernance on CompoundStrategyProxy");
 
     await withConfirmation(
-      cThreePoolStrategyProxy.connect(sGovernor).transferGovernance(
-        dGovernor.address,
-        await getTxOpts(gasLimit)
-      )
+      cThreePoolStrategyProxy
+        .connect(sGovernor)
+        .transferGovernance(dGovernor.address, await getTxOpts(gasLimit))
     );
     log("Called transferGovernance on ThreePoolStrategyProxy");
 

--- a/contracts/deploy/018_upgrade_governor.js
+++ b/contracts/deploy/018_upgrade_governor.js
@@ -31,7 +31,6 @@ const runDeployment = async (hre) => {
 
   const cOUSDProxy = await ethers.getContract("OUSDProxy");
   const cVaultProxy = await ethers.getContract("VaultProxy");
-  const cChainlinkOracle = await ethers.getContract("ChainlinkOracle");
   const cCompoundStrategyProxy = await ethers.getContract(
     "CompoundStrategyProxy"
   );
@@ -61,11 +60,6 @@ const runDeployment = async (hre) => {
     },
     {
       contract: cVaultProxy,
-      signature: "transferGovernance(address)",
-      args: [dGovernor.address],
-    },
-    {
-      contract: cChainlinkOracle,
       signature: "transferGovernance(address)",
       args: [dGovernor.address],
     },
@@ -110,10 +104,6 @@ const runDeployment = async (hre) => {
     },
     {
       contract: cVaultProxy,
-      signature: "claimGovernance()",
-    },
-    {
-      contract: cChainlinkOracle,
       signature: "claimGovernance()",
     },
     {
@@ -181,13 +171,6 @@ const runDeployment = async (hre) => {
         .transferGovernance(dGovernor.address, await getTxOpts(gasLimit))
     );
     log("Called transferGovernance on VaultProxy");
-
-    await withConfirmation(
-      cChainlinkOracle
-        .connect(sGovernor)
-        .transferGovernance(dGovernor.address, await getTxOpts(gasLimit))
-    );
-    log("Called transferGovernance on OracleRouter");
 
     await withConfirmation(
       cCompoundStrategyProxy

--- a/contracts/deploy/018_upgrade_governor.js
+++ b/contracts/deploy/018_upgrade_governor.js
@@ -155,64 +155,6 @@ const runDeployment = async (hre) => {
     await executeProposal(propClaimArgs, propClaimDescription, {
       guardianAddr: addresses.mainnet.Guardian,
     });
-  } else {
-    // Hardcoding gas estimate on Rinkeby since it fails for an undetermined reason...
-    const gasLimit = isRinkeby ? 1000000 : null;
-    await withConfirmation(
-      cOUSDProxy
-        .connect(sGovernor)
-        .transferGovernance(dGovernor.address, await getTxOpts(gasLimit))
-    );
-    log("Called transferGovernance on OUSDPoxy");
-
-    await withConfirmation(
-      cVaultProxy
-        .connect(sGovernor)
-        .transferGovernance(dGovernor.address, await getTxOpts(gasLimit))
-    );
-    log("Called transferGovernance on VaultProxy");
-
-    await withConfirmation(
-      cCompoundStrategyProxy
-        .connect(sGovernor)
-        .transferGovernance(dGovernor.address, await getTxOpts(gasLimit))
-    );
-    log("Called transferGovernance on CompoundStrategyProxy");
-
-    await withConfirmation(
-      cThreePoolStrategyProxy
-        .connect(sGovernor)
-        .transferGovernance(dGovernor.address, await getTxOpts(gasLimit))
-    );
-    log("Called transferGovernance on ThreePoolStrategyProxy");
-
-    await withConfirmation(
-      cAaveStrategyProxy
-        .connect(sGovernor)
-        .transferGovernance(dGovernor.address, await getTxOpts(gasLimit))
-    );
-    log("Called transferGovernance on AaveStrategyProxy");
-
-    await withConfirmation(
-      cBuyback
-        .connect(sGovernor)
-        .transferGovernance(dGovernor.address, await getTxOpts(gasLimit))
-    );
-    log("Called transferGovernance on BuyBack");
-
-    await withConfirmation(
-      cOGNStakingProxy
-        .connect(sGovernor)
-        .transferGovernance(dGovernor.address, await getTxOpts(gasLimit))
-    );
-    log("Called transferGovernance on OGNStakingProxy");
-
-    await withConfirmation(
-      cCompensationClaim
-        .connect(sGovernor)
-        .transferGovernance(dGovernor.address, await getTxOpts(gasLimit))
-    );
-    log("Called transferGovernance on CompensationClaim");
   }
 
   return true;

--- a/contracts/deploy/018_upgrade_governor.js
+++ b/contracts/deploy/018_upgrade_governor.js
@@ -26,9 +26,6 @@ const runDeployment = async (hre) => {
 
   const { governorAddr } = await hre.getNamedAccounts();
 
-  // Signers
-  const sGovernor = await ethers.provider.getSigner(governorAddr);
-
   const cOUSDProxy = await ethers.getContract("OUSDProxy");
   const cVaultProxy = await ethers.getContract("VaultProxy");
   const cCompoundStrategyProxy = await ethers.getContract(

--- a/contracts/deploy/018_upgrade_governor.js
+++ b/contracts/deploy/018_upgrade_governor.js
@@ -1,7 +1,7 @@
-// Deploys the latest governor contract and sets its ownership to the new multisig safe wallet.
-// Submits a proposal to call transferGovernance on all governable contracts.
-// Once the proposal is executed, the claimGovernance() method should be called
-// on all the contract from the new multisig wallet to finish transferring the governance.
+// 1. Deploy the latest governor contract and sets its ownership to the new multisig safe wallet.
+// 2. Submit a proposal on the old governor to call transferGovernance() on all governable contracts.
+// 3. Submit a proposal on the new governor to call claimGovernance() on all governable contracts.
+
 const {
   isMainnet,
   isFork,

--- a/contracts/deploy/018_upgrade_governor.js
+++ b/contracts/deploy/018_upgrade_governor.js
@@ -35,10 +35,10 @@ const runDeployment = async (hre) => {
   const cCompoundStrategyProxy = await ethers.getContract(
     "CompoundStrategyProxy"
   );
-  const cThreePoolStrategyProxy = await hre.ethers.getContract(
+  const cThreePoolStrategyProxy = await ethers.getContract(
     "ThreePoolStrategyProxy"
   );
-  const cAaveStrategyProxy = await hre.ethers.getContract("AaveStrategyProxy");
+  const cAaveStrategyProxy = await ethers.getContract("AaveStrategyProxy");
   const cBuyback = await ethers.getContract("Buyback");
   const cOGNStakingProxy = await ethers.getContract("OGNStakingProxy");
   const cCompensationClaim = await ethers.getContract("CompensationClaims");
@@ -144,13 +144,13 @@ const runDeployment = async (hre) => {
 
   if (isMainnet) {
     // On Mainnet, only propose. The enqueue and execution are handled manually via multi-sig.
-    log("Sending transfer proposal to governor...");
+    log("Sending transfer proposal to old governor...");
     await sendProposal(propTransferArgs, propTransferDescription, {
       governorAddr,
     });
     log("Transfer proposal sent.");
 
-    log("Sending claim proposal to governor...");
+    log("Sending claim proposal to new governor...");
     await sendProposal(propClaimArgs, propClaimDescription);
     log("Claim proposal sent.");
   } else if (isFork) {
@@ -160,11 +160,11 @@ const runDeployment = async (hre) => {
     await executeProposal(propTransferArgs, propTransferDescription, {
       governorAddr,
     });
-    log("Proposal executed.");
 
     log("Sending and executing claim proposal...");
-    await executeProposal(propClaimArgs, propClaimDescription);
-    log("Proposal executed.");
+    await executeProposal(propClaimArgs, propClaimDescription, {
+      guardianAddr: addresses.mainnet.Guardian,
+    });
   } else {
     // Hardcoding gas estimate on Rinkeby since it fails for an undetermined reason...
     const gasLimit = isRinkeby ? 1000000 : null;

--- a/contracts/deploy/018_upgrade_governor.js
+++ b/contracts/deploy/018_upgrade_governor.js
@@ -1,0 +1,200 @@
+// Deploys the latest governor contract and sets its ownership to the new multisig safe wallet.
+// Submits a proposal to call transferGovernance on all governable contracts.
+// Once the proposal is executed, the claimGovernance() method should be called
+// on all the contract from the new multisig wallet to finish transferring the governance.
+const {
+  isMainnet,
+  isFork,
+  isRinkeby,
+  isSmokeTest,
+} = require("../test/helpers.js");
+const {
+  log,
+  deployWithConfirmation,
+  withConfirmation,
+  executeProposal,
+  sendProposal,
+} = require("../utils/deploy");
+const { proposeArgs } = require("../utils/governor");
+const { getTxOpts } = require("../utils/tx");
+const addresses = require("../utils/addresses");
+
+const deployName = "018_upgrade_governor";
+
+const runDeployment = async (hre) => {
+  console.log(`Running ${deployName} deployment...`);
+
+  const { governorAddr } = await hre.getNamedAccounts();
+
+  // Signers
+  const sGovernor = await ethers.provider.getSigner(governorAddr);
+
+  const cOUSDProxy = await ethers.getContract("OUSDProxy");
+  const cVaultProxy = await ethers.getContract("VaultProxy");
+  const cChainlinkOracle = await ethers.getContract("ChainlinkOracle");
+  const cCompoundStrategyProxy = await ethers.getContract(
+    "CompoundStrategyProxy"
+  );
+  const cThreePoolStrategyProxy = await hre.ethers.getContract(
+    "ThreePoolStrategyProxy"
+  );
+  const cAaveStrategyProxy = await hre.ethers.getContract("AaveStrategyProxy");
+  const cBuyback = await ethers.getContract("Buyback");
+  const cOGNStakingProxy = await ethers.getContract("OGNStakingProxy");
+  const cCompensationClaim = await ethers.getContract("CompensationClaims");
+
+  // Deploy a new governor contract.
+  // The governor's admin is the guardian account (e.g. the multi-sig).
+  // Set a min delay of 60sec for executing proposals.
+  const dGovernor = await deployWithConfirmation("Governor", [
+    addresses.mainnet.Guardian,
+    60,
+  ]);
+
+  // Proposal for the governor update the contract
+  const propDescription = "Transfer governance to the new governor";
+  const propArgs = await proposeArgs([
+    {
+      contract: cOUSDProxy,
+      signature: "transferGovernance(address)",
+      args: [dGovernor.address],
+    },
+    {
+      contract: cVaultProxy,
+      signature: "transferGovernance(address)",
+      args: [dGovernor.address],
+    },
+    {
+      contract: cChainlinkOracle,
+      signature: "transferGovernance(address)",
+      args: [dGovernor.address],
+    },
+    {
+      contract: cCompoundStrategyProxy,
+      signature: "transferGovernance(address)",
+      args: [dGovernor.address],
+    },
+    {
+      contract: cThreePoolStrategyProxy,
+      signature: "transferGovernance(address)",
+      args: [dGovernor.address],
+    },
+    {
+      contract: cAaveStrategyProxy,
+      signature: "transferGovernance(address)",
+      args: [dGovernor.address],
+    },
+    {
+      contract: cBuyback,
+      signature: "transferGovernance(address)",
+      args: [dGovernor.address],
+    },
+    {
+      contract: cOGNStakingProxy,
+      signature: "transferGovernance(address)",
+      args: [dGovernor.address],
+    },
+    {
+      contract: cCompensationClaim,
+      signature: "transferGovernance(address)",
+      args: [dGovernor.address],
+    }
+  ]);
+
+  if (isMainnet) {
+    // On Mainnet, only propose. The enqueue and execution are handled manually via multi-sig.
+    log("Sending proposal to governor...");
+    await sendProposal(propArgs, propDescription);
+    log("Proposal sent.");
+  } else if (isFork) {
+    // On Fork we can send the proposal then impersonate the guardian to execute it.
+    // Note: we send thr proposal to the old governor by passing explicitly its address.
+    log("Sending and executing proposal...");
+    await executeProposal(propArgs, propDescription, { governorAddr });
+    log("Proposal executed.");
+  } else {
+    // Hardcoding gas estimate on Rinkeby since it fails for an undetermined reason...
+    const gasLimit = isRinkeby ? 1000000 : null;
+    await withConfirmation(
+      cOUSDProxy
+        .connect(sGovernor)
+        .transferGovernance(dGovernor.address, await getTxOpts(gasLimit))
+    );
+    log("Called transferGovernance on OUSDPoxy");
+
+    await withConfirmation(
+      cVaultProxy
+        .connect(sGovernor)
+        .transferGovernance(dGovernor.address, await getTxOpts(gasLimit))
+    );
+    log("Called transferGovernance on VaultProxy");
+
+    await withConfirmation(
+      cChainlinkOracle
+        .connect(sGovernor)
+        .transferGovernance(dGovernor.address, await getTxOpts(gasLimit))
+    );
+    log("Called transferGovernance on OracleRouter");
+
+    await withConfirmation(
+      cCompoundStrategyProxy
+        .connect(sGovernor)
+        .transferGovernance(dGovernor.address, await getTxOpts(gasLimit))
+    );
+    log("Called transferGovernance on CompoundStrategyProxy");
+
+    await withConfirmation(
+      cThreePoolStrategyProxy.connect(sGovernor).transferGovernance(
+        dGovernor.address,
+        await getTxOpts(gasLimit)
+      )
+    );
+    log("Called transferGovernance on ThreePoolStrategyProxy");
+
+    await withConfirmation(
+      cAaveStrategyProxy
+        .connect(sGovernor)
+        .transferGovernance(dGovernor.address, await getTxOpts(gasLimit))
+    );
+    log("Called transferGovernance on AaveStrategyProxy");
+
+    await withConfirmation(
+      cBuyback
+        .connect(sGovernor)
+        .transferGovernance(dGovernor.address, await getTxOpts(gasLimit))
+    );
+    log("Called transferGovernance on BuyBack");
+
+    await withConfirmation(
+      cOGNStakingProxy
+        .connect(sGovernor)
+        .transferGovernance(dGovernor.address, await getTxOpts(gasLimit))
+    );
+    log("Called transferGovernance on OGNStakingProxy");
+
+    await withConfirmation(
+      cCompensationClaim
+        .connect(sGovernor)
+        .transferGovernance(dGovernor.address, await getTxOpts(gasLimit))
+    );
+    log("Called transferGovernance on CompensationClaim");
+  }
+
+  return true;
+};
+
+const main = async (hre) => {
+  console.log(`Running ${deployName} deployment...`);
+  if (!hre) {
+    hre = require("hardhat");
+  }
+  await runDeployment(hre);
+  console.log(`${deployName} deploy done.`);
+  return true;
+};
+
+main.id = deployName;
+main.dependencies = ["017_3pool_strategy_update"];
+main.skip = () => !(isMainnet || isRinkeby || isFork) || isSmokeTest;
+
+module.exports = main;

--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -10,7 +10,12 @@ require("@openzeppelin/hardhat-upgrades");
 const { accounts, fund, mint, redeem, transfer } = require("./tasks/account");
 const { debug } = require("./tasks/debug");
 const { env } = require("./tasks/env");
-const { execute, executeOnFork, proposal } = require("./tasks/governance");
+const {
+  execute,
+  executeOnFork,
+  proposal,
+  governors,
+} = require("./tasks/governance");
 const { balance } = require("./tasks/ousd");
 const { smokeTest, smokeTestCheck } = require("./tasks/smokeTest");
 const {
@@ -114,6 +119,9 @@ task("executeOnFork", "Enqueue and execute a proposal on the Fork")
 task("proposal", "Dumps the state of a proposal")
   .addParam("id", "Id of the proposal")
   .setAction(proposal);
+task("governors", "Get list of governors for all contracts").setAction(
+  governors
+);
 
 // Compensation tasks
 task("isAdjusterLocked", "Is adjuster on Compensation claims locked").setAction(

--- a/contracts/tasks/governance.js
+++ b/contracts/tasks/governance.js
@@ -98,7 +98,6 @@ async function proposal(taskArguments, hre) {
 async function governors() {
   const cOUSDProxy = await ethers.getContract("OUSDProxy");
   const cVaultProxy = await ethers.getContract("VaultProxy");
-  const cChainlinkOracle = await ethers.getContract("ChainlinkOracle");
   const cCompoundStrategyProxy = await ethers.getContract(
     "CompoundStrategyProxy"
   );
@@ -115,7 +114,6 @@ async function governors() {
   console.log("===================");
   console.log("OUSDProxy:              ", await cOUSDProxy.governor());
   console.log("VaultProxy:             ", await cVaultProxy.governor());
-  console.log("ChainlinkOracle:        ", await cChainlinkOracle.governor());
   console.log(
     "CompoundStrategyProxy:  ",
     await cCompoundStrategyProxy.governor()

--- a/contracts/tasks/governance.js
+++ b/contracts/tasks/governance.js
@@ -94,7 +94,7 @@ async function proposal(taskArguments, hre) {
   console.log("  actions:  ", JSON.stringify(actions, null, 2));
 }
 
-// Dumps a list of the governor address for all the known contracts in the system.
+// Dumps the governor address for all the known contracts in the system.
 async function governors() {
   const cOUSDProxy = await ethers.getContract("OUSDProxy");
   const cVaultProxy = await ethers.getContract("VaultProxy");

--- a/contracts/tasks/governance.js
+++ b/contracts/tasks/governance.js
@@ -94,8 +94,46 @@ async function proposal(taskArguments, hre) {
   console.log("  actions:  ", JSON.stringify(actions, null, 2));
 }
 
+// Dumps a list of the governor address for all the known contracts in the system.
+async function governors() {
+  const cOUSDProxy = await ethers.getContract("OUSDProxy");
+  const cVaultProxy = await ethers.getContract("VaultProxy");
+  const cChainlinkOracle = await ethers.getContract("ChainlinkOracle");
+  const cCompoundStrategyProxy = await ethers.getContract(
+    "CompoundStrategyProxy"
+  );
+  const cThreePoolStrategyProxy = await ethers.getContract(
+    "ThreePoolStrategyProxy"
+  );
+  const cAaveStrategyProxy = await ethers.getContract("AaveStrategyProxy");
+  const cBuyback = await ethers.getContract("Buyback");
+  const cOGNStakingProxy = await ethers.getContract("OGNStakingProxy");
+  const cCompensationClaim = await ethers.getContract("CompensationClaims");
+  const cFlipper = await ethers.getContract("Flipper");
+
+  console.log("Governor addresses:");
+  console.log("===================");
+  console.log("OUSDProxy:              ", await cOUSDProxy.governor());
+  console.log("VaultProxy:             ", await cVaultProxy.governor());
+  console.log("ChainlinkOracle:        ", await cChainlinkOracle.governor());
+  console.log(
+    "CompoundStrategyProxy:  ",
+    await cCompoundStrategyProxy.governor()
+  );
+  console.log(
+    "ThreePoolStrategyProxy: ",
+    await cThreePoolStrategyProxy.governor()
+  );
+  console.log("AaveStrategyProxy:      ", await cAaveStrategyProxy.governor());
+  console.log("Buyback:                ", await cBuyback.governor());
+  console.log("OGNSTakingProxy:        ", await cOGNStakingProxy.governor());
+  console.log("CompensationClaim:      ", await cCompensationClaim.governor());
+  console.log("Flipper:                ", await cFlipper.governor());
+}
+
 module.exports = {
   execute,
   executeOnFork,
   proposal,
+  governors,
 };

--- a/contracts/utils/addresses.js
+++ b/contracts/utils/addresses.js
@@ -62,6 +62,7 @@ addresses.mainnet.chainlinkUSDT_ETH =
 // WETH Token
 addresses.mainnet.WETH = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
 // Deployed OUSD contracts
+addresses.mainnet.Guardian = "0xbe2AB3d3d8F6a32b96414ebbd865dBD276d3d899"; // ERC 20 owner multisig.
 addresses.mainnet.VaultProxy = "0x277e80f3E14E7fB3fc40A9d6184088e0241034bD";
 addresses.mainnet.Vault = "0xf251Cb9129fdb7e9Ca5cad097dE3eA70caB9d8F9";
 addresses.mainnet.OUSDProxy = "0x2A8e1E676Ec238d8A992307B495b45B3fEAa5e86";

--- a/contracts/utils/deploy.js
+++ b/contracts/utils/deploy.js
@@ -113,7 +113,7 @@ const impersonateGuardian = async () => {
  *   governorAddr: address of the governor contract to send the proposal to
  * @returns {Promise<void>}
  */
-const executeProposal = async (proposalArgs, description, opts) => {
+const executeProposal = async (proposalArgs, description, opts = {}) => {
   if (isMainnet || isRinkeby) {
     throw new Error("executeProposal only works on local test network");
   }
@@ -215,7 +215,7 @@ const executeProposalOnFork = async (proposalId, executeGasLimit = null) => {
  * @param {string} description
  * @returns {Promise<void>}
  */
-const sendProposal = async (proposalArgs, description) => {
+const sendProposal = async (proposalArgs, description, opts = {}) => {
   if (!isMainnet && !isFork) {
     throw new Error("sendProposal only works on Mainnet and Fork networks");
   }
@@ -223,7 +223,13 @@ const sendProposal = async (proposalArgs, description) => {
   const { deployerAddr } = await hre.getNamedAccounts();
   const sDeployer = hre.ethers.provider.getSigner(deployerAddr);
 
-  const governor = await ethers.getContract("Governor");
+  let governor;
+  if (opts.governorAddr) {
+    governor = await ethers.getContractAt("Governor", opts.governorAddr);
+    log(`Using governor contract at ${opts.governorAddr}`);
+  } else {
+    governor = await ethers.getContract("Governor");
+  }
 
   log(`Submitting proposal for ${description} to governor ${governor.address}`);
   log(`Args: ${JSON.stringify(proposalArgs, null, 2)}`);

--- a/contracts/utils/deploy.js
+++ b/contracts/utils/deploy.js
@@ -112,7 +112,6 @@ const impersonateGuardian = async (optGuardianAddr = null) => {
  * @param {Array<Object>} proposalArgs
  * @param {string} description
  * @param {opts} Options
- *   v1: whether to use the V1 governor (e.g. MinuteTimelock)
  *   governorAddr: address of the governor contract to send the proposal to
  *   guardianAddr: address of the guardian (aka the governor's admin) to use for sending the queue and execute tx
  * @returns {Promise<void>}
@@ -134,21 +133,7 @@ const executeProposal = async (proposalArgs, description, opts = {}) => {
   }
 
   let governorContract;
-  if (opts.v1) {
-    const v1GovernorAddr = "0x8a5fF78BFe0de04F5dc1B57d2e1095bE697Be76E";
-    const v1GovernorAbi = [
-      "function propose(address[],uint256[],string[],bytes[],string) returns (uint256)",
-      "function proposalCount() view returns (uint256)",
-      "function queue(uint256)",
-      "function execute(uint256)",
-    ];
-    proposalArgs = [proposalArgs[0], [0], proposalArgs[1], proposalArgs[2]];
-    governorContract = new ethers.Contract(
-      v1GovernorAddr,
-      v1GovernorAbi,
-      hre.ethers.provider
-    );
-  } else if (opts.governorAddr) {
+  if (opts.governorAddr) {
     governorContract = await ethers.getContractAt(
       "Governor",
       opts.governorAddr

--- a/contracts/utils/deploy.js
+++ b/contracts/utils/deploy.js
@@ -108,10 +108,12 @@ const impersonateGuardian = async () => {
  *
  * @param {Array<Object>} proposalArgs
  * @param {string} description
- * @param {boolean} whether to use the V1 governor (e.g. MinuteTimelock)
+ * @param {opts} Options
+ *   v1: whether to use the V1 governor (e.g. MinuteTimelock)
+ *   governorAddr: address of the governor contract to send the proposal to
  * @returns {Promise<void>}
  */
-const executeProposal = async (proposalArgs, description, v1 = false) => {
+const executeProposal = async (proposalArgs, description, opts) => {
   if (isMainnet || isRinkeby) {
     throw new Error("executeProposal only works on local test network");
   }
@@ -125,7 +127,7 @@ const executeProposal = async (proposalArgs, description, v1 = false) => {
   }
 
   let governorContract;
-  if (v1) {
+  if (opts.v1) {
     const v1GovernorAddr = "0x8a5fF78BFe0de04F5dc1B57d2e1095bE697Be76E";
     const v1GovernorAbi = [
       "function propose(address[],uint256[],string[],bytes[],string) returns (uint256)",
@@ -140,6 +142,9 @@ const executeProposal = async (proposalArgs, description, v1 = false) => {
       hre.ethers.provider
     );
     log(`Using V1 governor contract at ${v1GovernorAddr}`);
+  } else if (opts.governorAddr) {
+    governorContract = await ethers.getContractAt("Governor", opts.governorAddr);
+    log(`Using governor contract at ${opts.governorAddr}`);
   } else {
     governorContract = await ethers.getContract("Governor");
   }

--- a/contracts/utils/deploy.js
+++ b/contracts/utils/deploy.js
@@ -143,7 +143,10 @@ const executeProposal = async (proposalArgs, description, opts) => {
     );
     log(`Using V1 governor contract at ${v1GovernorAddr}`);
   } else if (opts.governorAddr) {
-    governorContract = await ethers.getContractAt("Governor", opts.governorAddr);
+    governorContract = await ethers.getContractAt(
+      "Governor",
+      opts.governorAddr
+    );
     log(`Using governor contract at ${opts.governorAddr}`);
   } else {
     governorContract = await ethers.getContract("Governor");


### PR DESCRIPTION
This is part of the work for migrating to a new multisig.

I initially wanted to just change the admin on the currently deployed governor/timelock contract to point to the new multisig.
But a bug prevents us from doing that. 

###  Details of the bug
 - Here is the deployed contract: https://etherscan.io/address/0x8e7bdfecd1164c46ad51b58e49a611f954d23377#code
I was planning on calling setPendingAdmin(<new_safe_address>), then call acceptAdmin() from the new safe. 
 - There is this assert on line 290 in the Timelock contract which implies the call to setPendingAdmin should come from a proposal execution:
```require(msg.sender == address(this), "Timelock::setPendingAdmin: Call must come from Timelock.");```
 - But another assert prevents adding a proposal for calling setPendingAdmin. See line 514 in the Governor contract
```require(keccak256(bytes(signatures[i])) != setPendingAdminSign, "Governor::propose: setPendingAdmin transaction cannot be proposed or queued");```
=> We can neither call setPendingAdmin directly or use a proposal to call it.

### Alternate solution
 - Deploy a new Governor/Timelock contract. This is anyway not a bad thing since the currently deployed contract does not include the latest code from master
 - Send and execute a proposal for the old governor to call transferGovernance(<new_governor_address>) on all the governable contracts
 - Send an execute a proposal for the new governor to call claimGovernance() on all the governable contracts

### Testing on fork
This can be simulated on the fork using the following commands:
1. Start a fork node. That will execute deploy 18 which deploys the new governor contract and sends the 2 proposals
```
export BLOCK_NUMBER=<recent_block_num>
export PROVIDER_URL=<mainnet_provider_url>
yarn run node:fork
```
2. In a separate terminal, run a task to check that all contracts (except Flipper which is owned by the Strategist and should remain this way) have the new governor properly set.
```
FORK=true npx hardhat governors --network localhost
```
====

If you made a contract change, make sure to complete the checklist below before merging it in master.

Refer to our [documentation](https://github.com/OriginProtocol/security) for more details about contract security best practices.


Contract change checklist:
  - [ ] Code reviewed by 2 reviewers. See [template](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) and [example](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md).
  - [ ] Unit tests pass
  - [ ] Slither tests pass with no warning
  - [ ] Echidna tests pass if PR includes changes to OUSD contract (not automated, run manually on local)
