### PR TITLE
fix ledger address error

### DIFF
--- a/dapp/src/components/LedgerAccountContent.js
+++ b/dapp/src/components/LedgerAccountContent.js
@@ -9,10 +9,12 @@ const LedgerAccountContent = ({
   addresses,
   addressBalances,
   addressStableBalances,
+  activePath,
 }) => {
   const { activate, provider, connector } = useWeb3React()
 
   const onSelectAddress = async (address) => {
+    await ledgerConnector.setPath(activePath)
     ledgerConnector.setAccount(address)
 
     await activate(

--- a/dapp/src/components/LedgerDerivationContent.js
+++ b/dapp/src/components/LedgerDerivationContent.js
@@ -253,6 +253,7 @@ const LedgerDerivationContent = ({}) => {
                   addresses={addresses[activePath]}
                   addressBalances={addressBalances[activePath]}
                   addressStableBalances={addressStableBalances[activePath]}
+                  activePath={activePath}
                 />
               )}
               {!next[activePath] && !nextLoading[activePath] && (


### PR DESCRIPTION
Fix for Ledger address error. The code was setting each derivation path in sequence to extract all addresses, but on choosing an address the path wasn't being changed, so anything other than the last preloaded derivation path wasn't activated.