### PR TITLE
Ledger + Uniswap updates

### DIFF
--- a/brownie/README.md
+++ b/brownie/README.md
@@ -5,6 +5,9 @@ TODO...
 
 ## Usage
 
+Set etherscan env variable token
+export ETHERSCAN_TOKEN={TOKEN_VALUE}
+
 Start console and connect to forked hardhat:
 `brownie console --network hardhat`
 


### PR DESCRIPTION
- bump `gasLimit` by 20% when swapping on Uniswap with ledger. Seems that Ledger's node sometime undervalues the gas required. Idea picked up from the Uniswap Dapp, seem that this is what they did
- for Uniswap USDT / USDC swaps use the pool with 0.01% fee instead of 0.05% one. Couldn't get the USDT / DAI 0.01% to work without throwing an error. 