### PR TITLE
max including dust + unsupported contract estimation

### DIFF
--- a/dapp/pages/history.js
+++ b/dapp/pages/history.js
@@ -40,7 +40,7 @@ export default function History({ locale, onLocale }) {
         .home {
           padding-top: 20px;
         }
-        
+
         .empty-placeholder {
           min-height: 470px;
           height: 100%;

--- a/dapp/pages/history.js
+++ b/dapp/pages/history.js
@@ -16,7 +16,7 @@ export default function History({ locale, onLocale }) {
     <>
       <Layout locale={locale} onLocale={onLocale} dapp>
         <Nav dapp page={'history'} locale={locale} onLocale={onLocale} />
-        <div className="d-flex flex-column p-0 pt-md-5">
+        <div className="home d-flex flex-column">
           <BalanceHeader />
           {active && <TransactionHistory />}
           {!active && (
@@ -37,6 +37,10 @@ export default function History({ locale, onLocale }) {
         </div>
       </Layout>
       <style jsx>{`
+        .home {
+          padding-top: 20px;
+        }
+        
         .empty-placeholder {
           min-height: 470px;
           height: 100%;

--- a/dapp/src/components/buySell/ContractsTable.js
+++ b/dapp/src/components/buySell/ContractsTable.js
@@ -279,7 +279,7 @@ const ContractsTable = () => {
                   {swapContract.name}
                 </div>
                 <div className="value-cell d-none d-md-block text-right">
-                  {loadingOrEmpty
+                  {loadingOrEmpty || !canDoSwap
                     ? '-'
                     : formatCurrency(estimation.amountReceived, 2)}
                 </div>

--- a/dapp/src/components/buySell/SwapCurrencyPill.js
+++ b/dapp/src/components/buySell/SwapCurrencyPill.js
@@ -348,7 +348,12 @@ const SwapCurrencyPill = ({
   const coinSplits = bottomItem && selectedSwap && selectedSwap.coinSplits
 
   useEffect(() => {
-    if (maxBalanceSet && Number(removeCommas(roundTo2to6Decimals(displayBalance.detailedBalance))) !== Number(removeCommas(roundTo2to6Decimals(coinValue)))) {
+    if (
+      maxBalanceSet &&
+      Number(
+        removeCommas(roundTo2to6Decimals(displayBalance.detailedBalance))
+      ) !== Number(removeCommas(roundTo2to6Decimals(coinValue)))
+    ) {
       setMaxBalanceSet(false)
     }
   }, [coinValue])
@@ -370,7 +375,9 @@ const SwapCurrencyPill = ({
   }
 
   const formatMax = (value) => {
-    return maxBalanceSet && parseFloat(displayBalance.balance) > 0 ? removeCommas(roundTo2to6Decimals(value)) : value
+    return maxBalanceSet && parseFloat(displayBalance.balance) > 0
+      ? removeCommas(roundTo2to6Decimals(value))
+      : value
   }
 
   return (
@@ -429,15 +436,16 @@ const SwapCurrencyPill = ({
                   const value = truncateDecimals(e.target.value)
                   const valueNoCommas = removeCommas(value)
                   if (checkValidInputForCoin(valueNoCommas, selectedCoin)) {
-                    if (maxBalanceSet && e.target.value === value) setMaxBalanceSet(false)
+                    if (maxBalanceSet && e.target.value === value)
+                      setMaxBalanceSet(false)
                     onAmountChange(valueNoCommas)
                   }
-                  
                 }}
                 onBlur={(e) => {
                   setMaxBalanceSet(
                     displayBalance &&
-                    Number(displayBalance.detailedBalance) === Number(coinValue)
+                      Number(displayBalance.detailedBalance) ===
+                        Number(coinValue)
                   )
                   const valueRounded = removeCommas(
                     roundTo2to6Decimals(coinValue)

--- a/dapp/src/components/buySell/SwapCurrencyPill.js
+++ b/dapp/src/components/buySell/SwapCurrencyPill.js
@@ -432,7 +432,6 @@ const SwapCurrencyPill = ({
                 value={formatMax(coinValue)}
                 placeholder="0.00"
                 onChange={(e) => {
-                  console.log('change')
                   const value = truncateDecimals(e.target.value)
                   const valueNoCommas = removeCommas(value)
                   if (checkValidInputForCoin(valueNoCommas, selectedCoin)) {
@@ -442,11 +441,16 @@ const SwapCurrencyPill = ({
                   }
                 }}
                 onBlur={(e) => {
-                  setMaxBalanceSet(
+                  if (
                     displayBalance &&
-                      Number(displayBalance.detailedBalance) ===
-                        Number(coinValue)
-                  )
+                    Number(displayBalance.detailedBalance) === Number(coinValue)
+                  ) {
+                    setMaxBalanceSet(true)
+                  } else {
+                    setMaxBalanceSet(false)
+                    onAmountChange(coinValue)
+                    return
+                  }
                   const valueRounded = removeCommas(
                     roundTo2to6Decimals(coinValue)
                   )


### PR DESCRIPTION
Changes for including all decimal places when selecting max balance on swap page for issue #652, and estimate display change for issue #653.
The max balance code might seem a bit overly complex, but I think it's needed to cover all the weird formatting edge cases.