### PR TITLE
make it more convenient running fork tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,7 @@ This forks the blockchain (using `PROVIDER_URL`) everytime you run the command, 
 
 ### Option 2: Nested forking
 In cases where you don't want to fork or run the deployments again and again
-- Start the node in a separate terminal using `yarn run node`
-- Set `LOCAL_PROVIDER_URL` in your `.env` file to `http://localhost:8545`
+- Start the node in a separate terminal using `FORK=true IS_TEST=true yarn run node`
 - Run `yarn test:fork` in a new terminal
 
 Basically, you start a forked node that runs the deployments and all. Next, the hardhat forks from this forked node when running the tests. Since any new deployments have already been run on the base fork, running `yarn test:fork` will be much faster. This can be useful when you are just writing tests and there isn't any change to contracts or deployment files.

--- a/contracts/fork-test.sh
+++ b/contracts/fork-test.sh
@@ -11,25 +11,29 @@ main()
     rm -rf deployments/hardhat
 
     ENV_FILE=.env
+    LOCAL_PROVIDER_URL=http://localhost:8545
     source .env
 
     if [ ! -f "$ENV_FILE" ]; then
         echo -e "${RED} File $ENV_FILE does not exist. Have you forgotten to rename the dev.env to .env? ${NO_COLOR}"
         exit 1
     fi
-    if [ -z "$PROVIDER_URL" ] && [ -z "$LOCAL_PROVIDER_URL" ]; then echo "Set PROVIDER_URL" && exit 1; fi
+    if [ -z "$PROVIDER_URL" ]; then echo "Set PROVIDER_URL" && exit 1; fi
     
     params=()
+    # if local node is running resp is a non empty string
+    resp=$(curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"web3_clientVersion","params":[],"id":67}' "$LOCAL_PROVIDER_URL")
 
-    if [ -z "$LOCAL_PROVIDER_URL" ]; then
+    if [ -z "$resp" ]; then
         cp -r deployments/mainnet deployments/hardhat
+        echo "No running node detected spinning up a fresh one"
     else
         mineresp=$(curl -s -H "Content-Type: application/json" -X POST --data '{"id":1,"jsonrpc":"2.0","method":"evm_mine"}' "$LOCAL_PROVIDER_URL")
         blockresp=$((curl -s -H "Content-Type: application/json" -X POST --data '{"id":1,"jsonrpc":"2.0","method":"eth_blockNumber"}' "$LOCAL_PROVIDER_URL") | jq -r '.result')
         blocknum=$((16#${blockresp:2}))
         export FORK_BLOCK_NUMBER=$blocknum
 
-        echo "Will be using block number: $FORK_BLOCK_NUMBER"
+        echo "Connecting to node $LOCAL_PROVIDER_URL using block number: $FORK_BLOCK_NUMBER"
 
         # params+="--deploy-fixture "
 


### PR DESCRIPTION
Instead of user configuring, fork tests check on their own if another local node is running and attach to it. 