### PR TITLE
Metastrategy L-03 [Misusing safeApprove]

### DIFF
--- a/contracts/contracts/strategies/BaseConvexMetaStrategy.sol
+++ b/contracts/contracts/strategies/BaseConvexMetaStrategy.sol
@@ -138,17 +138,17 @@ abstract contract BaseConvexMetaStrategy is BaseCurveStrategy {
     function _approveBase() internal override {
         IERC20 pToken = IERC20(pTokenAddress);
         // 3Pool for LP token (required for removing liquidity)
-        pToken.safeApprove(platformAddress, 0);
-        pToken.safeApprove(platformAddress, type(uint256).max);
+        pToken.approve(platformAddress, 0);
+        pToken.approve(platformAddress, type(uint256).max);
         // Gauge for LP token
-        metapoolLPToken.safeApprove(cvxDepositorAddress, 0);
-        metapoolLPToken.safeApprove(cvxDepositorAddress, type(uint256).max);
+        metapoolLPToken.approve(cvxDepositorAddress, 0);
+        metapoolLPToken.approve(cvxDepositorAddress, type(uint256).max);
         // Metapool for LP token
-        pToken.safeApprove(address(metapool), 0);
-        pToken.safeApprove(address(metapool), type(uint256).max);
+        pToken.approve(address(metapool), 0);
+        pToken.approve(address(metapool), type(uint256).max);
         // Metapool for Metapool main token
-        metapoolMainToken.safeApprove(address(metapool), 0);
-        metapoolMainToken.safeApprove(address(metapool), type(uint256).max);
+        metapoolMainToken.approve(address(metapool), 0);
+        metapoolMainToken.approve(address(metapool), type(uint256).max);
     }
 
     /**

--- a/contracts/contracts/strategies/BaseCurveStrategy.sol
+++ b/contracts/contracts/strategies/BaseCurveStrategy.sol
@@ -258,8 +258,8 @@ abstract contract BaseCurveStrategy is InitializableAbstractStrategy {
     function _approveAsset(address _asset) internal {
         IERC20 asset = IERC20(_asset);
         // 3Pool for asset (required for adding liquidity)
-        asset.safeApprove(platformAddress, 0);
-        asset.safeApprove(platformAddress, type(uint256).max);
+        asset.approve(platformAddress, 0);
+        asset.approve(platformAddress, type(uint256).max);
     }
 
     function _approveBase() internal virtual;


### PR DESCRIPTION
**Issue description:**
The `BaseCurveStrategy` [contract](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/strategies/BaseCurveStrategy.sol#L261-L262) and the `BaseConvexMetaStrategy` [contract](https://github.com/OriginProtocol/origin-dollar/blob/bfe0ac8e5d7c05b9bf1021fafb25e0aed8a6ed45/contracts/contracts/strategies/BaseConvexMetaStrategy.sol#L138) provides
functionality to grant addresses an infinite allowance. However, they bypass the safety
mechanism in `safeApprove` that prevents changing the allowance between two non-zero
values, which is intended to prevent front-running attacks that spend both allowances. In this
case, since the intended allowance is unlimited, the possibility of front-running is irrelevant.
Nevertheless, we consider it bad practice to use a safety mechanism while bypassing its
additional requirements. Consider using the standard `approve` function and validating that it
succeeds.