### PR TITLE
add error message when swap price is too high

### DIFF
--- a/dapp/src/components/buySell/ContractsTable.js
+++ b/dapp/src/components/buySell/ContractsTable.js
@@ -65,6 +65,10 @@ const ContractsTable = () => {
       'Liquidity error',
       'Swap estimations: liquidity error'
     ),
+    price_too_high: fbt(
+      'Price too high',
+      'Swap estimations: price too high'
+    ),
   }
 
   // Defines the sorting order of errored items

--- a/dapp/src/components/buySell/ContractsTable.js
+++ b/dapp/src/components/buySell/ContractsTable.js
@@ -65,10 +65,7 @@ const ContractsTable = () => {
       'Liquidity error',
       'Swap estimations: liquidity error'
     ),
-    price_too_high: fbt(
-      'Price too high',
-      'Swap estimations: price too high'
-    ),
+    price_too_high: fbt('Price too high', 'Swap estimations: price too high'),
   }
 
   // Defines the sorting order of errored items

--- a/dapp/src/components/buySell/ContractsTable.js
+++ b/dapp/src/components/buySell/ContractsTable.js
@@ -57,10 +57,6 @@ const ContractsTable = () => {
       'Amount too high',
       'Swap estimations: amount too high'
     ),
-    slippage_too_high: fbt(
-      'Slippage too high',
-      'Swap estimations: slippage too high'
-    ),
     liquidity_error: fbt(
       'Liquidity error',
       'Swap estimations: liquidity error'

--- a/dapp/src/hooks/useSwapEstimator.js
+++ b/dapp/src/hooks/useSwapEstimator.js
@@ -412,13 +412,9 @@ const useSwapEstimator = ({
         isRedeem ? coinToReceiveDecimals : 18
       )
 
-      const decimals =
-        selectedCoin === 'ousd' || selectedCoin === 'dai' ? 18 : 6
+      const decimals = swapMode === 'redeem' || selectedCoin === 'dai' ? 18 : 6
 
-      if (
-        ethers.utils.formatUnits(swapAmount, decimals) / amountReceived >
-        max_price
-      ) {
+      if (ethers.utils.formatUnits(swapAmount, decimals) / amountReceived > max_price) {
         return {
           canDoSwap: false,
           error: 'price_too_high',
@@ -521,13 +517,9 @@ const useSwapEstimator = ({
         isRedeem ? coinToReceiveDecimals : 18
       )
 
-      const decimals =
-        selectedCoin === 'ousd' || selectedCoin === 'dai' ? 18 : 6
+      const decimals = swapMode === 'redeem' || selectedCoin === 'dai' ? 18 : 6
 
-      if (
-        ethers.utils.formatUnits(swapAmount, decimals) / amountReceived >
-        max_price
-      ) {
+      if (ethers.utils.formatUnits(swapAmount, decimals) / amountReceived > max_price) {
         return {
           canDoSwap: false,
           error: 'price_too_high',
@@ -634,7 +626,7 @@ const useSwapEstimator = ({
       ) {
         return {
           canDoSwap: false,
-          error: 'slippage_too_high',
+          error: 'price_too_high',
         }
       }
 
@@ -665,13 +657,11 @@ const useSwapEstimator = ({
         isRedeem ? coinToReceiveDecimals : 18
       )
 
-      const decimals =
-        selectedCoin === 'ousd' || selectedCoin === 'dai' ? 18 : 6
+      const decimals = swapMode === 'redeem' || selectedCoin === 'dai' ? 18 : 6
 
-      if (
-        ethers.utils.formatUnits(swapAmount, decimals) / amountReceived >
-        max_price
-      ) {
+      console.log()
+
+      if (ethers.utils.formatUnits(swapAmount, decimals) / amountReceived > max_price) {
         return {
           canDoSwap: false,
           error: 'price_too_high',
@@ -744,7 +734,7 @@ const useSwapEstimator = ({
       ) {
         return {
           canDoSwap: false,
-          error: 'slippage_too_high',
+          error: 'price_too_high',
         }
       }
 
@@ -836,7 +826,7 @@ const useSwapEstimator = ({
       ) {
         return {
           canDoSwap: false,
-          error: 'slippage_too_high',
+          error: 'price_too_high',
         }
       }
 
@@ -906,7 +896,7 @@ const useSwapEstimator = ({
       if (errorIncludes('Redeem amount lower than minimum')) {
         return {
           canDoSwap: false,
-          error: 'slippage_too_high',
+          error: 'price_too_high',
         }
         /* Various error messages strategies emit when too much funds attempt to
          * be withdrawn:

--- a/dapp/src/hooks/useSwapEstimator.js
+++ b/dapp/src/hooks/useSwapEstimator.js
@@ -8,6 +8,7 @@ import {
   mintPercentGasLimitBuffer,
   redeemPercentGasLimitBuffer,
   approveCoinGasLimits,
+  max_price,
 } from 'utils/constants'
 import { usePrevious } from 'utils/hooks'
 import useCurrencySwapper from 'hooks/useCurrencySwapper'
@@ -411,6 +412,15 @@ const useSwapEstimator = ({
         isRedeem ? coinToReceiveDecimals : 18
       )
 
+      const decimals = selectedCoin === 'ousd' || selectedCoin === 'dai' ? 18 : 6
+
+      if (ethers.utils.formatUnits(swapAmount, decimals) / amountReceived > max_price) {
+        return {
+          canDoSwap: false,
+          error: 'price_too_high',
+        }
+      }
+
       const approveAllowanceNeeded = allowancesLoaded
         ? parseFloat(allowances[coinToSwap].curve) === 0
         : true
@@ -506,6 +516,15 @@ const useSwapEstimator = ({
         priceQuoteBn,
         isRedeem ? coinToReceiveDecimals : 18
       )
+
+      const decimals = selectedCoin === 'ousd' || selectedCoin === 'dai' ? 18 : 6
+
+      if (ethers.utils.formatUnits(swapAmount, decimals) / amountReceived > max_price) {
+        return {
+          canDoSwap: false,
+          error: 'price_too_high',
+        }
+      }
 
       /* Check if Uniswap router has allowance to spend coin. If not we can not run gas estimation and need
        * to guess the gas usage.
@@ -637,6 +656,15 @@ const useSwapEstimator = ({
         priceQuoteBn,
         isRedeem ? coinToReceiveDecimals : 18
       )
+
+      const decimals = selectedCoin === 'ousd' || selectedCoin === 'dai' ? 18 : 6
+
+      if (ethers.utils.formatUnits(swapAmount, decimals) / amountReceived > max_price) {
+        return {
+          canDoSwap: false,
+          error: 'price_too_high',
+        }
+      }
 
       /* Check if Uniswap router has allowance to spend coin. If not we can not run gas estimation and need
        * to guess the gas usage.

--- a/dapp/src/hooks/useSwapEstimator.js
+++ b/dapp/src/hooks/useSwapEstimator.js
@@ -412,9 +412,13 @@ const useSwapEstimator = ({
         isRedeem ? coinToReceiveDecimals : 18
       )
 
-      const decimals = selectedCoin === 'ousd' || selectedCoin === 'dai' ? 18 : 6
+      const decimals =
+        selectedCoin === 'ousd' || selectedCoin === 'dai' ? 18 : 6
 
-      if (ethers.utils.formatUnits(swapAmount, decimals) / amountReceived > max_price) {
+      if (
+        ethers.utils.formatUnits(swapAmount, decimals) / amountReceived >
+        max_price
+      ) {
         return {
           canDoSwap: false,
           error: 'price_too_high',
@@ -517,9 +521,13 @@ const useSwapEstimator = ({
         isRedeem ? coinToReceiveDecimals : 18
       )
 
-      const decimals = selectedCoin === 'ousd' || selectedCoin === 'dai' ? 18 : 6
+      const decimals =
+        selectedCoin === 'ousd' || selectedCoin === 'dai' ? 18 : 6
 
-      if (ethers.utils.formatUnits(swapAmount, decimals) / amountReceived > max_price) {
+      if (
+        ethers.utils.formatUnits(swapAmount, decimals) / amountReceived >
+        max_price
+      ) {
         return {
           canDoSwap: false,
           error: 'price_too_high',
@@ -657,9 +665,13 @@ const useSwapEstimator = ({
         isRedeem ? coinToReceiveDecimals : 18
       )
 
-      const decimals = selectedCoin === 'ousd' || selectedCoin === 'dai' ? 18 : 6
+      const decimals =
+        selectedCoin === 'ousd' || selectedCoin === 'dai' ? 18 : 6
 
-      if (ethers.utils.formatUnits(swapAmount, decimals) / amountReceived > max_price) {
+      if (
+        ethers.utils.formatUnits(swapAmount, decimals) / amountReceived >
+        max_price
+      ) {
         return {
           canDoSwap: false,
           error: 'price_too_high',

--- a/dapp/src/hooks/useSwapEstimator.js
+++ b/dapp/src/hooks/useSwapEstimator.js
@@ -414,7 +414,10 @@ const useSwapEstimator = ({
 
       const decimals = swapMode === 'redeem' || selectedCoin === 'dai' ? 18 : 6
 
-      if (ethers.utils.formatUnits(swapAmount, decimals) / amountReceived > max_price) {
+      if (
+        ethers.utils.formatUnits(swapAmount, decimals) / amountReceived >
+        max_price
+      ) {
         return {
           canDoSwap: false,
           error: 'price_too_high',
@@ -519,7 +522,10 @@ const useSwapEstimator = ({
 
       const decimals = swapMode === 'redeem' || selectedCoin === 'dai' ? 18 : 6
 
-      if (ethers.utils.formatUnits(swapAmount, decimals) / amountReceived > max_price) {
+      if (
+        ethers.utils.formatUnits(swapAmount, decimals) / amountReceived >
+        max_price
+      ) {
         return {
           canDoSwap: false,
           error: 'price_too_high',
@@ -661,7 +667,10 @@ const useSwapEstimator = ({
 
       console.log()
 
-      if (ethers.utils.formatUnits(swapAmount, decimals) / amountReceived > max_price) {
+      if (
+        ethers.utils.formatUnits(swapAmount, decimals) / amountReceived >
+        max_price
+      ) {
         return {
           canDoSwap: false,
           error: 'price_too_high',

--- a/dapp/src/utils/constants.js
+++ b/dapp/src/utils/constants.js
@@ -16,7 +16,7 @@ const approveCoinGasLimits = {
 }
 const apyDayOptions = [7, 30, 60, 90, 365]
 const DEFAULT_SELECTED_APY = 30
-const max_price = 5
+const max_price = 1.1
 
 module.exports = {
   mintAbsoluteGasLimitBuffer,

--- a/dapp/src/utils/constants.js
+++ b/dapp/src/utils/constants.js
@@ -16,7 +16,7 @@ const approveCoinGasLimits = {
 }
 const apyDayOptions = [7, 30, 60, 90, 365]
 const DEFAULT_SELECTED_APY = 30
-const max_price = 1.1
+const max_price = 5
 
 module.exports = {
   mintAbsoluteGasLimitBuffer,

--- a/dapp/src/utils/constants.js
+++ b/dapp/src/utils/constants.js
@@ -16,6 +16,7 @@ const approveCoinGasLimits = {
 }
 const apyDayOptions = [7, 30, 60, 90, 365]
 const DEFAULT_SELECTED_APY = 30
+const max_price = 1.1
 
 module.exports = {
   mintAbsoluteGasLimitBuffer,
@@ -28,4 +29,5 @@ module.exports = {
   approveCoinGasLimits,
   apyDayOptions,
   DEFAULT_SELECTED_APY,
+  max_price,
 }


### PR DESCRIPTION
This adds a `Price too high` error message when the `Est. received` amount differs from the input amount by more than 10%, which prevents clearly unfavourable prices and large percentages in red from cluttering the screen. It's applicable to all routes other than Flipper and Vault

issue #1047