### PR TITLE
github workflow - nodejs 12 -> 14, using the recommended version on README

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Build is currently running on Node.js 12.x while 14.x is the recommended version on README

Should we upgrade here?

https://github.com/OriginProtocol/origin-dollar/actions/runs/3065435890/jobs/4949537573