### PR TITLE
Metastrategy L-04 [Incorrect event parameter]

### DIFF
--- a/contracts/contracts/strategies/BaseCurveStrategy.sol
+++ b/contracts/contracts/strategies/BaseCurveStrategy.sol
@@ -33,7 +33,7 @@ abstract contract BaseCurveStrategy is InitializableAbstractStrategy {
         nonReentrant
     {
         require(_amount > 0, "Must deposit something");
-        emit Deposit(_asset, address(platformAddress), _amount);
+        emit Deposit(_asset, pTokenAddress, _amount);
 
         // 3Pool requires passing deposit amounts for all 3 assets, set to 0 for
         // all
@@ -80,7 +80,7 @@ abstract contract BaseCurveStrategy is InitializableAbstractStrategy {
                     balance.scaleBy(18, assetDecimals).divPrecisely(
                         curveVirtualPrice
                     );
-                emit Deposit(assetAddress, address(platformAddress), balance);
+                emit Deposit(assetAddress, pTokenAddress, balance);
             }
         }
 


### PR DESCRIPTION
**Issue description:**
[Both](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/strategies/BaseCurveStrategy.sol#L36) [emissions](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/strategies/BaseCurveStrategy.sol#L83) of the `Deposit` event in the `BaseCurveStrategy` contract use the
`platformAddress` (after redundantly casting it to an address type) as the `_pToken`
parameter. Consider using the `pTokenAddress` [variable](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/strategies/BaseCurveStrategy.sol#L22) instead.