### PR TITLE
Fix race condition

### DIFF
--- a/dapp/src/components/AccountListener.js
+++ b/dapp/src/components/AccountListener.js
@@ -589,6 +589,9 @@ const AccountListener = (props) => {
     }
 
     const loadLifetimeEarnings = async () => {
+      if (!account)
+        return
+
       const response = await fetch(
         `${
           process.env.ANALYTICS_ENDPOINT
@@ -643,7 +646,9 @@ const AccountListener = (props) => {
         usedLibrary = null
       }
 
-      const contracts = await setupContracts(account, usedLibrary, usedChainId)
+      window.fetchId = window.fetchId ? window.fetchId : 0
+      window.fetchId += 1
+      const contracts = await setupContracts(account, usedLibrary, usedChainId, window.fetchId)
       setContracts(contracts)
 
       setTimeout(() => {

--- a/dapp/src/components/AccountListener.js
+++ b/dapp/src/components/AccountListener.js
@@ -589,8 +589,7 @@ const AccountListener = (props) => {
     }
 
     const loadLifetimeEarnings = async () => {
-      if (!account)
-        return
+      if (!account) return
 
       const response = await fetch(
         `${
@@ -648,7 +647,12 @@ const AccountListener = (props) => {
 
       window.fetchId = window.fetchId ? window.fetchId : 0
       window.fetchId += 1
-      const contracts = await setupContracts(account, usedLibrary, usedChainId, window.fetchId)
+      const contracts = await setupContracts(
+        account,
+        usedLibrary,
+        usedChainId,
+        window.fetchId
+      )
       setContracts(contracts)
 
       setTimeout(() => {

--- a/dapp/src/constants/contractAddresses.js
+++ b/dapp/src/constants/contractAddresses.js
@@ -76,7 +76,7 @@ addresses.mainnet.WETH = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'
 
 // Deployed OUSD contracts
 addresses.mainnet.VaultProxy = '0x277e80f3E14E7fB3fc40A9d6184088e0241034bD'
-addresses.mainnet.Vault = '0xf251Cb9129fdb7e9Ca5cad097dE3eA70caB9d8F9'
+addresses.mainnet.Vault = '0xe75d77b1865ae93c7eaa3040b038d7aa7bc02f70'
 addresses.mainnet.OUSDProxy = '0x2A8e1E676Ec238d8A992307B495b45B3fEAa5e86'
 addresses.mainnet.CompoundStrategyProxy =
   '0x12115A32a19e4994C2BA4A5437C22CEf5ABb59C3'

--- a/dapp/src/stores/ContractStore.js
+++ b/dapp/src/stores/ContractStore.js
@@ -52,6 +52,7 @@ const ContractStore = new Store({
   readOnlyProvider: false,
   showAllContracts: false,
   curveMetapoolUnderlyingCoins: false,
+  fetchId: -1,
 })
 
 export default ContractStore

--- a/dapp/src/utils/connectors.js
+++ b/dapp/src/utils/connectors.js
@@ -33,8 +33,7 @@ let gnosisConnectorCache
 export const gnosisConnector = () => {
   if (!process.browser) return
 
-  if (!gnosisConnectorCache)
-    gnosisConnectorCache = new SafeAppConnector()
+  if (!gnosisConnectorCache) gnosisConnectorCache = new SafeAppConnector()
   return gnosisConnectorCache
 }
 

--- a/dapp/src/utils/connectors.js
+++ b/dapp/src/utils/connectors.js
@@ -2,6 +2,7 @@ import { InjectedConnector } from '@web3-react/injected-connector'
 import { WalletConnectConnector } from '@web3-react/walletconnect-connector'
 import { LedgerConnector } from './LedgerConnector'
 import { MewConnectConnector } from '@myetherwallet/mewconnect-connector'
+import { SafeAppConnector } from '@gnosis.pm/safe-apps-web3-react'
 
 import { providerName } from 'utils/web3'
 
@@ -26,6 +27,16 @@ const getChainId = () => {
 export const injected = new InjectedConnector({
   supportedChainIds: [1, 3, 4, 5, 42, 31337],
 })
+
+let gnosisConnectorCache
+
+export const gnosisConnector = () => {
+  if (!process.browser) return
+
+  if (!gnosisConnectorCache)
+    gnosisConnectorCache = new SafeAppConnector()
+  return gnosisConnectorCache
+}
 
 export const ledger = new LedgerConnector({
   chainId: getChainId(),
@@ -99,5 +110,10 @@ export const connectorsByName = {
     connector: walletConnect,
     displayName: 'WalletConnect',
     fileName: 'walletconnect',
+  },
+  GnosisSafe: {
+    connector: gnosisConnectorCache,
+    displayName: 'Gnosis Safe',
+    fileName: 'gnosis',
   },
 }

--- a/dapp/src/utils/contracts.js
+++ b/dapp/src/utils/contracts.js
@@ -70,7 +70,12 @@ const curveMetapoolMiniAbi = [
   },
 ]
 
-export async function setupContracts(account, library, chainId) {
+/* fetchId - used to prevent race conditions.
+ * Sometimes "setupContracts" is called twice with very little time in between and it can happen
+ * that the call issued first (for example with not yet signed in account) finishes after the second
+ * call. We must make sure that previous calls to setupContracts don't override later calls Stores
+ */
+export async function setupContracts(account, library, chainId, fetchId) {
   /* without an account logged in contracts are initialized with JsonRpcProvider and
    * can operate in a read-only mode.
    *
@@ -491,6 +496,14 @@ export async function setupContracts(account, library, chainId) {
 
   callWithDelay()
 
+  const [curveRegistryExchange, curveOUSDMetaPool, curveUnderlyingCoins] =
+    await setupCurve(curveAddressProvider, getContract, chainId)
+
+  if (ContractStore.currentState.fetchId > fetchId) {
+    console.log("Contracts already setup with newer fetchId. Exiting...")
+    return
+  }
+
   if (window.fetchInterval) {
     clearInterval(fetchInterval)
   }
@@ -501,9 +514,6 @@ export async function setupContracts(account, library, chainId) {
       callWithDelay()
     }, 20000)
   }
-
-  const [curveRegistryExchange, curveOUSDMetaPool, curveUnderlyingCoins] =
-    await setupCurve(curveAddressProvider, getContract, chainId)
 
   const contractsToExport = {
     usdt,
@@ -570,6 +580,7 @@ export async function setupContracts(account, library, chainId) {
     s.chainId = chainId
     s.readOnlyProvider = jsonRpcProvider
     s.curveMetapoolUnderlyingCoins = curveUnderlyingCoins
+    s.fetchId = fetchId
   })
 
   if (process.env.ENABLE_LIQUIDITY_MINING === 'true') {

--- a/dapp/src/utils/contracts.js
+++ b/dapp/src/utils/contracts.js
@@ -500,7 +500,7 @@ export async function setupContracts(account, library, chainId, fetchId) {
     await setupCurve(curveAddressProvider, getContract, chainId)
 
   if (ContractStore.currentState.fetchId > fetchId) {
-    console.log("Contracts already setup with newer fetchId. Exiting...")
+    console.log('Contracts already setup with newer fetchId. Exiting...')
     return
   }
 

--- a/dapp/src/utils/hooks.js
+++ b/dapp/src/utils/hooks.js
@@ -1,12 +1,12 @@
 import { useEffect, useState, useRef } from 'react'
 import { useWeb3React } from '@web3-react/core'
-import { SafeAppConnector } from '@gnosis.pm/safe-apps-web3-react'
 
 import {
   injected,
   connectorsByName,
   getConnector,
   getConnectorImage,
+  gnosisConnector
 } from './connectors'
 import AccountStore from 'stores/AccountStore'
 import analytics from 'utils/analytics'
@@ -25,13 +25,12 @@ export function useEagerConnect() {
     async function attemptSafeConnection() {
       if (!process.browser) return
 
-      // Safe multisig connector not yet initialised, wait for it
-      const safeMultisigConnector = new SafeAppConnector()
+      const gconnector = gnosisConnector()  
       // OK to use Gnosis Safe?
-      const canUseGnosisSafe = await safeMultisigConnector.isSafeApp()
+      const canUseGnosisSafe = await gconnector.isSafeApp()
 
       try {
-        await activate(safeMultisigConnector, undefined, true)
+        await activate(gconnector, undefined, true)
       } catch (error) {
         // Outside of Safe context
         console.debug(error)
@@ -39,7 +38,7 @@ export function useEagerConnect() {
         return
       }
 
-      setConnector(safeMultisigConnector)
+      setConnector(gconnector)
       setConnectorIcon('gnosis-safe-icon.svg')
 
       setIsSafeMultisig(true)

--- a/dapp/src/utils/hooks.js
+++ b/dapp/src/utils/hooks.js
@@ -6,7 +6,7 @@ import {
   connectorsByName,
   getConnector,
   getConnectorImage,
-  gnosisConnector
+  gnosisConnector,
 } from './connectors'
 import AccountStore from 'stores/AccountStore'
 import analytics from 'utils/analytics'
@@ -25,7 +25,7 @@ export function useEagerConnect() {
     async function attemptSafeConnection() {
       if (!process.browser) return
 
-      const gconnector = gnosisConnector()  
+      const gconnector = gnosisConnector()
       // OK to use Gnosis Safe?
       const canUseGnosisSafe = await gconnector.isSafeApp()
 


### PR DESCRIPTION
In Gnosis environment (maybe elsewhere as well) it would happen that `setupContracts` can be called 2 times very close together and the first call can take longer to finish than the second one. The first call also does not have information about user's account while the second one does. 

This can lead up to the first call overriding a more richer data of the second call. 

**note:**
this has already been deployed, so it is tested in production and it works...