### PR TITLE
Metastrategy N-01 [Constants not declared explicitly] 

### DIFF
--- a/contracts/contracts/strategies/BaseConvexMetaStrategy.sol
+++ b/contracts/contracts/strategies/BaseConvexMetaStrategy.sol
@@ -132,7 +132,7 @@ abstract contract BaseConvexMetaStrategy is BaseCurveStrategy {
         }
 
         uint256 assetDecimals = Helpers.getDecimals(_asset);
-        balance = balance.scaleBy(assetDecimals, 18) / 3;
+        balance = balance.scaleBy(assetDecimals, 18) / THREEPOOL_ASSET_COUNT;
     }
 
     function _approveBase() internal override {

--- a/contracts/contracts/strategies/BaseCurveStrategy.sol
+++ b/contracts/contracts/strategies/BaseCurveStrategy.sol
@@ -18,7 +18,9 @@ abstract contract BaseCurveStrategy is InitializableAbstractStrategy {
     using StableMath for uint256;
     using SafeERC20 for IERC20;
 
-    uint256 internal constant maxSlippage = 1e16; // 1%, same as the Curve UI
+    uint256 internal constant MAX_SLIPPAGE = 1e16; // 1%, same as the Curve UI
+    // number of assets in Curve 3Pool (USDC, DAI, USDT)
+    uint256 internal constant THREEPOOL_ASSET_COUNT = 3;
     address internal pTokenAddress;
 
     /**
@@ -47,7 +49,7 @@ abstract contract BaseCurveStrategy is InitializableAbstractStrategy {
             curvePool.get_virtual_price()
         );
         uint256 minMintAmount = depositValue.mulTruncate(
-            uint256(1e18) - maxSlippage
+            uint256(1e18) - MAX_SLIPPAGE
         );
         // Do the deposit to 3pool
         curvePool.add_liquidity(_amounts, minMintAmount);
@@ -85,7 +87,7 @@ abstract contract BaseCurveStrategy is InitializableAbstractStrategy {
         }
 
         uint256 minMintAmount = depositValue.mulTruncate(
-            uint256(1e18) - maxSlippage
+            uint256(1e18) - MAX_SLIPPAGE
         );
         // Do the deposit to 3pool
         curvePool.add_liquidity(_amounts, minMintAmount);
@@ -209,7 +211,7 @@ abstract contract BaseCurveStrategy is InitializableAbstractStrategy {
             uint256 virtual_price = curvePool.get_virtual_price();
             uint256 value = (totalPTokens * virtual_price) / 1e18;
             uint256 assetDecimals = Helpers.getDecimals(_asset);
-            balance = value.scaleBy(assetDecimals, 18) / 3;
+            balance = value.scaleBy(assetDecimals, 18) / THREEPOOL_ASSET_COUNT;
         }
     }
 

--- a/contracts/contracts/strategies/ConvexGeneralizedMetaStrategy.sol
+++ b/contracts/contracts/strategies/ConvexGeneralizedMetaStrategy.sol
@@ -43,7 +43,7 @@ contract ConvexGeneralizedMetaStrategy is BaseConvexMetaStrategy {
          */
         uint256 minReceived = threePoolLpDollarValue
             .divPrecisely(metapoolVirtualPrice)
-            .mulTruncate(uint256(1e18) - maxSlippage);
+            .mulTruncate(uint256(1e18) - MAX_SLIPPAGE);
 
         // slither-disable-next-line unused-return
         metapool.add_liquidity(_amounts, minReceived);

--- a/contracts/contracts/strategies/ConvexOUSDMetaStrategy.sol
+++ b/contracts/contracts/strategies/ConvexOUSDMetaStrategy.sol
@@ -76,7 +76,7 @@ contract ConvexOUSDMetaStrategy is BaseConvexMetaStrategy {
          */
         uint256 minReceived = (ousdBalance + threePoolLpDollarValue)
             .divPrecisely(metapoolVirtualPrice)
-            .mulTruncate(uint256(1e18) - maxSlippage);
+            .mulTruncate(uint256(1e18) - MAX_SLIPPAGE);
 
         // slither-disable-next-line unused-return
         metapool.add_liquidity(_amounts, minReceived);


### PR DESCRIPTION
**Issue description:**
There are some occurrences of literal values with unexplained meaning in Origin's contracts.
For example, [line 135](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/strategies/BaseConvexMetaStrategy.sol#L135) in `BaseConvexMetaStrategy` and line [212](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/strategies/BaseCurveStrategy.sol#L212) in
BaseCurveStrategy.sol . Literal values in the code base without an explained meaning
make the code harder to read, understand, and maintain. This makes the code harder to
understand for developers, auditors, and external contributors alike.

Developers should define a constant variable for every magic value used (including booleans),
giving it a clear and self-explanatory name. Additionally, for complex values, inline comments
explaining how they were calculated or why they were chosen are highly recommended.
Following [Solidity's style guide](https://docs.soliditylang.org/en/latest/style-guide.html#constants), constants should be named in
`UPPER_CASE_WITH_UNDERSCORES` format.