### PR TITLE
Metastrategy N-02 [Implicit visibility]

### DIFF
--- a/contracts/contracts/strategies/BaseConvexMetaStrategy.sol
+++ b/contracts/contracts/strategies/BaseConvexMetaStrategy.sol
@@ -45,8 +45,8 @@ abstract contract BaseConvexMetaStrategy is BaseCurveStrategy {
     address[] internal metapoolAssets;
     // Max withdrawal slippage denominated in 1e18 (1e18 == 100%)
     uint256 public maxWithdrawalSlippage = 1e16;
-    uint128 crvCoinIndex;
-    uint128 mainCoinIndex;
+    uint128 internal crvCoinIndex;
+    uint128 internal mainCoinIndex;
 
     int256[30] private __reserved;
 


### PR DESCRIPTION
**Issue description:**
The state variables [crvCoinIndex](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/strategies/BaseConvexMetaStrategy.sol#L48-L49) and [mainCoinIndex](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/strategies/BaseConvexMetaStrategy.sol#L48-L49) in the
`BaseConvexMetaStrategy` contract do not have an explicit visibility modifier. In the interest
of clarity, consider including it.