### PR TITLE
Fix APY discrepancy

### DIFF
--- a/dapp/src/utils/contracts.js
+++ b/dapp/src/utils/contracts.js
@@ -3,7 +3,6 @@ import { ethers, Contract, BigNumber } from 'ethers'
 import ContractStore from 'stores/ContractStore'
 import PoolStore from 'stores/PoolStore'
 import CoinStore from 'stores/CoinStore'
-import { aprToApy } from 'utils/math'
 import { pools } from 'constants/Pool'
 import { displayCurrency } from 'utils/math'
 import { sleep } from 'utils/utils'
@@ -384,7 +383,7 @@ export async function setupContracts(account, library, chainId, fetchId) {
       const response = await fetch(process.env.APR_ANALYTICS_ENDPOINT)
       if (response.ok) {
         const json = await response.json()
-        const apy = aprToApy(parseFloat(json.apr), 7)
+        const apy = parseFloat(json.apy) / 100
         ContractStore.update((s) => {
           s.apy = apy
         })


### PR DESCRIPTION
I submitted a fix in utils/contracts.js to fix the discrepancy in APY between the Dapp and the Analytics page. The Dapp was fetching the 30-day trailing average APR and then converting to APY using a 7 day compounding period instead of 30. Recalculating correctly on the Dapp side can introduce some rounding errors so I fetched the already calculated APY from the Analytics side.

I was wondering whether the choice of a 30 day compounding period in calculations was due to the infrequent and unpredictable harvests. Now that this has been smoothed out a bit, would it be a good idea to decrease it?