### PR TITLE
Default to placing AAVE in DAI

### DIFF
--- a/contracts/deploy/028_dai_default_aave.js
+++ b/contracts/deploy/028_dai_default_aave.js
@@ -1,0 +1,39 @@
+const { deploymentWithProposal } = require("../utils/deploy");
+
+module.exports = deploymentWithProposal(
+  { deployName: "028_dai_default_aave", forceDeploy: false },
+  async ({ ethers, assetAddresses }) => {
+    const cVaultProxy = await ethers.getContract("VaultProxy");
+    const cVaultAdmin = await ethers.getContractAt(
+      "VaultAdmin",
+      cVaultProxy.address
+    );
+    const cAaveStrategyProxy = await ethers.getContract("AaveStrategyProxy");
+    const cCompoundStrategyProxy = await ethers.getContract(
+      "CompoundStrategyProxy"
+    );
+
+    return {
+      name: "Default DAI to AAVE Strategy",
+      actions: [
+        {
+          // Set DAI default to AAVE
+          contract: cVaultAdmin,
+          signature: "setAssetDefaultStrategy(address,address)",
+          args: [assetAddresses.DAI, cAaveStrategyProxy.address],
+        },
+        {
+          // Move 8 million DAI to AAVE
+          contract: cVaultAdmin,
+          signature: "reallocate(address,address,address[],uint256[])",
+          args: [
+            cCompoundStrategyProxy.address, // from
+            cAaveStrategyProxy.address, // to
+            [assetAddresses.DAI], // assets
+            [ethers.utils.parseEther("8000000")], // amounts
+          ],
+        },
+      ],
+    };
+  }
+);

--- a/contracts/deployments/mainnet/.migrations.json
+++ b/contracts/deployments/mainnet/.migrations.json
@@ -21,5 +21,8 @@
   "021_solidity_upgrade": 1633577395,
   "023_set_dai_default_strategy": 1633999707,
   "024_resolution_upgrade_start": 1635794591,
-  "025_resolution_upgrade_start": 1635806725
+  "025_resolution_upgrade_start": 1635806725,
+  "026_comp_rescue_a": 1635960232,
+  "027_comp_rescue_b": 1635960287,
+  "028_dai_default_aave": 1635960341
 }


### PR DESCRIPTION
Per this [community snapshot proposal ](https://vote.originprotocol.com/#/proposal/QmTzUJADm4XNFyoUQAAVpwzsWm1wQT8Q49uCvNAkdRYAJX) we are ready to move to using AAVE as our DAI default. 

This proposal sets AAVE to be the default DAI AAVE strategy that mints/redeems will come in and out of.

This also moves 8 million of the 8.6 million DAI we currently have on Compound over to AAVE. The entire amount is not moved since we must specify an exact amount to transfer, unless we were to pull everything out of Compound (USDT and USDC) as well and reinvest. By doing less than the full amount, we ensure this governance proposal succeeds.

We can do a later strategist action to move the remaining DAI.