### PR TITLE
fix for Flipper error on redeem

### DIFF
--- a/dapp/src/components/buySell/SwapHomepage.js
+++ b/dapp/src/components/buySell/SwapHomepage.js
@@ -39,7 +39,7 @@ const SwapHomepage = ({
 
   // mint / redeem
   const [swapMode, setSwapMode] = useState(
-    process.browser ? localStorage.getItem(lastSelectedSwapModeKey) : 'mint'
+    process.browser && localStorage.getItem(lastSelectedSwapModeKey) !== 'null' ? localStorage.getItem(lastSelectedSwapModeKey) : 'mint'
   )
   const previousSwapMode = usePrevious(swapMode)
   const [buyErrorToDisplay, setBuyErrorToDisplay] = useState(false)

--- a/dapp/src/components/buySell/SwapHomepage.js
+++ b/dapp/src/components/buySell/SwapHomepage.js
@@ -39,7 +39,7 @@ const SwapHomepage = ({
 
   // mint / redeem
   const [swapMode, setSwapMode] = useState(
-    process.browser && localStorage.getItem(lastSelectedSwapModeKey) !== 'null' ? localStorage.getItem(lastSelectedSwapModeKey) : 'mint'
+    process.browser && localStorage.getItem(lastSelectedSwapModeKey) !== null ? localStorage.getItem(lastSelectedSwapModeKey) : 'mint'
   )
   const previousSwapMode = usePrevious(swapMode)
   const [buyErrorToDisplay, setBuyErrorToDisplay] = useState(false)
@@ -135,7 +135,7 @@ const SwapHomepage = ({
 
     // currencies flipped
     if (previousSwapMode !== swapMode) {
-      localStorage.setItem(lastSelectedSwapModeKey, swapMode)
+      if (swapMode) localStorage.setItem(lastSelectedSwapModeKey, swapMode)
       if (selectedSwap) {
         const otherCoinAmount =
           Math.floor(selectedSwap.amountReceived * 1000000) / 1000000

--- a/dapp/src/components/buySell/SwapHomepage.js
+++ b/dapp/src/components/buySell/SwapHomepage.js
@@ -14,7 +14,6 @@ import SettingsDropdown from 'components/buySell/SettingsDropdown'
 import useSwapEstimator from 'hooks/useSwapEstimator'
 import withIsMobile from 'hoc/withIsMobile'
 import { getUserSource } from 'utils/user'
-import usePrevious from 'utils/usePrevious'
 import ApproveSwap from 'components/buySell/ApproveSwap'
 import analytics from 'utils/analytics'
 import { formatCurrencyMinMaxDecimals, removeCommas } from '../../utils/math'
@@ -43,7 +42,6 @@ const SwapHomepage = ({
       ? localStorage.getItem(lastSelectedSwapModeKey)
       : 'mint'
   )
-  const previousSwapMode = usePrevious(swapMode)
   const [buyErrorToDisplay, setBuyErrorToDisplay] = useState(false)
 
   const storedSelectedCoin = process.browser
@@ -136,14 +134,12 @@ const SwapHomepage = ({
     }
 
     // currencies flipped
-    if (previousSwapMode !== swapMode) {
-      if (swapMode) localStorage.setItem(lastSelectedSwapModeKey, swapMode)
-      if (selectedSwap) {
-        const otherCoinAmount =
-          Math.floor(selectedSwap.amountReceived * 1000000) / 1000000
-        setSelectedBuyCoinAmount(Math.floor(otherCoinAmount * 100) / 100)
-        setSelectedRedeemCoinAmount(Math.floor(otherCoinAmount * 100) / 100)
-      }
+    localStorage.setItem(lastSelectedSwapModeKey, swapMode)
+    if (selectedSwap) {
+      const otherCoinAmount =
+        Math.floor(selectedSwap.amountReceived * 1000000) / 1000000
+      setSelectedBuyCoinAmount(Math.floor(otherCoinAmount * 100) / 100)
+      setSelectedRedeemCoinAmount(Math.floor(otherCoinAmount * 100) / 100)
     }
   }, [swapMode])
 

--- a/dapp/src/components/buySell/SwapHomepage.js
+++ b/dapp/src/components/buySell/SwapHomepage.js
@@ -39,7 +39,9 @@ const SwapHomepage = ({
 
   // mint / redeem
   const [swapMode, setSwapMode] = useState(
-    process.browser && localStorage.getItem(lastSelectedSwapModeKey) !== null ? localStorage.getItem(lastSelectedSwapModeKey) : 'mint'
+    process.browser && localStorage.getItem(lastSelectedSwapModeKey) !== null
+      ? localStorage.getItem(lastSelectedSwapModeKey)
+      : 'mint'
   )
   const previousSwapMode = usePrevious(swapMode)
   const [buyErrorToDisplay, setBuyErrorToDisplay] = useState(false)


### PR DESCRIPTION
fix for issue #792

The `swapMode` variable was being read from local storage regardless of whether it had a value, so that was `null` for anyone visiting for the first time or after deleting cookies if they didn't change the swap mode manually. That then caused both the swap dapp to default to redeem mode and `coinInfoList[swapMode === 'redeem' ? selectedCoin : 'ousd']` to choose OUSD, which had the Flipper estimate looking at levels of OUSD in the contract instead of the stables being redeemed.
Also the swap page is in mint mode by default now