### PR TITLE
Metastrategy L-01

### DIFF
--- a/contracts/contracts/strategies/BaseCurveStrategy.sol
+++ b/contracts/contracts/strategies/BaseCurveStrategy.sol
@@ -127,6 +127,9 @@ abstract contract BaseCurveStrategy is InitializableAbstractStrategy {
             false
         );
 
+        // Adjust the required amount for the fee (fee is integer with 1e10 precision)
+        requiredCrv3Tokens += (requiredCrv3Tokens * curvePool.fee()) / 1e10;
+
         // We have enough LP tokens, make sure they are all on this contract
         if (contractCrv3Tokens < requiredCrv3Tokens) {
             _lpWithdraw(requiredCrv3Tokens - contractCrv3Tokens);

--- a/contracts/contracts/strategies/ICurvePool.sol
+++ b/contracts/contracts/strategies/ICurvePool.sol
@@ -6,6 +6,8 @@ interface ICurvePool {
 
     function add_liquidity(uint256[3] calldata _amounts, uint256 _min) external;
 
+    function fee() external view returns (uint256);
+
     function balances(uint256) external view returns (uint256);
 
     function calc_token_amount(uint256[3] calldata _amounts, bool _deposit)


### PR DESCRIPTION
**Issue description:**
The `withdraw` function of the `BaseCurveStrategy` determines the number of 3CRV
tokens to burn by using the price to [slightly overestimate](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/strategies/BaseCurveStrategy.sol#L134-L137) the desired value, [determining the
corresponding amount](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/strategies/BaseCurveStrategy.sol#L141-L144) of stablecoin, and then [scaling down the LP amount](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/strategies/BaseCurveStrategy.sol#L146) linearly to match
the required stablecoin value. Instead, consider directly querying the amount of LP tokens to
burn with the [calc_token_amount function](https://curve.readthedocs.io/exchange-pools.html#StableSwap.calc_token_amount), and then adjusting for fees. If desired, the
amount could be validated with the [calc_withdraw_one_coin function](https://curve.readthedocs.io/exchange-pools.html#StableSwap.calc_withdraw_one_coin).