### PR TITLE
change error message placement

### DIFF
--- a/dapp/src/components/buySell/ApproveSwap.js
+++ b/dapp/src/components/buySell/ApproveSwap.js
@@ -30,8 +30,14 @@ const ApproveSwap = ({
   const { library, account } = web3react
   const coinApproved = stage === 'done'
   const formHasErrors = formError !== null
-  const approvalNeeded = (selectedSwap && !formHasErrors && !swappingGloballyDisabled && allowancesLoaded && needsApproval) || coinApproved
-  
+  const approvalNeeded =
+    (selectedSwap &&
+      !formHasErrors &&
+      !swappingGloballyDisabled &&
+      allowancesLoaded &&
+      needsApproval) ||
+    coinApproved
+
   useEffect(() => {
     ContractStore.update((s) => {
       s.approvalNeeded = approvalNeeded
@@ -242,7 +248,8 @@ const ApproveSwap = ({
           onClick={onSwap}
         >
           {swappingGloballyDisabled && process.env.DISABLE_SWAP_BUTTON_MESSAGE}
-          {!swappingGloballyDisabled && (formHasErrors ? formError : fbt('Swap', 'Swap'))}
+          {!swappingGloballyDisabled &&
+            (formHasErrors ? formError : fbt('Swap', 'Swap'))}
         </button>
       </div>
       <style jsx>{`

--- a/dapp/src/components/buySell/ApproveSwap.js
+++ b/dapp/src/components/buySell/ApproveSwap.js
@@ -16,7 +16,8 @@ const ApproveSwap = ({
   onSwap,
   allowancesLoaded,
   onMintingError,
-  formError,
+  balanceError,
+  swapsLoaded,
   swappingGloballyDisabled,
   storeTransaction,
   storeTransactionError,
@@ -29,10 +30,9 @@ const ApproveSwap = ({
   const web3react = useWeb3React()
   const { library, account } = web3react
   const coinApproved = stage === 'done'
-  const formHasErrors = formError !== null
   const approvalNeeded =
     (selectedSwap &&
-      !formHasErrors &&
+      !balanceError &&
       !swappingGloballyDisabled &&
       allowancesLoaded &&
       needsApproval) ||
@@ -169,6 +169,28 @@ const ApproveSwap = ({
     )
   }
 
+  const SwapMessage = ({balanceError, stableCoinToApprove, swapsLoaded, selectedSwap, swappingGloballyDisabled}) => {
+    const coin = stableCoinToApprove.toUpperCase()
+    const noSwapRouteAvailable = swapsLoaded && !selectedSwap
+    if (swappingGloballyDisabled) {
+      return process.env.DISABLE_SWAP_BUTTON_MESSAGE
+    } else if (balanceError) {
+      return fbt(
+        'Insufficient ' +
+          fbt.param('coin', coin) +
+          ' balance',
+        'Insufficient balance for swapping'
+      )
+    } else if (noSwapRouteAvailable) {
+      return fbt(
+        'Route for selected swap not available',
+        'No route available for selected swap'
+      )
+    } else {
+      return fbt('Swap', 'Swap')
+    }
+  }
+
   return (
     <>
       <button
@@ -241,15 +263,18 @@ const ApproveSwap = ({
           className={`btn-blue buy-button mt-2 mt-md-0 w-100`}
           disabled={
             !selectedSwap ||
-            formHasErrors ||
+            balanceError ||
             swappingGloballyDisabled ||
             (needsApproval && !coinApproved)
           }
           onClick={onSwap}
         >
-          {swappingGloballyDisabled && process.env.DISABLE_SWAP_BUTTON_MESSAGE}
-          {!swappingGloballyDisabled &&
-            (formHasErrors ? formError : fbt('Swap', 'Swap'))}
+          <SwapMessage
+            balanceError={balanceError}
+            stableCoinToApprove={stableCoinToApprove}
+            swapsLoaded={swapsLoaded}
+            selectedSwap={selectedSwap}
+          />
         </button>
       </div>
       <style jsx>{`

--- a/dapp/src/components/buySell/ApproveSwap.js
+++ b/dapp/src/components/buySell/ApproveSwap.js
@@ -169,16 +169,20 @@ const ApproveSwap = ({
     )
   }
 
-  const SwapMessage = ({balanceError, stableCoinToApprove, swapsLoaded, selectedSwap, swappingGloballyDisabled}) => {
+  const SwapMessage = ({
+    balanceError,
+    stableCoinToApprove,
+    swapsLoaded,
+    selectedSwap,
+    swappingGloballyDisabled,
+  }) => {
     const coin = stableCoinToApprove.toUpperCase()
     const noSwapRouteAvailable = swapsLoaded && !selectedSwap
     if (swappingGloballyDisabled) {
       return process.env.DISABLE_SWAP_BUTTON_MESSAGE
     } else if (balanceError) {
       return fbt(
-        'Insufficient ' +
-          fbt.param('coin', coin) +
-          ' balance',
+        'Insufficient ' + fbt.param('coin', coin) + ' balance',
         'Insufficient balance for swapping'
       )
     } else if (noSwapRouteAvailable) {

--- a/dapp/src/components/buySell/ApproveSwap.js
+++ b/dapp/src/components/buySell/ApproveSwap.js
@@ -16,7 +16,7 @@ const ApproveSwap = ({
   onSwap,
   allowancesLoaded,
   onMintingError,
-  formHasErrors,
+  formError,
   swappingGloballyDisabled,
   storeTransaction,
   storeTransactionError,
@@ -29,18 +29,12 @@ const ApproveSwap = ({
   const web3react = useWeb3React()
   const { library, account } = web3react
   const coinApproved = stage === 'done'
-
-  const approvalNeeded =
-    (!selectedSwap ||
-      formHasErrors ||
-      swappingGloballyDisabled ||
-      !allowancesLoaded ||
-      !needsApproval) &&
-    !coinApproved
-
+  const formHasErrors = formError !== null
+  const approvalNeeded = (selectedSwap && !formHasErrors && !swappingGloballyDisabled && allowancesLoaded && needsApproval) || coinApproved
+  
   useEffect(() => {
     ContractStore.update((s) => {
-      s.approvalNeeded = !approvalNeeded
+      s.approvalNeeded = approvalNeeded
     })
   }, [approvalNeeded])
 
@@ -173,7 +167,7 @@ const ApproveSwap = ({
     <>
       <button
         className={`btn-blue buy-button mt-4 mt-md-3 w-100`}
-        hidden={approvalNeeded}
+        hidden={!approvalNeeded}
         disabled={coinApproved}
         onClick={async () => {
           if (stage === 'approve' && contract) {
@@ -248,7 +242,7 @@ const ApproveSwap = ({
           onClick={onSwap}
         >
           {swappingGloballyDisabled && process.env.DISABLE_SWAP_BUTTON_MESSAGE}
-          {!swappingGloballyDisabled && fbt('Swap', 'Swap')}
+          {!swappingGloballyDisabled && (formHasErrors ? formError : fbt('Swap', 'Swap'))}
         </button>
       </div>
       <style jsx>{`

--- a/dapp/src/components/buySell/SwapCurrencyPill.js
+++ b/dapp/src/components/buySell/SwapCurrencyPill.js
@@ -328,7 +328,12 @@ const SwapCurrencyPill = ({
 
     setError(
       parseFloat(coinBalances[coin]) < parseFloat(coinValue)
-        ? fbt('Insufficient ' + fbt.param('coin', coin.toUpperCase()) + ' balance', 'Insufficient balance for swapping')
+        ? fbt(
+            'Insufficient ' +
+              fbt.param('coin', coin.toUpperCase()) +
+              ' balance',
+            'Insufficient balance for swapping'
+          )
         : null
     )
   }

--- a/dapp/src/components/buySell/SwapCurrencyPill.js
+++ b/dapp/src/components/buySell/SwapCurrencyPill.js
@@ -326,16 +326,7 @@ const SwapCurrencyPill = ({
 
     const coin = swapMode === 'mint' ? selectedCoin : 'ousd'
 
-    setError(
-      parseFloat(coinBalances[coin]) < parseFloat(coinValue)
-        ? fbt(
-            'Insufficient ' +
-              fbt.param('coin', coin.toUpperCase()) +
-              ' balance',
-            'Insufficient balance for swapping'
-          )
-        : null
-    )
+    setError(parseFloat(coinBalances[coin]) < parseFloat(coinValue))
   }
 
   const displayBalance = getDisplayBalance()
@@ -367,7 +358,6 @@ const SwapCurrencyPill = ({
     displayBalance &&
     !maxBalanceSet &&
     parseFloat(displayBalance.balance) > 0
-  const noSwapRouteAvailable = swapsLoaded && !selectedSwap
 
   const onMaxBalanceClick = (e) => {
     e.preventDefault()
@@ -468,14 +458,6 @@ const SwapCurrencyPill = ({
                   : '-'}
               </div>
             )}
-            {bottomItem && noSwapRouteAvailable && (
-              <div className="error">
-                {fbt(
-                  'Route for selected swap not available',
-                  'no route available for selected swap'
-                )}
-              </div>
-            )}
           </div>
         </div>
         {coinSplits && (
@@ -514,12 +496,6 @@ const SwapCurrencyPill = ({
         .balance {
           font-size: 12px;
           color: #8293a4;
-          margin-left: 4px;
-        }
-
-        .error {
-          font-size: 12px;
-          color: #ed2a28;
           margin-left: 4px;
         }
 

--- a/dapp/src/components/buySell/SwapCurrencyPill.js
+++ b/dapp/src/components/buySell/SwapCurrencyPill.js
@@ -5,8 +5,6 @@ import { fbt } from 'fbt-runtime'
 import AccountStore from 'stores/AccountStore'
 import Dropdown from 'components/Dropdown'
 import DownCaret from 'components/DownCaret'
-import { usePrevious } from 'utils/hooks'
-import analytics from 'utils/analytics'
 import {
   formatCurrency,
   formatCurrencyMinMaxDecimals,
@@ -14,8 +12,8 @@ import {
   checkValidInputForCoin,
   removeCommas,
 } from 'utils/math'
-import { currencies } from 'constants/Contract'
 import { assetRootPath } from 'utils/image'
+import { _ } from 'fbt-runtime/lib/fbt'
 
 const CoinImage = ({ small, coin, isSemiTransparent = false }) => {
   const className = `coin-image ${isSemiTransparent ? 'transparent' : ''}`
@@ -330,7 +328,7 @@ const SwapCurrencyPill = ({
 
     setError(
       parseFloat(coinBalances[coin]) < parseFloat(coinValue)
-        ? fbt('Insufficient balance', 'Insufficient balance for swapping')
+        ? fbt('Insufficient ' + fbt.param('coin', coin.toUpperCase()) + ' balance', 'Insufficient balance for swapping')
         : null
     )
   }
@@ -442,7 +440,6 @@ const SwapCurrencyPill = ({
                 }}
               />
             )}
-            {topItem && error && <div className="error">{error}</div>}
             {bottomItem && (
               <div className="expected-value">
                 {expectedAmount ||

--- a/dapp/src/components/buySell/SwapHomepage.js
+++ b/dapp/src/components/buySell/SwapHomepage.js
@@ -1,15 +1,11 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect } from 'react'
 import { fbt } from 'fbt-runtime'
 import { useStoreState } from 'pullstate'
-import { ethers, BigNumber } from 'ethers'
-import { get, find } from 'lodash'
 
 import AccountStore from 'stores/AccountStore'
-import TransactionStore from 'stores/TransactionStore'
 import ContractStore from 'stores/ContractStore'
 import AddOUSDModal from 'components/buySell/AddOUSDModal'
 import ErrorModal from 'components/buySell/ErrorModal'
-import DisclaimerTooltip from 'components/buySell/DisclaimerTooltip'
 import { currencies } from 'constants/Contract'
 import { providersNotAutoDetectingOUSD, providerName } from 'utils/web3'
 import withRpcProvider from 'hoc/withRpcProvider'
@@ -18,22 +14,17 @@ import useCurrencySwapper from 'hooks/useCurrencySwapper'
 import SwapCurrencyPill from 'components/buySell/SwapCurrencyPill'
 import PillArrow from 'components/buySell/_PillArrow'
 import SettingsDropdown from 'components/buySell/SettingsDropdown'
-import { isMobileMetaMask } from 'utils/device'
 import useSwapEstimator from 'hooks/useSwapEstimator'
 import withIsMobile from 'hoc/withIsMobile'
 import { getUserSource } from 'utils/user'
 import usePrevious from 'utils/usePrevious'
-import LinkIcon from 'components/buySell/_LinkIcon'
-import { connectorNameIconMap, getConnectorIcon } from 'utils/connectors'
 import ApproveSwap from 'components/buySell/ApproveSwap'
 
 import analytics from 'utils/analytics'
 import {
-  truncateDecimals,
   formatCurrencyMinMaxDecimals,
   removeCommas,
 } from '../../utils/math'
-import { assetRootPath } from 'utils/image'
 
 let ReactPixel
 if (process.browser) {
@@ -49,30 +40,10 @@ const SwapHomepage = ({
   rpcProvider,
   isMobile,
 }) => {
-  const allowances = useStoreState(AccountStore, (s) => s.allowances)
-  const pendingMintTransactions = useStoreState(TransactionStore, (s) =>
-    s.transactions.filter((tx) => !tx.mined && tx.type === 'mint')
-  )
-  const balances = useStoreState(AccountStore, (s) => s.balances)
-  const ousdExchangeRates = useStoreState(
-    ContractStore,
-    (s) => s.ousdExchangeRates
-  )
   const swapEstimations = useStoreState(ContractStore, (s) => s.swapEstimations)
   const swapsLoaded = swapEstimations && typeof swapEstimations === 'object'
   const selectedSwap = useStoreState(ContractStore, (s) => s.selectedSwap)
 
-  const [displayedOusdToSell, setDisplayedOusdToSell] = useState('')
-  const [ousdToSell, setOusdToSell] = useState(0)
-  const [sellAllActive, setSellAllActive] = useState(false)
-  const [generalErrorReason, setGeneralErrorReason] = useState(null)
-  const [sellWidgetIsCalculating, setSellWidgetIsCalculating] = useState(false)
-  const [sellWidgetCoinSplit, setSellWidgetCoinSplit] = useState([])
-  // redeem now, waiting-user, waiting-network
-  const [sellWidgetState, setSellWidgetState] = useState('redeem now')
-  const [sellWidgetSplitsInterval, setSellWidgetSplitsInterval] = useState(null)
-  // buy/modal-buy, waiting-user/modal-waiting-user, waiting-network/modal-waiting-network
-  const [priceToleranceOpen, setPriceToleranceOpen] = useState(false)
   // mint / redeem
   const [swapMode, setSwapMode] = useState(
     localStorage.getItem(lastSelectedSwapModeKey) || 'mint'
@@ -92,37 +63,13 @@ const SwapHomepage = ({
   const [selectedRedeemCoin, setSelectedRedeemCoin] = useState(
     defaultSelectedCoinValue
   )
-
   const [selectedBuyCoinAmount, setSelectedBuyCoinAmount] = useState('')
   const [selectedRedeemCoinAmount, setSelectedRedeemCoinAmount] = useState('')
-  const [showApproveModal, _setShowApproveModal] = useState(false)
-  const {
-    vault: vaultContract,
-    usdt: usdtContract,
-    dai: daiContract,
-    usdc: usdcContract,
-    ousd: ousdContract,
-    flipper,
-  } = useStoreState(ContractStore, (s) => s.contracts || {})
-
   const [formError, setFormError] = useState(null)
-  const [buyFormWarnings, setBuyFormWarnings] = useState({})
-  const totalStablecoins =
-    parseFloat(balances['dai']) +
-    parseFloat(balances['usdt']) +
-    parseFloat(balances['usdc'])
-  const stableCoinsLoaded =
-    typeof balances['dai'] === 'string' &&
-    typeof balances['usdt'] === 'string' &&
-    typeof balances['usdc'] === 'string'
   const { setPriceToleranceValue, priceToleranceValue } =
     usePriceTolerance('mint')
 
   const swappingGloballyDisabled = process.env.DISABLE_SWAP_BUTTON === 'true'
-  const formHasErrors = formError !== null
-  const buyFormHasWarnings = buyFormWarnings !== null
-  const connectorName = useStoreState(AccountStore, (s) => s.connectorName)
-  const connectorIcon = getConnectorIcon(connectorName)
   const addOusdModalState = useStoreState(
     AccountStore,
     (s) => s.addOusdModalState
@@ -227,47 +174,6 @@ const SwapHomepage = ({
     localStorage.setItem(lastUserSelectedCoinKey, coin)
     setSelectedRedeemCoin(coin)
   }
-
-  // check if form should display any warnings
-  useEffect(() => {
-    if (pendingMintTransactions.length > 0) {
-      if (swapMode === 'mint') {
-        const allPendingCoins = pendingMintTransactions
-          .map((tx) => tx.data)
-          .reduce(
-            (a, b) => {
-              return {
-                dai: parseFloat(a.dai) + parseFloat(b.dai),
-                usdt: parseFloat(a.usdt) + parseFloat(b.usdt),
-                usdc: parseFloat(a.usdc) + parseFloat(b.usdc),
-              }
-            },
-            {
-              dai: 0,
-              usdt: 0,
-              usdc: 0,
-            }
-          )
-
-        if (
-          parseFloat(selectedBuyCoinAmount) >
-          parseFloat(balances[selectedBuyCoin]) -
-            parseFloat(allPendingCoins[selectedBuyCoin])
-        ) {
-          setBuyFormWarnings('not_have_enough')
-        } else {
-          setBuyFormWarnings(null)
-        }
-      }
-    } else {
-      setBuyFormWarnings(null)
-    }
-  }, [
-    swapMode,
-    selectedBuyCoin,
-    selectedBuyCoinAmount,
-    pendingMintTransactions,
-  ])
 
   const errorMap = [
     {
@@ -445,13 +351,6 @@ const SwapHomepage = ({
             }}
           />
         )}
-        {generalErrorReason && (
-          <ErrorModal
-            reason={generalErrorReason}
-            showRefreshButton={true}
-            onClose={() => {}}
-          />
-        )}
         {buyErrorToDisplay && (
           <ErrorModal
             error={buyErrorToDisplay}
@@ -495,7 +394,7 @@ const SwapHomepage = ({
           onSwap={() => onSwapOusd()}
           allowancesLoaded={allowancesLoaded}
           onMintingError={onMintingError}
-          formHasErrors={formHasErrors}
+          formError={formError}
           swappingGloballyDisabled={swappingGloballyDisabled}
         />
       </div>

--- a/dapp/src/components/buySell/SwapHomepage.js
+++ b/dapp/src/components/buySell/SwapHomepage.js
@@ -62,7 +62,7 @@ const SwapHomepage = ({
   )
   const [selectedBuyCoinAmount, setSelectedBuyCoinAmount] = useState('')
   const [selectedRedeemCoinAmount, setSelectedRedeemCoinAmount] = useState('')
-  const [formError, setFormError] = useState(null)
+  const [balanceError, setBalanceError] = useState(null)
   const { setPriceToleranceValue, priceToleranceValue } =
     usePriceTolerance('mint')
 
@@ -371,13 +371,12 @@ const SwapHomepage = ({
           }
           onSelectChange={userSelectsBuyCoin}
           topItem
-          onErrorChange={setFormError}
+          onErrorChange={setBalanceError}
         />
         <PillArrow swapMode={swapMode} setSwapMode={setSwapMode} />
         <SwapCurrencyPill
           swapMode={swapMode}
           selectedSwap={selectedSwap}
-          swapsLoaded={swapsLoaded}
           swapsLoading={swapEstimations === 'loading'}
           priceToleranceValue={priceToleranceValue}
           selectedCoin={selectedRedeemCoin}
@@ -391,7 +390,8 @@ const SwapHomepage = ({
           onSwap={() => onSwapOusd()}
           allowancesLoaded={allowancesLoaded}
           onMintingError={onMintingError}
-          formError={formError}
+          balanceError={balanceError}
+          swapsLoaded={swapsLoaded}
           swappingGloballyDisabled={swappingGloballyDisabled}
         />
       </div>

--- a/dapp/src/components/buySell/SwapHomepage.js
+++ b/dapp/src/components/buySell/SwapHomepage.js
@@ -21,10 +21,7 @@ import usePrevious from 'utils/usePrevious'
 import ApproveSwap from 'components/buySell/ApproveSwap'
 
 import analytics from 'utils/analytics'
-import {
-  formatCurrencyMinMaxDecimals,
-  removeCommas,
-} from '../../utils/math'
+import { formatCurrencyMinMaxDecimals, removeCommas } from '../../utils/math'
 
 let ReactPixel
 if (process.browser) {


### PR DESCRIPTION
Changing the error message placement for insufficient balance and nonavailable routes from the input fields to instead replace the text on the disabled swap button as in #658
Also some general cleanup in the approve/swap files