### PR TITLE
Fix sentry on staging

### DIFF
--- a/dapp/src/utils/sentry.js
+++ b/dapp/src/utils/sentry.js
@@ -3,7 +3,8 @@ import { RewriteFrames } from '@sentry/integrations'
 import getConfig from 'next/config'
 
 const isStaging = process.env.STAGING === 'true'
-const isProduction = process.env.NODE_ENV === 'production'
+// in staging environment NODE_ENV is also set to 'production'
+const isProduction = process.env.NODE_ENV === 'production' && isStaging !== 'true'
 
 export const initSentry = () => {
   if (!process.env.SENTRY_DSN) {


### PR DESCRIPTION
Staging env variables are setup as NODE_ENV=production and STAGING=true, so this configures sentry to send notifications to the proper environment.