### PR TITLE
add insufficient liquidity message

### DIFF
--- a/dapp/src/components/buySell/ApproveSwap.js
+++ b/dapp/src/components/buySell/ApproveSwap.js
@@ -212,8 +212,8 @@ const ApproveSwap = ({
       )
     } else if (noSwapRouteAvailable) {
       return fbt(
-        'Route for selected swap not available',
-        'No route available for selected swap'
+        'Insufficient liquidity',
+        'Insufficient liquidity'
       )
     } else if (isWrapped) {
       return fbt('Wrap', 'Wrap')

--- a/dapp/src/components/buySell/ApproveSwap.js
+++ b/dapp/src/components/buySell/ApproveSwap.js
@@ -211,10 +211,7 @@ const ApproveSwap = ({
         'Insufficient balance'
       )
     } else if (noSwapRouteAvailable) {
-      return fbt(
-        'Insufficient liquidity',
-        'Insufficient liquidity'
-      )
+      return fbt('Insufficient liquidity', 'Insufficient liquidity')
     } else if (isWrapped) {
       return fbt('Wrap', 'Wrap')
     } else if (stableCoinToApprove === 'wousd') {


### PR DESCRIPTION
Small change to add `Insufficient liquidity` message when no swap routes are available. Between #1049 eliminating routes with low liquidity and the way of displaying error messages in general having changed in the meantime, I think that's enough to close issue #728