### PR TITLE
Reduce the cost of harvesting from Compound by ONE MILLION GAS

### DIFF
--- a/contracts/contracts/interfaces/IComptroller.sol
+++ b/contracts/contracts/interfaces/IComptroller.sol
@@ -2,9 +2,11 @@
 pragma solidity ^0.8.0;
 
 interface IComptroller {
-    /**
-     * @notice Claim all the comp accrued by holder in all markets
-     * @param holder The address to claim COMP for
-     */
-    function claimComp(address holder) external;
+    // Claim all the COMP accrued by specific holders in specific markets for their supplies and/or borrows
+    function claimComp(
+        address[] memory holders,
+        address[] memory cTokens,
+        bool borrowers,
+        bool suppliers
+    ) external;
 }

--- a/contracts/contracts/mocks/MockComptroller.sol
+++ b/contracts/contracts/mocks/MockComptroller.sol
@@ -2,5 +2,11 @@
 pragma solidity ^0.8.0;
 
 contract MockComptroller {
-    function claimComp(address _holder) external {}
+    // Claim all the COMP accrued by specific holders in specific markets for their supplies and/or borrows
+    function claimComp(
+        address[] memory holders,
+        address[] memory cTokens,
+        bool borrowers,
+        bool suppliers
+    ) external {}
 }

--- a/contracts/deploy/035_reduce_collect_gas.js
+++ b/contracts/deploy/035_reduce_collect_gas.js
@@ -9,16 +9,10 @@ module.exports = deploymentWithProposal(
     getTxOpts,
     withConfirmation,
   }) => {
-    const { deployerAddr, governorAddr } = await getNamedAccounts();
-    const sDeployer = await ethers.provider.getSigner(deployerAddr);
-
     // Current contracts
     const cCompStratProxy = await ethers.getContract("CompoundStrategyProxy");
 
-    // Deployer Actions
-    // ----------------
-
-    // 1. Deploy new compound strategy implementation
+    // Deploy new compound strategy implementation
     const dCompoundStrategy = await deployWithConfirmation("CompoundStrategy");
 
     // Governance Actions

--- a/contracts/deploy/035_reduce_collect_gas.js
+++ b/contracts/deploy/035_reduce_collect_gas.js
@@ -24,9 +24,9 @@ module.exports = deploymentWithProposal(
     // Governance Actions
     // ----------------
     return {
-      name: "Reduce COMP collect gas useage by 80%",
+      name: "Reduce COMP rewards gas cost",
       actions: [
-        // 1. Value use new implementation
+        // 1. Compound Strategy use new implementation
         {
           contract: cCompStratProxy,
           signature: "upgradeTo(address)",

--- a/contracts/deploy/035_reduce_collect_gas.js
+++ b/contracts/deploy/035_reduce_collect_gas.js
@@ -1,0 +1,38 @@
+const { deploymentWithProposal } = require("../utils/deploy");
+
+module.exports = deploymentWithProposal(
+  { deployName: "035_reduce_collect_gas", forceDeploy: false },
+  async ({
+    assetAddresses,
+    deployWithConfirmation,
+    ethers,
+    getTxOpts,
+    withConfirmation,
+  }) => {
+    const { deployerAddr, governorAddr } = await getNamedAccounts();
+    const sDeployer = await ethers.provider.getSigner(deployerAddr);
+
+    // Current contracts
+    const cCompStratProxy = await ethers.getContract("CompoundStrategyProxy");
+
+    // Deployer Actions
+    // ----------------
+
+    // 1. Deploy new compound strategy implementation
+    const dCompoundStrategy = await deployWithConfirmation("CompoundStrategy");
+
+    // Governance Actions
+    // ----------------
+    return {
+      name: "Reduce COMP collect gas useage by 80%",
+      actions: [
+        // 1. Value use new implementation
+        {
+          contract: cCompStratProxy,
+          signature: "upgradeTo(address)",
+          args: [dCompoundStrategy.address],
+        },
+      ],
+    };
+  }
+);


### PR DESCRIPTION
By default Compound loads and calculates rewards data on every Compound ctoken when you claim, which is wildly expensive.

Per Compound documentation, we can reduce the cost of harvesting by specifying which cTokens to harvest from. As a further optimization, we can only have it do the math for supplying funds to Compound, and not look at borrowing.

https://compound.finance/docs/comptroller#claim-comp

This results in an approximately one million gas reduction per harvest.

Sample allocate() call doing AAVE, Comp, Curve rewards, allocation, and rebase:

||Gas|
|--|--|
|Old code| 2,211,636|
|New code| 1,211,135|

----

Contract change checklist:
  - [ ] Code reviewed by 2 reviewers. See [template](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) and [example](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md).
  - [x] Unit tests pass
  - [x] Slither tests pass with no warning
