### PR TITLE
Metastrategy L-08 [Inconsistent storage gaps]

### DIFF
--- a/contracts/contracts/strategies/BaseConvexMetaStrategy.sol
+++ b/contracts/contracts/strategies/BaseConvexMetaStrategy.sol
@@ -48,7 +48,7 @@ abstract contract BaseConvexMetaStrategy is BaseCurveStrategy {
     uint128 crvCoinIndex;
     uint128 mainCoinIndex;
 
-    int256[41] private __reserved;
+    int256[41] private ___reserved;
 
     /**
      * Initializer for setting up strategy internal state. This overrides the

--- a/contracts/contracts/strategies/BaseConvexMetaStrategy.sol
+++ b/contracts/contracts/strategies/BaseConvexMetaStrategy.sol
@@ -48,7 +48,7 @@ abstract contract BaseConvexMetaStrategy is BaseCurveStrategy {
     uint128 crvCoinIndex;
     uint128 mainCoinIndex;
 
-    int256[30] private __reserved;
+    int256[41] private __reserved;
 
     /**
      * Initializer for setting up strategy internal state. This overrides the

--- a/contracts/contracts/strategies/BaseCurveStrategy.sol
+++ b/contracts/contracts/strategies/BaseCurveStrategy.sol
@@ -21,6 +21,8 @@ abstract contract BaseCurveStrategy is InitializableAbstractStrategy {
     uint256 internal constant maxSlippage = 1e16; // 1%, same as the Curve UI
     address internal pTokenAddress;
 
+    int256[49] private __reserved;
+
     /**
      * @dev Deposit asset into the Curve 3Pool
      * @param _asset Address of asset to deposit

--- a/contracts/contracts/strategies/ConvexStrategy.sol
+++ b/contracts/contracts/strategies/ConvexStrategy.sol
@@ -15,6 +15,13 @@ import { IERC20, BaseCurveStrategy } from "./BaseCurveStrategy.sol";
 import { StableMath } from "../utils/StableMath.sol";
 import { Helpers } from "../utils/Helpers.sol";
 
+/*
+ * IMPORTANT(!) If ConvexStrategy needs to be re-deployed, it requires new
+ * proxy contract with fresh storage slots. Changes in `BaseCurveStrategy`
+ * storage slots would break existing implementation.
+ *
+ * Remove this notice if ConvexStrategy is re-deployed
+ */
 contract ConvexStrategy is BaseCurveStrategy {
     using StableMath for uint256;
     using SafeERC20 for IERC20;

--- a/contracts/contracts/strategies/ThreePoolStrategy.sol
+++ b/contracts/contracts/strategies/ThreePoolStrategy.sol
@@ -19,7 +19,7 @@ import { Helpers } from "../utils/Helpers.sol";
  * IMPORTANT(!) If ThreePoolStrategy needs to be re-deployed, it requires new
  * proxy contract with fresh storage slots. Changes in `BaseCurveStrategy`
  * storage slots would break existing implementation.
- * 
+ *
  * Remove this notice if ThreePoolStrategy is re-deployed
  */
 contract ThreePoolStrategy is BaseCurveStrategy {

--- a/contracts/contracts/strategies/ThreePoolStrategy.sol
+++ b/contracts/contracts/strategies/ThreePoolStrategy.sol
@@ -15,6 +15,11 @@ import { IERC20, BaseCurveStrategy } from "./BaseCurveStrategy.sol";
 import { StableMath } from "../utils/StableMath.sol";
 import { Helpers } from "../utils/Helpers.sol";
 
+/*
+ * IMPORTANT(!) If TreePoolStrategy is every to be re-deployed, it needs new
+ * proxy contract with fresh storage slots. Changes in `BaseCurveStrategy`
+ * storage slots would break existing implementation.
+ */
 contract ThreePoolStrategy is BaseCurveStrategy {
     using StableMath for uint256;
     using SafeERC20 for IERC20;

--- a/contracts/contracts/strategies/ThreePoolStrategy.sol
+++ b/contracts/contracts/strategies/ThreePoolStrategy.sol
@@ -16,9 +16,11 @@ import { StableMath } from "../utils/StableMath.sol";
 import { Helpers } from "../utils/Helpers.sol";
 
 /*
- * IMPORTANT(!) If TreePoolStrategy is every to be re-deployed, it needs new
+ * IMPORTANT(!) If ThreePoolStrategy needs to be re-deployed, it requires new
  * proxy contract with fresh storage slots. Changes in `BaseCurveStrategy`
  * storage slots would break existing implementation.
+ * 
+ * Remove this notice if ThreePoolStrategy is re-deployed
  */
 contract ThreePoolStrategy is BaseCurveStrategy {
     using StableMath for uint256;

--- a/contracts/contracts/utils/InitializableAbstractStrategy.sol
+++ b/contracts/contracts/utils/InitializableAbstractStrategy.sol
@@ -55,7 +55,11 @@ abstract contract InitializableAbstractStrategy is Initializable, Governable {
 
     // Reward token addresses
     address[] public rewardTokenAddresses;
-    // Reserved for future expansion
+    /* Reserved for future expansion. Used to be 100 storage slots
+     * and has decreased to accommodate: 
+     * - harvesterAddress
+     * - rewardTokenAddresses
+     */
     int256[98] private _reserved;
 
     /**

--- a/contracts/contracts/utils/InitializableAbstractStrategy.sol
+++ b/contracts/contracts/utils/InitializableAbstractStrategy.sol
@@ -56,7 +56,7 @@ abstract contract InitializableAbstractStrategy is Initializable, Governable {
     // Reward token addresses
     address[] public rewardTokenAddresses;
     /* Reserved for future expansion. Used to be 100 storage slots
-     * and has decreased to accommodate: 
+     * and has decreased to accommodate:
      * - harvesterAddress
      * - rewardTokenAddresses
      */


### PR DESCRIPTION
**Issue description:**
When using the proxy pattern for upgrades, it is common practice to include storage gaps on
parent contracts to reserve space for potential future variables. The size is typically chosen so
that all contracts have the same number of variables (usually 50). However, the code base uses
inconsistent sizes and does not always include a gap at all. In particular:
- The `InitializableAbstractStrategy` contract [reserves 98 slots](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/utils/InitializableAbstractStrategy.sol#L59), bringing the total
storage usage up to 106.
- The `BaseCurveStrategy` has no storage gaps.
The `BaseConvexMetaStrategy` contract [reserves 30 slots](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/strategies/BaseConvexMetaStrategy.sol#L51), bringing the total storage
usage up to 39.

Consider using consistently sized storage gaps in all contracts that have not yet been
deployed. For contracts that cannot be changed, because they are ancestors of live contracts
in the code base, consider documenting the unusual storage size to facilitate safe upgrades.