### PR TITLE
Check for trustee/buyback before calling during allocate/mint

### DIFF
--- a/contracts/contracts/vault/VaultCore.sol
+++ b/contracts/contracts/vault/VaultCore.sol
@@ -347,7 +347,10 @@ contract VaultCore is VaultStorage {
         }
 
         // Trigger OGN Buyback
-        IBuyback(trusteeAddress).swap();
+        address _trusteeAddress = trusteeAddress; // gas savings
+        if (_trusteeAddress != address(0)) {
+            IBuyback(trusteeAddress).swap();
+        }
     }
 
     /**


### PR DESCRIPTION
We check that we have trustee contract when we call it during the rebase, but not when we try to call it during the allocate. This breaks large mints if no trustee contract is set. 

Since a trustee contract is set in production, this is not a problem for the live contracts. It's just good to have the code act consistently, and how you would expect.

Contract change checklist:
  - [ ] Code reviewed by 2 reviewers. See [template](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) and [example](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md).
  - [x] Unit tests pass
  - [x] Slither tests pass with no warning
