### PR TITLE
info icons on unsupported swap routes

### DIFF
--- a/dapp/src/components/buySell/ContractsTable.js
+++ b/dapp/src/components/buySell/ContractsTable.js
@@ -11,7 +11,7 @@ import ContractStore from 'stores/ContractStore'
 import ConfirmationModal from 'components/buySell/ConfirmationModal'
 import Dropdown from 'components/Dropdown'
 
-const Info = ({contract}) => {
+const Info = ({ contract }) => {
   const [infoOpen, setInfoOpen] = useState(false)
   const vault = contract === 'vault'
 
@@ -20,8 +20,20 @@ const Info = ({contract}) => {
       <div className="info-box">
         <Dropdown
           content={
-            <div className={`d-flex dropdown-menu text-wrap ${vault ? '' : 'short'}`}>
-              {vault ? fbt('The Origin Vault only allows redeeming OUSD into a mix of stablecoins, determined by the proportion of assets it governs', 'Unsupported-vault-message') : fbt('This route only supports redeeming OUSD into a single stablecoin', 'Unsupported-route-message')}
+            <div
+              className={`d-flex dropdown-menu text-wrap ${
+                vault ? '' : 'short'
+              }`}
+            >
+              {vault
+                ? fbt(
+                    'The Origin Vault only allows redeeming OUSD into a mix of stablecoins, determined by the proportion of assets it governs',
+                    'Unsupported-vault-message'
+                  )
+                : fbt(
+                    'This route only supports redeeming OUSD into a single stablecoin',
+                    'Unsupported-route-message'
+                  )}
             </div>
           }
           open={infoOpen}
@@ -415,9 +427,7 @@ const ContractsTable = () => {
                 }`}
               >
                 {empty ? '-' : status}
-                {errorReason === 'unsupported' && (
-                  <Info contract={contract}/>
-                )}
+                {errorReason === 'unsupported' && <Info contract={contract} />}
               </div>
             </div>
           )

--- a/dapp/src/components/buySell/ContractsTable.js
+++ b/dapp/src/components/buySell/ContractsTable.js
@@ -5,9 +5,66 @@ import { find, sortBy } from 'lodash'
 import { useStoreState } from 'pullstate'
 import { formatCurrency } from 'utils/math'
 import analytics from 'utils/analytics'
+import { assetRootPath } from 'utils/image'
 
 import ContractStore from 'stores/ContractStore'
 import ConfirmationModal from 'components/buySell/ConfirmationModal'
+import Dropdown from 'components/Dropdown'
+
+const Info = ({contract}) => {
+  const [infoOpen, setInfoOpen] = useState(false)
+  const vault = contract === 'vault'
+
+  return (
+    <>
+      <div className="info-box">
+        <Dropdown
+          content={
+            <div className={`d-flex dropdown-menu text-wrap ${vault ? '' : 'short'}`}>
+              {vault ? fbt('The Origin Vault only allows redeeming OUSD into a mix of stablecoins, determined by the proportion of assets it governs', 'Unsupported-vault-message') : fbt('This route only supports redeeming OUSD into a single stablecoin', 'Unsupported-route-message')}
+            </div>
+          }
+          open={infoOpen}
+          onClose={() => setInfoOpen(false)}
+        >
+          <img
+            className="info-icon"
+            src={assetRootPath('/images/question-icon.svg')}
+            onClick={() => {
+              setInfoOpen(!infoOpen)
+            }}
+          />
+        </Dropdown>
+      </div>
+      <style jsx>{`
+        .info-box {
+          display: inline-block;
+          margin-left: 4px;
+        }
+
+        .dropdown-menu {
+          font-size: 14px;
+          top: 115%;
+          left: 0;
+          right: auto;
+          min-width: 230px;
+          padding: 18px 18px 18px 20px;
+        }
+
+        .dropdown-menu.short {
+          min-width: 190px;
+        }
+
+        .info-icon {
+          width: 16px;
+          height: 16px;
+          margin-bottom: 2px;
+          cursor: pointer;
+        }
+      `}</style>
+    </>
+  )
+}
 
 const ContractsTable = () => {
   const swapEstimations = useStoreState(ContractStore, (s) => s.swapEstimations)
@@ -140,6 +197,7 @@ const ContractsTable = () => {
     }
     setAlternateTxRouteConfirmed(isConfirmed)
   }
+
   return (
     <div className="contracts-table">
       {showAlternateRouteModal && (
@@ -357,6 +415,9 @@ const ContractsTable = () => {
                 }`}
               >
                 {empty ? '-' : status}
+                {errorReason === 'unsupported' && (
+                  <Info contract={contract}/>
+                )}
               </div>
             </div>
           )

--- a/dapp/src/components/buySell/ContractsTable.js
+++ b/dapp/src/components/buySell/ContractsTable.js
@@ -27,11 +27,11 @@ const Info = ({ contract }) => {
             >
               {vault
                 ? fbt(
-                    'The Origin Vault only allows redeeming OUSD into a mix of stablecoins, determined by the proportion of assets it governs',
+                    'The Origin Vault only supports redeeming OUSD for a mix of stablecoins.',
                     'Unsupported-vault-message'
                   )
                 : fbt(
-                    'This route only supports redeeming OUSD into a single stablecoin',
+                    'This route only supports swapping OUSD for a single stablecoin.',
                     'Unsupported-route-message'
                   )}
             </div>

--- a/dapp/src/components/buySell/ContractsTable.js
+++ b/dapp/src/components/buySell/ContractsTable.js
@@ -73,6 +73,13 @@ const Info = ({ contract }) => {
           margin-bottom: 2px;
           cursor: pointer;
         }
+
+        @media (max-width: 992px) {
+          .dropdown-menu {
+            left: auto;
+            right: 0;
+          }
+        }
       `}</style>
     </>
   )


### PR DESCRIPTION
Adding icons to `Unsupported` error messages, that display some info when clicked. The text itself might need some work

issue #1048

<img width="358" alt="Screenshot 2022-07-23 at 14 06 08" src="https://user-images.githubusercontent.com/62400812/180604141-b1d5e35d-8f36-416d-9416-f916299c7e6d.png">
<img width="524" alt="Screenshot 2022-07-23 at 14 06 21" src="https://user-images.githubusercontent.com/62400812/180604153-4b53c31e-8d6a-4efa-8210-14db3005b02a.png">
<img width="828" alt="Screenshot 2022-07-23 at 14 10 40" src="https://user-images.githubusercontent.com/62400812/180604339-e632ae29-9c58-485a-b631-cf4cde859837.png">