### PR TITLE
defensive programming for Brave

### DIFF
--- a/dapp/src/components/buySell/SwapHomepage.js
+++ b/dapp/src/components/buySell/SwapHomepage.js
@@ -406,10 +406,12 @@ const SwapHomepage = ({
           currency: 'usd',
         })
 
-        twttr.conversion.trackPid('o73z1', {
-          tw_sale_amount: selectedRedeemCoinAmount,
-          tw_order_quantity: 1,
-        })
+        if (twttr) {
+          twttr.conversion.trackPid('o73z1', {
+            tw_sale_amount: selectedRedeemCoinAmount,
+            tw_order_quantity: 1,
+          })
+        }
       }
 
       if (localStorage.getItem('addOUSDModalShown') !== 'true') {


### PR DESCRIPTION
twttr does not get loaded up on Brave. This make the transaction not fail in the UI (even though it succeeds on chain)