### PR TITLE
Metastrategy L-03 [Inconsistent rebase bound]

### DIFF
--- a/contracts/contracts/vault/VaultCore.sol
+++ b/contracts/contracts/vault/VaultCore.sol
@@ -226,7 +226,7 @@ contract VaultCore is VaultStorage {
         // by withdrawing them, this should be here.
         // It's possible that a strategy was off on its asset total, perhaps
         // a reward token sold for more or for less than anticipated.
-        if (_amount > rebaseThreshold && !rebasePaused) {
+        if (_amount >= rebaseThreshold && !rebasePaused) {
             _rebase();
         }
     }
@@ -262,7 +262,7 @@ contract VaultCore is VaultStorage {
         // by withdrawing them, this should be here.
         // It's possible that a strategy was off on its asset total, perhaps
         // a reward token sold for more or for less than anticipated.
-        if (_amount > rebaseThreshold && !rebasePaused) {
+        if (_amount >= rebaseThreshold && !rebasePaused) {
             _rebase();
         }
     }


### PR DESCRIPTION
**Issue description:**
When minting OUSD tokens, there will be a rebase if the [amount equals the threshold](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/vault/VaultCore.sol#L129).
However, when [redeeming](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/vault/VaultCore.sol#L229) or [burning](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/vault/VaultCore.sol#L265) tokens, the amount needs to be strictly greater than the
threshold. Consider using an exclusive (or inclusive) bound throughout the code base.