### PR TITLE
Remove duplicated withdraw event on Compound Strategy

### DIFF
--- a/contracts/contracts/strategies/CompoundStrategy.sol
+++ b/contracts/contracts/strategies/CompoundStrategy.sol
@@ -84,8 +84,6 @@ contract CompoundStrategy is InitializableAbstractStrategy {
         require(_amount > 0, "Must withdraw something");
         require(_recipient != address(0), "Must specify recipient");
 
-        emit Withdrawal(_asset, address(assetToPToken[_asset]), _amount);
-
         ICERC20 cToken = _getCTokenFor(_asset);
         // If redeeming 0 cTokens, just skip, else COMP will revert
         uint256 cTokensToRedeem = _convertUnderlyingToCToken(cToken, _amount);


### PR DESCRIPTION
Remove duplicated withdraw event on Compound Strategy.

----

Contract change checklist:
  - [ ] Code reviewed by 2 reviewers. See [template](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) and [example](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md).
  - [ ] Unit tests pass
  - [ ] Slither tests pass with no warning
  - [ ] Echidna tests pass if PR includes changes to OUSD contract (not automated, run manually on local)
