### PR TITLE
[N04] Unnecessary external calls

### DIFF
--- a/contracts/contracts/strategies/ThreePoolStrategy.sol
+++ b/contracts/contracts/strategies/ThreePoolStrategy.sol
@@ -116,6 +116,7 @@ contract ThreePoolStrategy is InitializableAbstractStrategy {
         uint256[3] memory _amounts = [uint256(0), uint256(0), uint256(0)];
         uint256 depositValue = 0;
         ICurvePool curvePool = ICurvePool(platformAddress);
+        uint256 curveVirtualPrice = curvePool.get_virtual_price();
 
         for (uint256 i = 0; i < assetsMapped.length; i++) {
             address assetAddress = assetsMapped[i];
@@ -129,7 +130,7 @@ contract ThreePoolStrategy is InitializableAbstractStrategy {
                 // the minMintAmount argument for add_liquidity
                 depositValue = depositValue.add(
                     balance.scaleBy(int8(18 - assetDecimals)).divPrecisely(
-                        curvePool.get_virtual_price()
+                        curveVirtualPrice
                     )
                 );
                 emit Deposit(assetAddress, address(platformAddress), balance);


### PR DESCRIPTION
Move Curve `get_virtual_price` call out of the loop to safe on external calls.


Contract change checklist:
  - [ ] Code reviewed by 2 reviewers. See [template](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) and [example](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md).
  - [x] Unit tests pass
  - [x] Slither tests pass with no warning
  - [x] Echidna tests pass if PR includes changes to OUSD contract (not automated, run manually on local)
