### PR TITLE
fix input flipping

### DIFF
--- a/dapp/next.config.js
+++ b/dapp/next.config.js
@@ -9,7 +9,7 @@ let envFile = 'local.env'
 /*
  * Environmental variables are inserted into the code at the next build step. So it doesn't matter what
  * env variables the production instance has, because the vars have already been inserted and replaced at
- * build step. For that reason we decode production and staging all into deploy.env and have google instaces
+ * build step. For that reason we decode production and staging all into deploy.env and have google instances
  * read from that env file.
  */
 if (isProduction || isStaging) {

--- a/dapp/src/components/buySell/SwapHomepage.js
+++ b/dapp/src/components/buySell/SwapHomepage.js
@@ -202,8 +202,8 @@ const SwapHomepage = ({
       if (selectedSwap) {
         const otherCoinAmount =
           Math.floor(selectedSwap.amountReceived * 1000000) / 1000000
-        setSelectedBuyCoinAmount(otherCoinAmount)
-        setSelectedRedeemCoinAmount(otherCoinAmount)
+        setSelectedBuyCoinAmount(Math.floor(otherCoinAmount * 100) / 100)
+        setSelectedRedeemCoinAmount(Math.floor(otherCoinAmount * 100) / 100)
       }
     }
   }, [swapMode])

--- a/dapp/src/components/buySell/SwapHomepage.js
+++ b/dapp/src/components/buySell/SwapHomepage.js
@@ -203,7 +203,7 @@ const SwapHomepage = ({
         const otherCoinAmount =
           Math.floor(selectedSwap.amountReceived * 1000000) / 1000000
         setSelectedBuyCoinAmount(otherCoinAmount)
-        setSelectedRedeemCoinAmount(selectedBuyCoinAmount)
+        setSelectedRedeemCoinAmount(otherCoinAmount)
       }
     }
   }, [swapMode])


### PR DESCRIPTION
Small follow-up on what @micahalcorn was talking about in #655. On clicking the flip arrow the previous output becomes the input on either swap direction change.

To be fair I think this change might make changing the swap mode through clicking on OUSD in the dropdown menu less intuitive so appreciate any thoughts. It might not even be necessary