### PR TITLE
introduce global state for approval stage and update accordingly

### DIFF
--- a/dapp/src/components/buySell/ApproveSwap.js
+++ b/dapp/src/components/buySell/ApproveSwap.js
@@ -29,7 +29,7 @@ const ApproveSwap = ({
   const web3react = useWeb3React()
   const { library, account } = web3react
   const approvalStage = useStoreState(ContractStore, (s) => s.approvalStage)
-  const stage = approvalStage?.[stableCoinToApprove]?.[selectedSwap?.name];
+  const stage = approvalStage?.[stableCoinToApprove]?.[selectedSwap?.name]
   const coinApproved = stage === 'done'
   const isWrapped =
     selectedSwap &&
@@ -68,8 +68,8 @@ const ApproveSwap = ({
         ...s.approvalStage,
         [stableCoinToApprove]: {
           ...s.approvalStage?.[stableCoinToApprove],
-          [selectedSwap?.name]: newStage
-        }
+          [selectedSwap?.name]: newStage,
+        },
       }
     })
   }
@@ -132,12 +132,12 @@ const ApproveSwap = ({
         isApproving.contract === selectedSwap.name &&
         isApproving.coin === stableCoinToApprove
       ) {
-        updateApprovalStage('waiting-network');
+        updateApprovalStage('waiting-network')
         return
       }
     }
-    if(!stage){
-      updateApprovalStage('approve');
+    if (!stage) {
+      updateApprovalStage('approve')
     }
   }, [selectedSwap])
 
@@ -148,11 +148,7 @@ const ApproveSwap = ({
     }
   }, [stableCoinToApprove, usdt, dai, usdc, ousd, wousd])
 
-  const ApprovalMessage = ({
-    selectedSwap,
-    stableCoinToApprove,
-    isMobile,
-  }) => {
+  const ApprovalMessage = ({ selectedSwap, stableCoinToApprove, isMobile }) => {
     if (stage === 'waiting-user') {
       return fbt(
         'Waiting for you to confirm...',
@@ -229,7 +225,6 @@ const ApproveSwap = ({
 
   return (
     <>
-    <p>this is a test</p>
       <button
         className={`btn-blue buy-button mt-4 mt-md-3 w-100`}
         hidden={!approvalNeeded}

--- a/dapp/src/components/buySell/ApproveSwap.js
+++ b/dapp/src/components/buySell/ApproveSwap.js
@@ -236,6 +236,9 @@ const ApproveSwap = ({
               label: swapMetadata.coinGiven,
               value: parseInt(swapMetadata.swapAmount),
             })
+            ContractStore.update((s) => {
+              s.approvalInProgress = true
+            })
             updateApprovalStage('waiting-user')
             try {
               const result = await contract
@@ -262,10 +265,16 @@ const ApproveSwap = ({
               })
               setIsApproving({})
               updateApprovalStage('done')
+              ContractStore.update((s) => {
+                s.approvalInProgress = false
+              })
             } catch (e) {
               onMintingError(e)
               console.error('Exception happened: ', e)
               updateApprovalStage('approve')
+              ContractStore.update((s) => {
+                s.approvalInProgress = false
+              })
               if (e.code !== 4001) {
                 await storeTransactionError('approve', stableCoinToApprove)
                 analytics.track(`Approval failed`, {

--- a/dapp/src/components/buySell/ApproveSwap.js
+++ b/dapp/src/components/buySell/ApproveSwap.js
@@ -240,9 +240,6 @@ const ApproveSwap = ({
               label: swapMetadata.coinGiven,
               value: parseInt(swapMetadata.swapAmount),
             })
-            ContractStore.update((s) => {
-              s.approvalInProgress = true
-            })
             updateApprovalStage('waiting-user')
             try {
               const result = await contract
@@ -269,16 +266,10 @@ const ApproveSwap = ({
               })
               setIsApproving({})
               updateApprovalStage('done')
-              ContractStore.update((s) => {
-                s.approvalInProgress = false
-              })
             } catch (e) {
               onMintingError(e)
               console.error('Exception happened: ', e)
               updateApprovalStage('approve')
-              ContractStore.update((s) => {
-                s.approvalInProgress = false
-              })
               if (e.code !== 4001) {
                 await storeTransactionError('approve', stableCoinToApprove)
                 analytics.track(`Approval failed`, {

--- a/dapp/src/components/buySell/ApproveSwap.js
+++ b/dapp/src/components/buySell/ApproveSwap.js
@@ -228,7 +228,7 @@ const ApproveSwap = ({
       <button
         className={`btn-blue buy-button mt-4 mt-md-3 w-100`}
         hidden={!approvalNeeded}
-        disabled={coinApproved}
+        disabled={coinApproved || stage === 'waiting-user'}
         onClick={async () => {
           if (stage === 'approve' && contract) {
             analytics.track('On Approve Coin', {

--- a/dapp/src/components/buySell/ApproveSwap.js
+++ b/dapp/src/components/buySell/ApproveSwap.js
@@ -228,7 +228,11 @@ const ApproveSwap = ({
       <button
         className={`btn-blue buy-button mt-4 mt-md-3 w-100`}
         hidden={!approvalNeeded}
-        disabled={coinApproved || stage === 'waiting-user'}
+        disabled={
+          coinApproved ||
+          stage === 'waiting-user' ||
+          stage === 'waiting-network'
+        }
         onClick={async () => {
           if (stage === 'approve' && contract) {
             analytics.track('On Approve Coin', {

--- a/dapp/src/components/buySell/ContractsTable.js
+++ b/dapp/src/components/buySell/ContractsTable.js
@@ -10,6 +10,10 @@ import ContractStore from 'stores/ContractStore'
 import ConfirmContractPickModal from 'components/buySell/ConfirmContractPickModal'
 
 const ContractsTable = () => {
+  const approvalInProgress = useStoreState(
+    ContractStore,
+    (s) => s.approvalInProgress
+  )
   const swapEstimations = useStoreState(ContractStore, (s) => s.swapEstimations)
   const [alternateTxRouteConfirmed, setAlternateTxRouteConfirmed] =
     useState(false)
@@ -247,7 +251,10 @@ const ContractsTable = () => {
                 ? estimation.userSelected
                 : estimation.isBest)
             const isViableOption =
-              canDoSwap && numberOfCanDoSwaps > 1 && !isSelected
+              canDoSwap &&
+              numberOfCanDoSwaps > 1 &&
+              !isSelected &&
+              !approvalInProgress
 
             return (
               <div

--- a/dapp/src/components/buySell/ContractsTable.js
+++ b/dapp/src/components/buySell/ContractsTable.js
@@ -10,10 +10,6 @@ import ContractStore from 'stores/ContractStore'
 import ConfirmContractPickModal from 'components/buySell/ConfirmContractPickModal'
 
 const ContractsTable = () => {
-  const approvalInProgress = useStoreState(
-    ContractStore,
-    (s) => s.approvalInProgress
-  )
   const swapEstimations = useStoreState(ContractStore, (s) => s.swapEstimations)
   const [alternateTxRouteConfirmed, setAlternateTxRouteConfirmed] =
     useState(false)
@@ -251,10 +247,7 @@ const ContractsTable = () => {
                 ? estimation.userSelected
                 : estimation.isBest)
             const isViableOption =
-              canDoSwap &&
-              numberOfCanDoSwaps > 1 &&
-              !isSelected &&
-              !approvalInProgress
+              canDoSwap && numberOfCanDoSwaps > 1 && !isSelected
 
             return (
               <div

--- a/dapp/src/stores/ContractStore.js
+++ b/dapp/src/stores/ContractStore.js
@@ -5,6 +5,7 @@ const ContractStore = new Store({
   contracts: {},
   apy: {},
   approvalStage: {},
+  approvalInProgress: false,
   ousdExchangeRates: {
     dai: {
       mint: 1,

--- a/dapp/src/stores/ContractStore.js
+++ b/dapp/src/stores/ContractStore.js
@@ -5,7 +5,6 @@ const ContractStore = new Store({
   contracts: {},
   apy: {},
   approvalStage: {},
-  approvalInProgress: false,
   ousdExchangeRates: {
     dai: {
       mint: 1,

--- a/dapp/src/stores/ContractStore.js
+++ b/dapp/src/stores/ContractStore.js
@@ -4,6 +4,7 @@ import { BigNumber } from 'ethers'
 const ContractStore = new Store({
   contracts: {},
   apy: {},
+  approvalStage: {},
   ousdExchangeRates: {
     dai: {
       mint: 1,


### PR DESCRIPTION
original issue: https://github.com/OriginProtocol/origin-dollar/issues/963

- Maintain the approval button status while switching between other contracts. 
- Disable the approval button while waiting for the network or user's approval.