### PR TITLE
Metastrategy L-02

### DIFF
--- a/contracts/contracts/strategies/BaseCurveStrategy.sol
+++ b/contracts/contracts/strategies/BaseCurveStrategy.sol
@@ -111,7 +111,7 @@ abstract contract BaseCurveStrategy is InitializableAbstractStrategy {
     ) external override onlyVault nonReentrant {
         require(_amount > 0, "Invalid amount");
 
-        emit Withdrawal(_asset, address(assetToPToken[_asset]), _amount);
+        emit Withdrawal(_asset, pTokenAddress, _amount);
 
         uint256 contractCrv3Tokens = IERC20(pTokenAddress).balanceOf(
             address(this)
@@ -201,9 +201,7 @@ abstract contract BaseCurveStrategy is InitializableAbstractStrategy {
         // LP tokens in this contract. This should generally be nothing as we
         // should always stake the full balance in the Gauge, but include for
         // safety
-        uint256 totalPTokens = IERC20(assetToPToken[_asset]).balanceOf(
-            address(this)
-        );
+        uint256 totalPTokens = IERC20(pTokenAddress).balanceOf(address(this));
         ICurvePool curvePool = ICurvePool(platformAddress);
         if (totalPTokens > 0) {
             uint256 virtual_price = curvePool.get_virtual_price();


### PR DESCRIPTION
**Issue description:**
The `BaseCurveStrategy` has two mechanisms to refer to the 3CRV token: [the generic
mapping](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/utils/InitializableAbstractStrategy.sol#L40) it inherits from `InitializableAbstractStrategy` and its [own local variable](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/strategies/BaseCurveStrategy.sol#L22). We
believe the local variable was introduced as a simplification, because all three assets
correspond to the same platform token, but it is used inconsistently. In particular:
- The `withdraw` function equivocates between the mapping and the local variable in the
[event emission and balance check](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/strategies/BaseCurveStrategy.sol#L114-L118).
- The `checkBalance` function [uses the mapping](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/strategies/BaseCurveStrategy.sol#L200-L206) to retrieve the platform token balance
but then [assumes the asset is worth one third of the value](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/strategies/BaseCurveStrategy.sol#L212). This only makes sense if
there are three assets mapping to the same platform token.
- There are code comments that [explicitly account](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/strategies/BaseCurveStrategy.sol#L180-L181) for the possibility that not all assets are
mapped correctly.

Consider using the local variable throughout the contract and disabling the ability to set the
mapping individually.