### PR TITLE
fix vault redeem fee calculation amount

### DIFF
--- a/dapp/src/hooks/useSwapEstimator.js
+++ b/dapp/src/hooks/useSwapEstimator.js
@@ -438,25 +438,22 @@ const useSwapEstimator = ({
     let gasEstimate
     try {
       await loadRedeemFee()
-
-      const exitFee = amount * redeemFee
       const coinSplits = await _calculateSplits(amount)
       const splitsSum = coinSplits
         .map((coin) => parseFloat(coin.amount))
         .reduce((a, b) => a + b, 0)
-      const amountReceived = splitsSum - exitFee
 
       if (!userHasEnoughStablecoin('ousd', amount)) {
         return {
           canDoSwap: true,
           gasUsed: 1500000,
-          amountReceived,
+          amountReceived: splitsSum,
           coinSplits,
         }
       }
 
       const { minSwapAmount: minAmountReceived } = calculateSwapAmounts(
-        amountReceived,
+        splitsSum,
         coinToReceiveDecimals,
         priceToleranceValue
       )
@@ -467,7 +464,7 @@ const useSwapEstimator = ({
         canDoSwap: true,
         gasUsed: gasEstimate,
         // TODO: should this be rather done with BigNumbers instead?
-        amountReceived: splitsSum - exitFee,
+        amountReceived: splitsSum,
         coinSplits,
       }
     } catch (e) {


### PR DESCRIPTION
fix vault redeem fee calculation amount: calculate splits already includes the vault redeem fee. 

**issue:** https://github.com/OriginProtocol/origin-dollar/issues/650


Contract change checklist:
  - [ ] Code reviewed by 2 reviewers. See [template](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) and [example](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md).
  - [ ] Unit tests pass
  - [ ] Slither tests pass with no warning
  - [ ] Echidna tests pass if PR includes changes to OUSD contract (not automated, run manually on local)
