### PR TITLE
add inline assembly to solhint

### DIFF
--- a/contracts/.solhint.json
+++ b/contracts/.solhint.json
@@ -8,6 +8,7 @@
       "avoid-tx-origin": "error",
       "no-complex-fallback": "error",
       "not-rely-on-block-hash": "error",
-      "reentrancy": "error"
+      "reentrancy": "error",
+      "no-inline-assembly": "error"
     }
 }

--- a/contracts/contracts/governance/Governable.sol
+++ b/contracts/contracts/governance/Governable.sol
@@ -56,6 +56,7 @@ contract Governable {
      */
     function _governor() internal view returns (address governorOut) {
         bytes32 position = governorPosition;
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             governorOut := sload(position)
         }
@@ -70,6 +71,7 @@ contract Governable {
         returns (address pendingGovernor)
     {
         bytes32 position = pendingGovernorPosition;
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             pendingGovernor := sload(position)
         }
@@ -92,6 +94,7 @@ contract Governable {
 
     function _setGovernor(address newGovernor) internal {
         bytes32 position = governorPosition;
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             sstore(position, newGovernor)
         }
@@ -107,6 +110,7 @@ contract Governable {
     modifier nonReentrant() {
         bytes32 position = reentryStatusPosition;
         uint256 _reentry_status;
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             _reentry_status := sload(position)
         }
@@ -115,6 +119,7 @@ contract Governable {
         require(_reentry_status != _ENTERED, "Reentrant call");
 
         // Any calls to nonReentrant after this point will fail
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             sstore(position, _ENTERED)
         }
@@ -123,6 +128,7 @@ contract Governable {
 
         // By storing the original value once again, a refund is triggered (see
         // https://eips.ethereum.org/EIPS/eip-2200)
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             sstore(position, _NOT_ENTERED)
         }
@@ -130,6 +136,7 @@ contract Governable {
 
     function _setPendingGovernor(address newGovernor) internal {
         bytes32 position = pendingGovernorPosition;
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             sstore(position, newGovernor)
         }

--- a/contracts/contracts/proxies/InitializeGovernedUpgradeabilityProxy.sol
+++ b/contracts/contracts/proxies/InitializeGovernedUpgradeabilityProxy.sol
@@ -106,6 +106,7 @@ contract InitializeGovernedUpgradeabilityProxy is Governable {
      * @param _impl Address to delegate.
      */
     function _delegate(address _impl) internal {
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             // Copy msg.data. We take full control of memory in this inline assembly
             // block because it will not return to Solidity code. We overwrite the
@@ -160,6 +161,7 @@ contract InitializeGovernedUpgradeabilityProxy is Governable {
      */
     function _implementation() internal view returns (address impl) {
         bytes32 slot = IMPLEMENTATION_SLOT;
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             impl := sload(slot)
         }
@@ -186,6 +188,7 @@ contract InitializeGovernedUpgradeabilityProxy is Governable {
 
         bytes32 slot = IMPLEMENTATION_SLOT;
 
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             sstore(slot, newImplementation)
         }

--- a/contracts/contracts/timelock/Timelock.sol
+++ b/contracts/contracts/timelock/Timelock.sol
@@ -159,7 +159,8 @@ contract Timelock {
         // If the _res length is less than 68, then the transaction failed
         // silently (without a revert message)
         if (_returnData.length < 68) return "Transaction reverted silently";
-
+        
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             // Slice the sighash.
             _returnData := add(_returnData, 0x04)

--- a/contracts/contracts/vault/VaultCore.sol
+++ b/contracts/contracts/vault/VaultCore.sol
@@ -587,6 +587,7 @@ contract VaultCore is VaultStorage {
      // solhint-disable-next-line no-complex-fallback
     fallback() external payable {
         bytes32 slot = adminImplPosition;
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             // Copy msg.data. We take full control of memory in this inline assembly
             // block because it will not return to Solidity code. We overwrite the

--- a/contracts/contracts/vault/VaultStorage.sol
+++ b/contracts/contracts/vault/VaultStorage.sol
@@ -119,6 +119,7 @@ contract VaultStorage is Initializable, Governable {
             "new implementation is not a contract"
         );
         bytes32 position = adminImplPosition;
+        // solhint-disable-next-line no-inline-assembly
         assembly {
             sstore(position, newImpl)
         }


### PR DESCRIPTION
In light of [Arbitrum hack](https://medium.com/@0xriptide/hackers-in-arbitrums-inbox-ca23272641a2) where assembly gas optimisation code was carelessly used we should be extra cautious when using assembly code as well. While this solhint rule change by itself won't fix much, it should serve as a nice reminder to be extra careful when using assembly. 

All our current assembly usages look ok and have added solhint exceptions. 