### PR TITLE
fix input flipping on wrap page

### DIFF
--- a/dapp/src/components/wrap/WrapHomepage.js
+++ b/dapp/src/components/wrap/WrapHomepage.js
@@ -117,8 +117,7 @@ const WrapHomepage = ({
     // currencies flipped
     if (previousSwapMode !== swapMode) {
       localStorage.setItem(lastSelectedSwapModeKey, swapMode)
-      const otherCoinAmount = Math.floor(wrapEstimate * 1000000) / 1000000
-      setInputAmount(Math.floor(otherCoinAmount * 100) / 100)
+      setInputAmount(wrapEstimate)
     }
   }, [swapMode])
 

--- a/dapp/src/components/wrap/WrapOusdPill.js
+++ b/dapp/src/components/wrap/WrapOusdPill.js
@@ -162,7 +162,7 @@ const WrapOusdPill = ({
       removeCommas(displayBalance.detailedBalance) !==
         removeCommas(coinValue) &&
       // this bit is required so that zeroes can be added to input when already at max value
-      parseFloat(displayBalance.detailedBalance) !== parseFloat(coinValue)
+      parseFloat(displayBalance.detailedBalance) !== parseFloat(floorTo2to6Decimals(coinValue))
     ) {
       setMaxBalance()
     }

--- a/dapp/src/components/wrap/WrapOusdPill.js
+++ b/dapp/src/components/wrap/WrapOusdPill.js
@@ -162,7 +162,8 @@ const WrapOusdPill = ({
       removeCommas(displayBalance.detailedBalance) !==
         removeCommas(coinValue) &&
       // this bit is required so that zeroes can be added to input when already at max value
-      parseFloat(displayBalance.detailedBalance) !== parseFloat(floorTo2to6Decimals(coinValue))
+      parseFloat(displayBalance.detailedBalance) !==
+        parseFloat(floorTo2to6Decimals(coinValue))
     ) {
       setMaxBalance()
     }


### PR DESCRIPTION
Fix downward spiral on flipping fields on wrap form. When the inputs are flipped twice the top field shows a slightly smaller floored value compared to original due to the nature of the contract, but that's the extent of the spiral.
The actual value decreases in the background, but that's negligible. In the case of the user wanting to wrap their max balance and then flipping a couple times where this would matter, the actual value returns to max balance, making sure no dust is left behind

related to #1015