### PR TITLE
Connected wallet race condition

### DIFF
--- a/dapp/src/hooks/useSwapEstimator.js
+++ b/dapp/src/hooks/useSwapEstimator.js
@@ -87,6 +87,8 @@ const useSwapEstimator = ({
   )
 
   const swapEstimations = useStoreState(ContractStore, (s) => s.swapEstimations)
+  const walletConnected = useStoreState(ContractStore, (s) => s.walletConnected)
+
   useEffect(() => {
     const swapsLoaded = swapEstimations && typeof swapEstimations === 'object'
     const userSelectionExists =
@@ -124,6 +126,15 @@ const useSwapEstimator = ({
       return
     }
 
+    /*
+     * Weird race condition would happen where estimations were ran with the utils/contracts setting up
+     * the contracts with alchemy provider instead of Metamask one. When estimations are ran with that
+     * setup, half of the estimations fail with an error.
+     */
+    if (!walletConnected) {
+      return
+    }
+
     /* Timeout the execution so it doesn't happen on each key stroke rather aiming
      * to when user has already stopped typing
      */
@@ -132,7 +143,13 @@ const useSwapEstimator = ({
         await runEstimations(swapMode, selectedCoin, inputAmountRaw)
       }, 700)
     )
-  }, [swapMode, selectedCoin, inputAmountRaw, allowancesLoaded])
+  }, [
+    swapMode,
+    selectedCoin,
+    inputAmountRaw,
+    allowancesLoaded,
+    walletConnected,
+  ])
 
   const runEstimations = async (mode, selectedCoin, amount) => {
     ContractStore.update((s) => {

--- a/dapp/src/stores/ContractStore.js
+++ b/dapp/src/stores/ContractStore.js
@@ -43,6 +43,7 @@ const ContractStore = new Store({
     },
   },
   chainId: parseInt(process.env.ETHEREUM_RPC_CHAIN_ID),
+  walletConnected: false,
   vaultAllocateThreshold: null,
   vaultRebaseThreshold: null,
 })

--- a/dapp/src/utils/contracts.js
+++ b/dapp/src/utils/contracts.js
@@ -516,6 +516,7 @@ export async function setupContracts(account, library, chainId) {
   ContractStore.update((s) => {
     s.contracts = contractsToExport
     s.coinInfoList = coinInfoList
+    s.walletConnected = walletConnected
   })
 
   if (process.env.ENABLE_LIQUIDITY_MINING === 'true') {


### PR DESCRIPTION
Fixes issue: https://github.com/OriginProtocol/origin-dollar/issues/745
Had a very hard time reproducing the error with just testing. But to easily reproduce the error just comment out these lines: https://github.com/OriginProtocol/origin-dollar/blob/master/dapp/src/utils/contracts.js#L39-L43
Meaning that there is a race condition possible where allowances for stablecoins are already loaded, but the swap estimator somehow still received "the old" version of contracts that didn't have a web3 provider yet set and was using Alchemy provider. (that is how you get that error by running swap estimations with Alchemy instead of web3 provider (say Metamask)

Contract change checklist:
  - [ ] Code reviewed by 2 reviewers. See [template](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) and [example](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md).
  - [ ] Unit tests pass
  - [ ] Slither tests pass with no warning
  - [ ] Echidna tests pass if PR includes changes to OUSD contract (not automated, run manually on local)
