### PR TITLE
Update ContractStore.walletConnected in AccountListener when the user disconnects the wallet

### DIFF
--- a/contracts/test/vault/rebase.js
+++ b/contracts/test/vault/rebase.js
@@ -51,7 +51,7 @@ describe("Vault rebase pausing", async () => {
     );
   });
 
-  it("Should allow governor tonpause rebasing", async () => {
+  it("Should allow governor to pause rebasing", async () => {
     let { vault, governor } = await loadFixture(defaultFixture);
     await vault.connect(governor).pauseRebase();
   });

--- a/dapp/src/components/AccountListener.js
+++ b/dapp/src/components/AccountListener.js
@@ -86,6 +86,9 @@ const AccountListener = (props) => {
         s.allowances = {}
         s.balances = {}
       })
+      ContractStore.update((s) => {
+        s.walletConnected = false
+      })
       PoolStore.update((s) => {
         s.claimable_ogn = null
         s.lp_tokens = null

--- a/dapp/src/components/buySell/BalanceHeader.js
+++ b/dapp/src/components/buySell/BalanceHeader.js
@@ -239,7 +239,9 @@ const BalanceHeader = ({
             <Statistic
               title={fbt('Balance', 'OUSD Balance')}
               value={
-                !isNaN(parseFloat(displayedBalance)) && ousdBalanceLoaded
+                walletConnected &&
+                !isNaN(parseFloat(displayedBalance)) &&
+                ousdBalanceLoaded
                   ? displayedBalance
                   : '--.--'
               }

--- a/dapp/src/components/wrap/BalanceHeaderWrapped.js
+++ b/dapp/src/components/wrap/BalanceHeaderWrapped.js
@@ -257,7 +257,9 @@ const BalanceHeaderWrapped = ({
             <Statistic
               title={fbt('wOUSD Balance', 'wOUSD Balance')}
               value={
-                !isNaN(parseFloat(displayedWousdBalance)) && wousdBalanceLoaded
+                walletConnected &&
+                !isNaN(parseFloat(displayedWousdBalance)) &&
+                wousdBalanceLoaded
                   ? displayedWousdBalance
                   : '--.--'
               }

--- a/dapp/src/services/apy.service.js
+++ b/dapp/src/services/apy.service.js
@@ -12,7 +12,7 @@ export default class ApyService {
           throw new Error(`Unexpected days param: ${days}`)
         }
         const response = await fetch(endpoint)
-        if (!response.ok) {
+        if (!response || !response.ok) {
           throw new Error(`Failed to fetch ${days} day APY`, err)
         }
         const json = await response.json()

--- a/dapp/src/services/balances.service.js
+++ b/dapp/src/services/balances.service.js
@@ -44,7 +44,7 @@ export default class BalancesService {
       body: JSON.stringify(data),
     })
 
-    if (!response.ok) {
+    if (!response || !response.ok) {
       throw new Error(
         `Could not fetch balances from Alchemy http status: ${response.status}`
       )

--- a/dapp/src/services/transaction-history-page.service.js
+++ b/dapp/src/services/transaction-history-page.service.js
@@ -19,7 +19,7 @@ export default class TransactionHistoryPageService {
       }/${account.toLowerCase()}/history?per_page=${transactionHistoryItemsPerPage}&page=${page}${filter_param}`
     )
 
-    if (!response.ok) {
+    if (!response || !response.ok) {
       throw new Error('Failed fetching history from analytics')
     }
 

--- a/dapp/src/services/transaction-history.service.js
+++ b/dapp/src/services/transaction-history.service.js
@@ -13,7 +13,7 @@ export default class TransactionHistoryService {
         this.baseURL
       }/${account.toLowerCase()}/history?per_page=1000000${filter_param}`
     )
-    if (!response.ok) {
+    if (!response || !response.ok) {
       throw new Error('Failed fetching history from analytics')
     }
 

--- a/dapp/src/utils/contracts.js
+++ b/dapp/src/utils/contracts.js
@@ -389,6 +389,9 @@ export async function setupContracts(account, library, chainId, fetchId) {
 
   const fetchCreditsPerToken = async () => {
     try {
+      if (!walletConnected) {
+        return
+      }
       const response = await fetch(process.env.CREDITS_ANALYTICS_ENDPOINT)
       if (response.ok) {
         const json = await response.json()


### PR DESCRIPTION
Issue https://github.com/OriginProtocol/origin-dollar/issues/823

`Disconnecting your wallet in MetaMask resets your balance, but not your pending yield or lifetime earnings`
and
`I had the opposite experience today: my balance remained but the other two numbers were removed.`

occurred because we were waiting until the fetch queries were completed in `AccountListener` after a wallet is disconnected. 

A good way to reproduce some of this behavior is to connect the wallet first. Then, open Chrome DevTools -> Network -> set it to "offline" to force fetch queries to fail. And then, disconnect the wallet and see that "Pending Yield" still has the value set on the header.

A better approach is to update `ContractStore` and set `ContractStore.walletConnected = false` when `useWeb3React` tells us that the account is no longer `active` as soon as the user disconnects their wallet.



