### PR TITLE
Fix node-hid warning on GitHub workflow

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install dependencies
-      run: sudo apt update && sudo apt-get install -y libudev-dev
+      run: sudo apt update && sudo apt-get install -y libudev-dev libusb-1.0-0-dev
     - run: yarn install
       working-directory: ./contracts
     - run: yarn run lint

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,6 +17,8 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Install dependencies
+      run: sudo apt update && sudo apt-get install -y libudev-dev
     - run: yarn install
       working-directory: ./contracts
     - run: yarn run lint


### PR DESCRIPTION
As discussed on,
https://github.com/OriginProtocol/origin-dollar/pull/1102#issuecomment-1250126698

Installing dependencies removes this warning,
```
warning Error running install script for optional dependency: "/home/runner/work/origin-dollar/origin-dollar/dapp/node_modules/node-hid: Command failed.
info This module is OPTIONAL, you can safely ignore this error
Exit code: 1
```

This extra step adds about 30 seconds of build time, so it may be not worth adding it because we can `safetly ignore this error`.

