### PR TITLE
high slippage warning

### DIFF
--- a/dapp/src/components/buySell/SettingsDropdown.js
+++ b/dapp/src/components/buySell/SettingsDropdown.js
@@ -63,7 +63,9 @@ const SettingsDropdown = ({ setPriceToleranceValue, priceToleranceValue }) => {
                 </button>
               </div>
             </div>
-            <div className={`warning ${showWarning ? '' : 'hide'}`}>Your transaction may be frontrun</div>
+            <div className={`warning ${showWarning ? '' : 'hide'}`}>
+              Your transaction may be frontrun
+            </div>
             <div className="d-flex justify-content-between align-items-center margin-top">
               <div className="setting-title">
                 {fbt('Gas price', 'Gas price setting')}

--- a/dapp/src/components/buySell/SettingsDropdown.js
+++ b/dapp/src/components/buySell/SettingsDropdown.js
@@ -37,15 +37,8 @@ const SettingsDropdown = ({ setPriceToleranceValue, priceToleranceValue }) => {
                       let value = 0
                       if (!isNaN(e.target.value)) {
                         value = e.target.value
-                        if (value < 0) {
-                          value = 0
-                        }
-                        if (value > 1) {
-                          setShowWarning(true)
-                        }
-                        if (value > 50) {
-                          value = 50
-                        }
+                        setShowWarning(value > 1)
+                        value = value > 50 ? 50 : value
                         value = truncateDecimals(value, 2)
                         if (value !== priceToleranceValue) {
                           analytics.track('On price tolerance change', {

--- a/dapp/src/components/buySell/SettingsDropdown.js
+++ b/dapp/src/components/buySell/SettingsDropdown.js
@@ -10,7 +10,12 @@ import { truncateDecimals } from 'utils/math'
 
 const SettingsDropdown = ({ setPriceToleranceValue, priceToleranceValue }) => {
   const [settingsOpen, setSettingsOpen] = useState(false)
+  const [showWarning, setShowWarning] = useState()
   const gasPrice = useStoreState(ContractStore, (s) => s.gasPrice)
+
+  useEffect(() => {
+    setShowWarning(priceToleranceValue > 1)
+  }, [priceToleranceValue])
 
   return (
     <div className="dropdown-holder">
@@ -35,6 +40,9 @@ const SettingsDropdown = ({ setPriceToleranceValue, priceToleranceValue }) => {
                         if (value < 0) {
                           value = 0
                         }
+                        if (value > 1) {
+                          setShowWarning(true)
+                        }
                         if (value > 50) {
                           value = 50
                         }
@@ -55,12 +63,14 @@ const SettingsDropdown = ({ setPriceToleranceValue, priceToleranceValue }) => {
                   className="w-50 d-flex align-items-center justify-content-center auto"
                   onClick={() => {
                     setPriceToleranceValue(0.5)
+                    setShowWarning(false)
                   }}
                 >
                   AUTO
                 </button>
               </div>
             </div>
+            <div className={`warning ${showWarning ? '' : 'hide'}`}>Your transaction may be frontrun</div>
             <div className="d-flex justify-content-between align-items-center margin-top">
               <div className="setting-title">
                 {fbt('Gas price', 'Gas price setting')}
@@ -169,6 +179,16 @@ const SettingsDropdown = ({ setPriceToleranceValue, priceToleranceValue }) => {
           text-align: center;
           border-radius: 5px 0 0 5px;
           background-color: #f2f3f5;
+        }
+
+        .warning {
+          font-size: 14px;
+          color: #ff8000;
+          margin-top: 10px;
+        }
+
+        .warning.hide {
+          display: none;
         }
 
         .gwei {


### PR DESCRIPTION
High slippage warning when input is larger than 1%.

I've not added any explanation bubbles, to not clutter the settings box further, and with the live 'min received' field sort of serving that purpose, but happy to add some if needed.

<img width="512" alt="Screenshot 2022-04-11 at 13 08 18" src="https://user-images.githubusercontent.com/62400812/162736246-cf399a45-de4f-4c4b-991d-aaceab97cad9.png">