### PR TITLE
Metastrategy L-06 [Missing docstrings]

### DIFF
--- a/contracts/contracts/strategies/BaseConvexMetaStrategy.sol
+++ b/contracts/contracts/strategies/BaseConvexMetaStrategy.sol
@@ -168,8 +168,8 @@ abstract contract BaseConvexMetaStrategy is BaseCurveStrategy {
     /**
      * @dev Sets max withdrawal slippage that is considered when removing
      * liquidity from Metapools.
-     *
-     * 1e18 == 100%, 1e16 == 1%
+     * @param _maxWithdrawalSlippage Max withdrawal slippage denominated in
+     *        wad (number with 18 decimals): 1e18 == 100%, 1e16 == 1%
      */
     function setMaxWithdrawalSlippage(uint256 _maxWithdrawalSlippage)
         external


### PR DESCRIPTION
The `setMaxWithdrawalSlippage` [function](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/strategies/BaseConvexMetaStrategy.sol#L174) of the `BaseConvexMetaStrategy` contract is
missing its `@param` statement. Consider including it.