### PR TITLE
wrapped OUSD transaction history

### DIFF
--- a/dapp/pages/history.js
+++ b/dapp/pages/history.js
@@ -19,13 +19,10 @@ export default function History({ locale, onLocale }) {
       <Layout locale={locale} onLocale={onLocale} dapp>
         <Nav dapp page={'history'} locale={locale} onLocale={onLocale} />
         <div className="home d-flex flex-column">
-        {wousdBalanceHeader ? (
-          <BalanceHeaderWrapped />
-            ) : (
-          <BalanceHeader />
-          )
-        }
-          {active && <TransactionHistory setWousdBalanceHeader={setWousdBalanceHeader}/>}
+          {wousdBalanceHeader ? <BalanceHeaderWrapped /> : <BalanceHeader />}
+          {active && (
+            <TransactionHistory setWousdBalanceHeader={setWousdBalanceHeader} />
+          )}
           {!active && (
             <div className="empty-placeholder d-flex flex-column align-items-center justify-content-start">
               <img src={assetRootPath('/images/wallet-icons.svg')} />

--- a/dapp/pages/history.js
+++ b/dapp/pages/history.js
@@ -5,20 +5,27 @@ import { fbt } from 'fbt-runtime'
 import Layout from 'components/layout'
 import Nav from 'components/Nav'
 import BalanceHeader from 'components/buySell/BalanceHeader'
+import BalanceHeaderWrapped from 'components/wrap/BalanceHeaderWrapped'
 import TransactionHistory from 'components/TransactionHistory'
 import GetOUSD from 'components/GetOUSD'
 import { assetRootPath } from 'utils/image'
 
 export default function History({ locale, onLocale }) {
   const { active } = useWeb3React()
+  const [wousdBalanceHeader, setWousdBalanceHeader] = useState()
 
   return (
     <>
       <Layout locale={locale} onLocale={onLocale} dapp>
         <Nav dapp page={'history'} locale={locale} onLocale={onLocale} />
         <div className="home d-flex flex-column">
+        {wousdBalanceHeader ? (
+          <BalanceHeaderWrapped />
+            ) : (
           <BalanceHeader />
-          {active && <TransactionHistory />}
+          )
+        }
+          {active && <TransactionHistory setWousdBalanceHeader={setWousdBalanceHeader}/>}
           {!active && (
             <div className="empty-placeholder d-flex flex-column align-items-center justify-content-start">
               <img src={assetRootPath('/images/wallet-icons.svg')} />

--- a/dapp/src/components/AccountListener.js
+++ b/dapp/src/components/AccountListener.js
@@ -22,6 +22,7 @@ import useBalancesQuery from '../queries/useBalancesQuery'
 import useAllowancesQuery from '../queries/useAllowancesQuery'
 import useApyQuery from '../queries/useApyQuery'
 import useTransactionHistoryQuery from '../queries/useTransactionHistoryQuery'
+import useTransactionHistoryWrappedQuery from '../queries/useTransactionHistoryWrappedQuery'
 import useWousdQuery from '../queries/useWousdQuery'
 
 const AccountListener = (props) => {
@@ -75,6 +76,7 @@ const AccountListener = (props) => {
   })
 
   const historyQuery = useTransactionHistoryQuery(account)
+  const historyWrappedQuery = useTransactionHistoryWrappedQuery(account)
 
   useEffect(() => {
     if ((prevActive && !active) || prevAccount !== account) {
@@ -356,6 +358,7 @@ const AccountListener = (props) => {
     if (account) {
       login(account, setCookie)
       historyQuery.refetch()
+      historyWrappedQuery.refetch()
     }
 
     const loadLifetimeEarnings = async () => {

--- a/dapp/src/components/TransactionHistory.js
+++ b/dapp/src/components/TransactionHistory.js
@@ -119,55 +119,55 @@ const FormatCurrencyByImportance = ({
   )
 }
 
-const CoinToggle = ({
-  setFilters,
-  isOusd,
-  setIsOusd,
-}) => {
+const CoinToggle = ({ setFilters, isOusd, setIsOusd }) => {
   const ousdSelected = isOusd
   return (
     <>
-    <div className='d-flex'>
-      <div key='ousd'>
-        <div
-          className={`button ousd d-flex align-items-center justify-content-center ${
-            ousdSelected ? 'selected' : ''
-          }`}
-          onClick={() => {
-            if (!ousdSelected) {
-              setIsOusd(true)
-              setFilters([])
-            }
-          }}
-        >
-          <span className="d-none d-md-flex">{fbt('OUSD', 'Tx history filter: OUSD')}</span>
-          <img
-            className="d-flex d-md-none"
-            src={assetRootPath(`/images/history/mint_icon.svg`)}
-          />
+      <div className="d-flex">
+        <div key="ousd">
+          <div
+            className={`button ousd d-flex align-items-center justify-content-center ${
+              ousdSelected ? 'selected' : ''
+            }`}
+            onClick={() => {
+              if (!ousdSelected) {
+                setIsOusd(true)
+                setFilters([])
+              }
+            }}
+          >
+            <span className="d-none d-md-flex">
+              {fbt('OUSD', 'Tx history filter: OUSD')}
+            </span>
+            <img
+              className="d-flex d-md-none"
+              src={assetRootPath(`/images/history/mint_icon.svg`)}
+            />
+          </div>
+        </div>
+        <div key="wousd">
+          <div
+            className={`button wousd d-flex align-items-center justify-content-center ${
+              !ousdSelected ? 'selected' : ''
+            }`}
+            onClick={() => {
+              if (ousdSelected) {
+                setIsOusd(false)
+                setFilters([])
+              }
+            }}
+          >
+            <span className="d-none d-md-flex">
+              {fbt('wOUSD', 'Tx history filter: wOUSD')}
+            </span>
+            <img
+              className="d-flex d-md-none"
+              src={assetRootPath(`/images/history/redeem_icon.svg`)}
+            />
+          </div>
         </div>
       </div>
-      <div key='wousd'>
-      <div
-        className={`button wousd d-flex align-items-center justify-content-center ${
-          !ousdSelected ? 'selected' : ''
-        }`}
-        onClick={() => {
-          if (ousdSelected) {
-            setIsOusd(false)
-            setFilters([])
-          }
-        }}
-      >
-        <span className="d-none d-md-flex">{fbt('wOUSD', 'Tx history filter: wOUSD')}</span>
-        <img
-          className="d-flex d-md-none"
-          src={assetRootPath(`/images/history/redeem_icon.svg`)}
-        />
-      </div>
-      </div>
-    </div>
-    <style jsx>{`
+      <style jsx>{`
         .button {
           color: #8293a4;
           min-height: 40px;
@@ -398,25 +398,29 @@ const TransactionHistory = ({ setWousdBalanceHeader, isMobile }) => {
                 <FilterButton
                   filterText={fbt('Received', 'Tx history filter: Received')}
                   filterImage="received_icon.svg"
-                  filter={isOusd ? "received" : "received_wousd"}
+                  filter={isOusd ? 'received' : 'received_wousd'}
                   filters={filters}
                   setFilters={setFilters}
                 />
                 <FilterButton
                   filterText={fbt('Sent', 'Tx history filter: Sent')}
                   filterImage="sent_icon.svg"
-                  filter={isOusd ? "sent" : "sent_wousd"}
+                  filter={isOusd ? 'sent' : 'sent_wousd'}
                   filters={filters}
                   setFilters={setFilters}
                 />
                 <FilterButton
-                  filterText={isOusd ? fbt('Swap', 'Tx history filter: Swap') : fbt('Wrap', 'Tx history filter: Wrap')}
+                  filterText={
+                    isOusd
+                      ? fbt('Swap', 'Tx history filter: Swap')
+                      : fbt('Wrap', 'Tx history filter: Wrap')
+                  }
                   filterImage="swap_icon.svg"
-                  filter={isOusd ? "swap" : "wrap"}
+                  filter={isOusd ? 'swap' : 'wrap'}
                   filters={filters}
                   setFilters={setFilters}
                 />
-                {isOusd && 
+                {isOusd && (
                   <FilterButton
                     filterText={fbt('Yield', 'Tx history filter: Yield')}
                     filterImage="yield_icon.svg"
@@ -424,7 +428,7 @@ const TransactionHistory = ({ setWousdBalanceHeader, isMobile }) => {
                     filters={filters}
                     setFilters={setFilters}
                   />
-                }
+                )}
               </div>
               <div className="d-flex">
                 <div

--- a/dapp/src/constants/queryKeys.js
+++ b/dapp/src/constants/queryKeys.js
@@ -1,5 +1,6 @@
 export const QUERY_KEYS = {
   TransactionHistory: (account) => ['transactionHistory', { account }],
+  TransactionHistoryWrapped: (account) => ['transactionHistoryWrapped', { account }],
   Balances: (account) => ['balances', { account }],
   Allowances: (account) => ['allowances', { account }],
   Apy: () => ['apy'],

--- a/dapp/src/constants/queryKeys.js
+++ b/dapp/src/constants/queryKeys.js
@@ -1,6 +1,9 @@
 export const QUERY_KEYS = {
   TransactionHistory: (account) => ['transactionHistory', { account }],
-  TransactionHistoryWrapped: (account) => ['transactionHistoryWrapped', { account }],
+  TransactionHistoryWrapped: (account) => [
+    'transactionHistoryWrapped',
+    { account },
+  ],
   Balances: (account) => ['balances', { account }],
   Allowances: (account) => ['allowances', { account }],
   Apy: () => ['apy'],

--- a/dapp/src/queries/useTransactionHistoryWrappedQuery.js
+++ b/dapp/src/queries/useTransactionHistoryWrappedQuery.js
@@ -1,0 +1,19 @@
+import { useQuery } from 'react-query'
+
+import { QUERY_KEYS } from '../constants/queryKeys'
+
+import { transactionHistoryWrappedService } from '../services/transaction-history-wrapped.service'
+
+const useTransactionHistoryWrappedQuery = (account, options) => {
+  return useQuery(
+    QUERY_KEYS.TransactionHistoryWrapped(account),
+    () => transactionHistoryWrappedService.fetchHistoryWrapped(account),
+    {
+      enabled: account != null,
+      refetchOnWindowFocus: false,
+      ...options,
+    }
+  )
+}
+
+export default useTransactionHistoryWrappedQuery

--- a/dapp/src/services/transaction-history-wrapped.service.js
+++ b/dapp/src/services/transaction-history-wrapped.service.js
@@ -1,0 +1,19 @@
+export default class TransactionHistoryWrappedService {
+  constructor() {
+    this.baseURL = `${process.env.ANALYTICS_ENDPOINT}/api/v1/address`
+  }
+
+  async fetchHistoryWrapped(account) {
+    const response = await fetch(
+      `${this.baseURL}/${account.toLowerCase()}/wrap_history`
+    )
+
+    if (!response.ok) {
+      throw new Error('Failed fetching wrapped history from analytics')
+    }
+
+    return (await response.json()).history
+  }
+}
+
+export const transactionHistoryWrappedService = new TransactionHistoryWrappedService()

--- a/dapp/src/services/transaction-history-wrapped.service.js
+++ b/dapp/src/services/transaction-history-wrapped.service.js
@@ -16,4 +16,5 @@ export default class TransactionHistoryWrappedService {
   }
 }
 
-export const transactionHistoryWrappedService = new TransactionHistoryWrappedService()
+export const transactionHistoryWrappedService =
+  new TransactionHistoryWrappedService()


### PR DESCRIPTION
Integrating wOUSD transactions into transaction history page. User can toggle between OUSD and wOUSD tabs and within each further specify transaction type.

<img width="1202" alt="Screenshot 2022-05-12 at 16 15 43" src="https://user-images.githubusercontent.com/62400812/168096060-5d581798-7c6c-428a-ac83-a4b1cf211028.png">

**Connected PR:** https://github.com/OriginProtocol/ousd-analytics/pull/206