### PR TITLE
fix: add www prefix to host check

### DIFF
--- a/dapp/src/components/IPFSDappLink.js
+++ b/dapp/src/components/IPFSDappLink.js
@@ -7,7 +7,7 @@ export default function IPFSDappLink({ dapp, css }) {
 
   useEffect(() => {
     setDisplayIpfsLink(
-      window.location.host === 'ousd.com' ||
+      ['ousd.com', 'www.ousd.com'].includes(window.location.host) ||
         window.location.host.startsWith('localhost:') ||
         window.location.host.startsWith('ousd-staging')
     )


### PR DESCRIPTION
This is a small bug fix for showing the ipfs link on: https://www.ousd.com/swap

Context: https://discord.com/channels/404673842007506945/758123420230615080/958593855459033128

Contract change checklist:
  - [ ] Code reviewed by 2 reviewers. See [template](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) and [example](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md).
  - [ ] Unit tests pass
  - [ ] Slither tests pass with no warning
  - [ ] Echidna tests pass if PR includes changes to OUSD contract (not automated, run manually on local)
