### PR TITLE
Test for falsy error value rather than null

### DIFF
--- a/dapp/src/services/balances.service.js
+++ b/dapp/src/services/balances.service.js
@@ -60,7 +60,7 @@ export default class BalancesService {
           contractData.contract.address.toLowerCase()
       )[0]
 
-      if (balanceResponseData.error === null) {
+      if (!balanceResponseData.error) {
         balanceData[contractData.name] =
           balanceResponseData.tokenBalance === '0x'
             ? '0'


### PR DESCRIPTION
`balanceResponseData.error` is `undefined` not `null` if there are no errors. Testing for a falsy value (safer in case the response changes again, which I assume has caused this bug) instead allows the balances to be fetched and displayed correctly.