### PR TITLE
🥏 [L19] Remove unneeded constructor

### DIFF
--- a/contracts/contracts/flipper/Flipper.sol
+++ b/contracts/contracts/flipper/Flipper.sol
@@ -22,11 +22,6 @@ contract Flipper is Governable {
     IERC20 usdc = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
     Tether constant usdt = Tether(0xdAC17F958D2ee523a2206206994597C13D831ec7);
 
-    // -----------
-    // Constructor
-    // -----------
-    constructor() public {}
-
     // -----------------
     // Trading functions
     // -----------------


### PR DESCRIPTION
Flipper contract does not need an empty constructor.


Contract change checklist:
  - [x] Code reviewed by 2 reviewers. See [template](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) and [example](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md).
  - [x] Unit tests pass
  - [x] Slither tests pass with no warning
