### PR TITLE
preloading history

### DIFF
--- a/dapp/src/components/AccountListener.js
+++ b/dapp/src/components/AccountListener.js
@@ -21,6 +21,7 @@ import { isProduction, isDevelopment } from 'constants/env'
 import useBalancesQuery from '../queries/useBalancesQuery'
 import useAllowancesQuery from '../queries/useAllowancesQuery'
 import useApyQuery from '../queries/useApyQuery'
+import useTransactionHistoryQuery from '../queries/useTransactionHistoryQuery'
 
 const AccountListener = (props) => {
   const web3react = useWeb3React()
@@ -62,6 +63,15 @@ const AccountListener = (props) => {
         s.apy = apy
       })
     },
+  })
+
+  const historyQuery = useTransactionHistoryQuery(account, {
+    onSuccess: (history) => {
+      AccountStore.update((s) => {
+        s.history = history,
+        s.historyIsLoading = false
+      })
+    }
   })
 
   useEffect(() => {
@@ -344,6 +354,7 @@ const AccountListener = (props) => {
     } else {
       balancesQuery.refetch()
       allowancesQuery.refetch()
+      historyQuery.refetch()
 
       await Promise.all([
         loadRebaseStatus(),
@@ -431,7 +442,7 @@ const AccountListener = (props) => {
   }, [userActive, contracts, refetchUserData, prevRefetchUserData])
 
   useEffect(() => {
-    // trigger a force referch user data when the flag is set by a user
+    // trigger a force refetch user data when the flag is set by a user
     if (
       (contracts && isCorrectNetwork(chainId),
       refetchStakingData && !prevRefetchStakingData)

--- a/dapp/src/components/AccountListener.js
+++ b/dapp/src/components/AccountListener.js
@@ -65,13 +65,7 @@ const AccountListener = (props) => {
     },
   })
 
-  const historyQuery = useTransactionHistoryQuery(account, {
-    onSuccess: (history) => {
-      AccountStore.update((s) => {
-        ;(s.history = history), (s.historyIsLoading = false)
-      })
-    },
-  })
+  const historyQuery = useTransactionHistoryQuery(account)
 
   useEffect(() => {
     if ((prevActive && !active) || prevAccount !== account) {
@@ -353,7 +347,6 @@ const AccountListener = (props) => {
     } else {
       balancesQuery.refetch()
       allowancesQuery.refetch()
-      historyQuery.refetch()
 
       await Promise.all([
         loadRebaseStatus(),
@@ -367,6 +360,7 @@ const AccountListener = (props) => {
   useEffect(() => {
     if (account) {
       login(account, setCookie)
+      historyQuery.refetch()
     }
 
     const loadLifetimeEarnings = async () => {

--- a/dapp/src/components/AccountListener.js
+++ b/dapp/src/components/AccountListener.js
@@ -68,10 +68,9 @@ const AccountListener = (props) => {
   const historyQuery = useTransactionHistoryQuery(account, {
     onSuccess: (history) => {
       AccountStore.update((s) => {
-        s.history = history,
-        s.historyIsLoading = false
+        ;(s.history = history), (s.historyIsLoading = false)
       })
-    }
+    },
   })
 
   useEffect(() => {

--- a/dapp/src/components/TransactionHistory.js
+++ b/dapp/src/components/TransactionHistory.js
@@ -11,7 +11,10 @@ import { exportToCsv, sleep } from '../utils/utils'
 import withIsMobile from 'hoc/withIsMobile'
 import { assetRootPath } from 'utils/image'
 
+import AccountStore from 'stores/AccountStore'
+import { useStoreState } from 'pullstate'
 import useTransactionHistoryQuery from '../queries/useTransactionHistoryQuery'
+import { xor } from 'lodash'
 
 const itemsPerPage = 50
 
@@ -119,15 +122,12 @@ const FormatCurrencyByImportance = ({
 }
 
 const TransactionHistory = ({ isMobile }) => {
-  const web3react = useWeb3React()
-  const router = useRouter()
-  const { account: web3Account, active } = web3react
   const [filters, _setFilters] = useState([])
   const [currentPage, setCurrentPage] = useState(1)
   const [pageNumbers, setPageNumbers] = useState([])
 
-  const overrideAccount = router.query.override_account
-  const account = overrideAccount || web3Account
+  const history = useStoreState(AccountStore, (s) => s.history)
+  const isLoading = useStoreState(AccountStore, (s) => s.historyIsLoading)
 
   const txTypeMap = {
     yield: {
@@ -185,13 +185,6 @@ const TransactionHistory = ({ isMobile }) => {
     setCurrentPage(1)
   }
 
-  const historyQuery = useTransactionHistoryQuery(account)
-
-  const history = useMemo(
-    () => (historyQuery.isSuccess ? historyQuery.data : []),
-    [historyQuery.isSuccess, historyQuery.data]
-  )
-
   const shownHistory = useMemo(() => {
     if (filters.length === 0) {
       return history
@@ -207,6 +200,7 @@ const TransactionHistory = ({ isMobile }) => {
   }, [history, filters])
 
   useEffect(() => {
+    //console.log(history)
     const length = shownHistory.length
     const pages = Math.ceil(length / itemsPerPage)
 
@@ -244,7 +238,7 @@ const TransactionHistory = ({ isMobile }) => {
   return (
     <>
       <div className="d-flex holder flex-column justify-content-start">
-        {historyQuery.isLoading ? (
+        {isLoading ? (
           <div className="m-4">{fbt('Loading...', 'Loading...')}</div>
         ) : (
           <>

--- a/dapp/src/components/TransactionHistory.js
+++ b/dapp/src/components/TransactionHistory.js
@@ -1,10 +1,8 @@
 import React, { useEffect, useState, useMemo } from 'react'
-import { useRouter } from 'next/router'
 import dateformat from 'dateformat'
 import EtherscanLink from 'components/earn/EtherscanLink'
 
 import { fbt } from 'fbt-runtime'
-import { useWeb3React } from '@web3-react/core'
 import { formatCurrency } from '../utils/math'
 import { shortenAddress } from '../utils/web3'
 import { exportToCsv, sleep } from '../utils/utils'
@@ -13,8 +11,6 @@ import { assetRootPath } from 'utils/image'
 
 import AccountStore from 'stores/AccountStore'
 import { useStoreState } from 'pullstate'
-import useTransactionHistoryQuery from '../queries/useTransactionHistoryQuery'
-import { xor } from 'lodash'
 
 const itemsPerPage = 50
 

--- a/dapp/src/components/TransactionHistory.js
+++ b/dapp/src/components/TransactionHistory.js
@@ -1,16 +1,16 @@
 import React, { useEffect, useState, useMemo } from 'react'
+import { useRouter } from 'next/router'
 import dateformat from 'dateformat'
 import EtherscanLink from 'components/earn/EtherscanLink'
 
 import { fbt } from 'fbt-runtime'
+import { useWeb3React } from '@web3-react/core'
 import { formatCurrency } from '../utils/math'
 import { shortenAddress } from '../utils/web3'
 import { exportToCsv, sleep } from '../utils/utils'
 import withIsMobile from 'hoc/withIsMobile'
 import { assetRootPath } from 'utils/image'
 
-import { useRouter } from 'next/router'
-import { useWeb3React } from '@web3-react/core'
 import useTransactionHistoryQuery from '../queries/useTransactionHistoryQuery'
 
 const itemsPerPage = 50

--- a/dapp/src/queries/useTransactionHistoryQuery.js
+++ b/dapp/src/queries/useTransactionHistoryQuery.js
@@ -8,7 +8,11 @@ const useTransactionHistoryQuery = (account, options) => {
   return useQuery(
     QUERY_KEYS.TransactionHistory(account),
     () => transactionHistoryService.fetchHistory(account),
-    options
+    {
+      enabled: account != null,
+      refetchOnWindowFocus: false,
+      ...options,
+    }
   )
 }
 

--- a/dapp/src/stores/AccountStore.js
+++ b/dapp/src/stores/AccountStore.js
@@ -13,8 +13,6 @@ const AccountStore = new Store({
   // is user active / engaged with the dapp
   active: 'active', // active / idle
   lifetimeYield: null,
-  history: [],
-  historyIsLoading: true,
 })
 
 export default AccountStore

--- a/dapp/src/stores/AccountStore.js
+++ b/dapp/src/stores/AccountStore.js
@@ -13,6 +13,8 @@ const AccountStore = new Store({
   // is user active / engaged with the dapp
   active: 'active', // active / idle
   lifetimeYield: null,
+  history: [],
+  historyIsLoading: true,
 })
 
 export default AccountStore


### PR DESCRIPTION
PR for issue #978. Moved transaction history fetching to AccountListener to preload the data in the background on connecting an account. Bit of a different solution and it refetches all this data more often now, not sure if that's an issue.