### PR TITLE
Sparrow dom/goveranance storage slots

### DIFF
--- a/contracts/contracts/ERC20BurnableUpgradeable.sol
+++ b/contracts/contracts/ERC20BurnableUpgradeable.sol
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v4.5.0) (token/ERC20/extensions/ERC20Burnable.sol)
+
+pragma solidity ^0.8.0;
+
+import { ContextUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+
+/**
+ * @dev Extension of {ERC20} that allows token holders to destroy both their own
+ * tokens and those that they have an allowance for, in a way that can be
+ * recognized off-chain (via event analysis).
+ */
+abstract contract ERC20BurnableUpgradeable is Initializable, ContextUpgradeable, ERC20Upgradeable {
+    function __ERC20Burnable_init() internal onlyInitializing {
+    }
+
+    function __ERC20Burnable_init_unchained() internal onlyInitializing {
+    }
+    /**
+     * @dev Destroys `amount` tokens from the caller.
+     *
+     * See {ERC20-_burn}.
+     */
+    function burn(uint256 amount) public virtual {
+        _burn(_msgSender(), amount);
+    }
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, deducting from the caller's
+     * allowance.
+     *
+     * See {ERC20-_burn} and {ERC20-allowance}.
+     *
+     * Requirements:
+     *
+     * - the caller must have allowance for ``accounts``'s tokens of at least
+     * `amount`.
+     */
+    function burnFrom(address account, uint256 amount) public virtual {
+        _spendAllowance(account, _msgSender(), amount);
+        _burn(account, amount);
+    }
+}

--- a/contracts/contracts/GovernanceToken.sol
+++ b/contracts/contracts/GovernanceToken.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+/// @custom:security-contact security@originprotocol.com
+contract OriginDollarGovernance is
+    Initializable,
+    ERC20Upgradeable,
+    OwnableUpgradeable,
+    UUPSUpgradeable,
+    AccessControlUpgradeable
+{
+    bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() initializer {}
+
+    function initialize() public initializer {
+        __ERC20_init("Origin Dollar Governance", "OGV");
+        __Ownable_init();
+        __UUPSUpgradeable_init();
+
+        _mint(msg.sender, 1000000000 * 10**decimals());
+    }
+
+    function mint(address to, uint256 amount) public onlyRole(MINTER_ROLE) {
+        _mint(to, amount);
+    }
+
+    function grantMinterRole(address _account) public onlyOwner {
+        _grantRole(MINTER_ROLE, _account);
+    }
+
+    function grantAdminRole(address _account) public onlyOwner {
+        _grantRole(DEFAULT_ADMIN_ROLE, _account);
+    }
+
+    function _authorizeUpgrade(address newImplementation)
+        internal
+        override
+        onlyOwner
+    {}
+}

--- a/contracts/contracts/GovernanceToken.sol
+++ b/contracts/contracts/GovernanceToken.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import { ERC20BurnableUpgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
+//import { ERC20BurnableUpgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
+import { ERC20BurnableUpgradeable } from "./ERC20BurnableUpgradeable.sol"; 
 //import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";

--- a/contracts/contracts/GovernanceToken.sol
+++ b/contracts/contracts/GovernanceToken.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { ERC20BurnableUpgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
+//import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
@@ -10,7 +11,8 @@ import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils
 /// @custom:security-contact security@originprotocol.com
 contract OriginDollarGovernance is
     Initializable,
-    ERC20Upgradeable,
+    ERC20BurnableUpgradeable,
+    //ERC20Upgradeable,
     OwnableUpgradeable,
     UUPSUpgradeable,
     AccessControlUpgradeable

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -60,5 +60,8 @@
     "hooks": {
       "pre-push": "yarn run prettier:check"
     }
+  },
+  "dependencies": {
+    "@openzeppelin/contracts-upgradeable": "4.6.0"
   }
 }

--- a/contracts/tasks/storageSlots.js
+++ b/contracts/tasks/storageSlots.js
@@ -273,7 +273,6 @@ const enrichLayoutData = (layout) => {
       sItem.newSlot = true;
       sItem.bits = 256;
     } else {
-      console.log("TYPE", sItem.type, sItem)
       throw new Error(
         `\x1b[31mUnexpected solidity type: ${sItem.type}  for item: ${sItem.label} located in ${sItem.src}\x1b[0m`
       );

--- a/contracts/tasks/storageSlots.js
+++ b/contracts/tasks/storageSlots.js
@@ -269,11 +269,13 @@ const enrichLayoutData = (layout) => {
       throw new Error(
         "\x1b[31mStructures are not yet supported. Logic needs to be updated (probably with recursion) \x1b[0m"
       );
+    } else if (sItem.type === "t_string_storage") {
+      sItem.newSlot = true;
+      sItem.bits = 256;
     } else {
+      console.log("TYPE", sItem.type, sItem)
       throw new Error(
-        "\x1b[31mUnexpected solidity type: ",
-        sItem.type,
-        "\x1b[0m"
+        `\x1b[31mUnexpected solidity type: ${sItem.type}  for item: ${sItem.label} located in ${sItem.src}\x1b[0m`
       );
     }
 

--- a/contracts/yarn.lock
+++ b/contracts/yarn.lock
@@ -670,6 +670,11 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
+"@openzeppelin/contracts-upgradeable@4.6.0":
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.6.0.tgz#1bf55f230f008554d4c6fe25eb165b85112108b0"
+  integrity sha512-5OnVuO4HlkjSCJO165a4i2Pu1zQGzMs//o54LPrwUgxvEO2P3ax1QuaSI0cEHHTveA77guS0PnNugpR2JMsPfA==
+
 "@openzeppelin/contracts@3.4.1-solc-0.7-2":
   version "3.4.1-solc-0.7-2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1-solc-0.7-2.tgz#371c67ebffe50f551c3146a9eec5fe6ffe862e92"


### PR DESCRIPTION
Make it easy to compare OriginDollarGovernance storage slots. To produce storage slot layout: 
- run `yarn install`
- run the node `yarn run node` so that OriginDollarGovernance compiles
- run `npx hardhat showStorageLayout --name OriginDollarGovernance` from the `contracts` folder
- comment in/out the different imported contract in the GovernanceToken.sol file

**Proposed solution:** contract contains also a possible solution. By removing the `_gap` in `ERC20BurnableUpgradeable` we leave all the storage slots intact. A version of this contract is also in the project. 