### PR TITLE
Solidity upgrade deploy changes

### DIFF
--- a/contracts/contracts/timelock/Timelock.sol
+++ b/contracts/contracts/timelock/Timelock.sol
@@ -151,6 +151,17 @@ contract Timelock {
         emit CancelTransaction(txHash, target, signature, data, eta);
     }
 
+    function _getRevertMsg(bytes memory _returnData) internal pure returns (string memory) {
+        // If the _res length is less than 68, then the transaction failed silently (without a revert message)
+        if (_returnData.length < 68) return 'Transaction reverted silently';
+
+        assembly {
+            // Slice the sighash.
+            _returnData := add(_returnData, 0x04)
+        }
+        return abi.decode(_returnData, (string)); // All that remains is the revert string
+    }
+
     function executeTransaction(
         address target,
         string memory signature,
@@ -192,10 +203,10 @@ contract Timelock {
         }
 
         (bool success, bytes memory returnData) = target.call(callData);
-        require(
-            success,
-            "Timelock::executeTransaction: Transaction execution reverted."
-        );
+
+        if (!success) {
+            revert(_getRevertMsg(returnData));
+        }
 
         emit ExecuteTransaction(txHash, target, signature, data, eta);
 

--- a/contracts/deploy/021_solidity_upgrade.js
+++ b/contracts/deploy/021_solidity_upgrade.js
@@ -57,14 +57,20 @@ module.exports = deploymentWithProposal(
     );
     log("Transferred governance of Buyback...");
 
+    // Old strategies for removal
+    const cOldCompoundStrategyProxy = await ethers.getContract(
+      "CompoundStrategyProxy"
+    );
+    const cOldAaveStrategyProxy = await ethers.getContract("AaveStrategyProxy");
+    const cOldThreePoolStrategyProxy = await ethers.getContract(
+      "ThreePoolStrategyProxy"
+    );
     /**
      *
      * Compound strategy
      *
      */
-    const cOldCompoundStrategyProxy = await ethers.getContract(
-      "CompoundStrategyProxy"
-    );
+
     const dCompoundStrategyProxy = await deployWithConfirmation(
       "CompoundStrategyProxy",
       [],
@@ -252,16 +258,16 @@ module.exports = deploymentWithProposal(
           args: [assetAddresses.AAVE],
         },
         {
-          // Remove old Compound strategy
-          contract: cVault,
-          signature: "removeStrategy(address)",
-          args: [cOldCompoundStrategyProxy.address],
-        },
-        {
           // Approve Compound strategy in Vault
           contract: cVault,
           signature: "approveStrategy(address)",
           args: [cCompoundStrategyProxy.address],
+        },
+        {
+          // Remove the deafult strategy for DAI
+          contract: cVault,
+          signature: "setAssetDefaultStrategy(address,address)",
+          args: [assetAddresses.DAI, addresses.zero],
         },
         {
           // Add Compound as default USDT strategy
@@ -280,6 +286,24 @@ module.exports = deploymentWithProposal(
           contract: cVault,
           signature: "approveStrategy(address)",
           args: [cAaveStrategyProxy.address],
+        },
+        {
+          // Remove old Compound strategy
+          contract: cVault,
+          signature: "removeStrategy(address)",
+          args: [cOldCompoundStrategyProxy.address],
+        },
+        {
+          // Remove old Aave strategy
+          contract: cVault,
+          signature: "removeStrategy(address)",
+          args: [cOldAaveStrategyProxy.address],
+        },
+        {
+          // Remove old Aave strategy
+          contract: cVault,
+          signature: "removeStrategy(address)",
+          args: [cOldThreePoolStrategyProxy.address],
         },
         {
           // Allocate funds to newly deployed strategies


### PR DESCRIPTION
Separate PR being merged into the existing one to make it easier to review. While running through predeploy checks I found a few issues:

**Contracts**

- Can't set a default strategy to nothing, you can only set it to another existing strategy. Added code to allow setting it to the zero address.
- You could remove a strategy even while it was the default strategy for an asset, with the result that allocations will get sent to a removed strategy.
- Added a way to get revert messages from the timelock rather than a generic error

**Deployment**
- Added code to remove the old AAVE and 3pool strategies which were still approved on the Vault