### PR TITLE
automatically deploy OUSD dapp by pushing staging branch

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,53 @@
+steps:
+- id: 'Decrypt secrets required for deployment'
+  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  dir: ./dapp
+  entrypoint: gcloud
+  args:
+    - kms
+    - decrypt
+    - --ciphertext-file=./prod.secrets.enc
+    - --plaintext-file=./deploy.env
+    - --location=global
+    - --keyring=origin
+    - --key=cloudbuild
+
+- id: 'Set larger timeout'
+  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  dir: ./dapp
+  entrypoint: gcloud
+  args:
+    - config
+    - set
+    - app/cloud_build_timeout
+    - "3200"
+
+- id: 'Install contracts dependencies'
+  name: 'node:16'
+  dir: ./contracts
+  entrypoint: yarn
+  args: ['install']
+
+- id: 'Generate abis step 2'
+  name: 'node:16'
+  dir: ./contracts
+  entrypoint: yarn
+  args: ['run', 'deploy']
+
+- id: 'Install dapp dependencies'
+  name: 'node:16'
+  dir: ./dapp
+  entrypoint: yarn
+  args: ['install']
+
+- id: 'Deploy the app'
+  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  dir: ./dapp
+  entrypoint: gcloud
+  args:
+    - app
+    - deploy
+    - prod.app.yaml
+    - --quiet
+
+timeout: "3200s"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,13 +22,13 @@ steps:
     - app/cloud_build_timeout
     - "3200"
 
-- id: 'Install contracts dependencies'
+- id: 'Install contract dependencies'
   name: 'node:16'
   dir: ./contracts
   entrypoint: yarn
   args: ['install']
 
-- id: 'Generate abis step 2'
+- id: 'Generate abis adn copy to dapp folder'
   name: 'node:16'
   dir: ./contracts
   entrypoint: yarn


### PR DESCRIPTION
Makes it possible to deploy OUSD dapp by pushing stable branch.

(other part of configuration present in the GAE console [build triggers section])

Currently only these devs have permission to push stable branch: 

<img width="893" alt="Screenshot 2022-02-28 at 14 37 50" src="https://user-images.githubusercontent.com/579910/155992648-2f8e0e1b-082b-4efa-ad9a-7320e66444d3.png">

