### PR TITLE
Remove translucency on OUSD input

### DIFF
--- a/dapp/src/components/buySell/SwapCurrencyPill.js
+++ b/dapp/src/components/buySell/SwapCurrencyPill.js
@@ -16,8 +16,8 @@ import {
 import { assetRootPath } from 'utils/image'
 import { _ } from 'fbt-runtime/lib/fbt'
 
-const CoinImage = ({ small, coin, isSemiTransparent = false }) => {
-  const className = `coin-image ${isSemiTransparent ? 'transparent' : ''}`
+const CoinImage = ({ small, coin }) => {
+  const className = `coin-image`
   return (
     <div className="d-flex align-items-center">
       {coin !== 'mix' && (
@@ -46,10 +46,6 @@ const CoinImage = ({ small, coin, isSemiTransparent = false }) => {
         .coin-image {
           width: 26px;
           height: 26px;
-        }
-
-        .coin-image.transparent {
-          opacity: 0.3;
         }
 
         .coin-image.small {
@@ -125,10 +121,7 @@ const CoinSelect = ({ selected, onChange, options = [] }) => {
                     setOpen(false)
                   }}
                 >
-                  <CoinImage
-                    coin={option}
-                    isSemiTransparent={option === 'ousd'}
-                  />
+                  <CoinImage coin={option} />
                   <div
                     className={`coin ${
                       option === 'mix' ? 'text-capitalize' : 'text-uppercase'

--- a/dapp/src/components/buySell/SwapCurrencyPill.js
+++ b/dapp/src/components/buySell/SwapCurrencyPill.js
@@ -194,18 +194,6 @@ const CoinSelect = ({ selected, onChange, options = [] }) => {
           cursor: pointer;
         }
 
-        /*.dropdown-item.ousd {
-          background-color: #e2e3e5;
-        }
-
-        .dropdown-item.ousd:hover {
-          background-color: #d2d3d5;
-        }*/
-
-        .dropdown-item.ousd .coin {
-          color: #18314055;
-        }
-
         .dropdown-item:hover {
           background-color: #f2f3f5;
         }

--- a/dapp/src/components/wrap/WrapOusdPill.js
+++ b/dapp/src/components/wrap/WrapOusdPill.js
@@ -14,8 +14,8 @@ import {
 import { assetRootPath } from 'utils/image'
 import { _ } from 'fbt-runtime/lib/fbt'
 
-const CoinImage = ({ small, coin, isSemiTransparent = false }) => {
-  const className = `coin-image ${isSemiTransparent ? 'transparent' : ''}`
+const CoinImage = ({ small, coin }) => {
+  const className = `coin-image`
   return (
     <div className="d-flex align-items-center">
       <img
@@ -26,10 +26,6 @@ const CoinImage = ({ small, coin, isSemiTransparent = false }) => {
         .coin-image {
           width: 26px;
           height: 26px;
-        }
-
-        .coin-image.transparent {
-          opacity: 0.3;
         }
 
         .coin-image.small {


### PR DESCRIPTION
We previously ghosted OUSD as an optional input when OUSD is the swap output. However, the option is still selectable. This causes confusion for @matt-bullock and likely others.

<img width="617" alt="Screen Shot 2022-09-15 at 9 30 01 PM" src="https://user-images.githubusercontent.com/273937/190557856-97374d6a-3430-432a-8c8d-193fab3e2227.png">

becomes

<img width="616" alt="Screen Shot 2022-09-15 at 9 31 16 PM" src="https://user-images.githubusercontent.com/273937/190557858-d1f58e14-247b-4671-ad41-565e74166b33.png">