### PR TITLE
Remove lower bound -> C-02

### DIFF
--- a/contracts/contracts/strategies/BaseConvexMetaStrategy.sol
+++ b/contracts/contracts/strategies/BaseConvexMetaStrategy.sol
@@ -170,14 +170,18 @@ abstract contract BaseConvexMetaStrategy is BaseCurveStrategy {
      * liquidity from Metapools.
      * @param _maxWithdrawalSlippage Max withdrawal slippage denominated in
      *        wad (number with 18 decimals): 1e18 == 100%, 1e16 == 1%
+     *
+     * IMPORTANT Minimum maxWithdrawalSlippage should actually be 0.1% (1e15)
+     * for production usage. Contract allows as low value as 0% for confirming
+     * correct behavior in test suite.
      */
     function setMaxWithdrawalSlippage(uint256 _maxWithdrawalSlippage)
         external
         onlyVaultOrGovernorOrStrategist
     {
         require(
-            _maxWithdrawalSlippage >= 1e15 && _maxWithdrawalSlippage <= 1e17,
-            "Max withdrawal slippage needs to be between 0.1% - 10%"
+            _maxWithdrawalSlippage <= 1e17,
+            "Max withdrawal slippage needs to be between 0% - 10%"
         );
         emit MaxWithdrawalSlippageUpdated(
             maxWithdrawalSlippage,

--- a/contracts/test/strategies/generalized-meta.fork-test.js
+++ b/contracts/test/strategies/generalized-meta.fork-test.js
@@ -234,7 +234,7 @@ metastrategies.forEach(
 
             expect(error).to.be.oneOf([
               "Transaction reverted without a reason string",
-              `'Not enough coins removed'`,
+              `\\'Not enough coins removed\\'`,
             ]);
 
             // should not revert when slippage tolerance set to 10%

--- a/contracts/test/strategies/generalized-meta.fork-test.js
+++ b/contracts/test/strategies/generalized-meta.fork-test.js
@@ -27,7 +27,7 @@ const metastrategies = [
     rewardPoolAddress: "0xDBFa6187C79f4fE4Cda20609E75760C5AaE88e52",
     // metapool implementation wont allow tilting of the pools the way this test does it
     // and then withdrawing liquidity
-    skipMewTest: true,
+    skipMewTest: false,
   },
   {
     token: "USDD",
@@ -218,7 +218,7 @@ metastrategies.forEach(
 
             await fixture.metaStrategy
               .connect(sGovernor)
-              .setMaxWithdrawalSlippage(ousdUnits("0.001"));
+              .setMaxWithdrawalSlippage(ousdUnits("0"));
             await tiltToMainToken(fixture);
 
             await expect(

--- a/contracts/test/strategies/generalized-meta.fork-test.js
+++ b/contracts/test/strategies/generalized-meta.fork-test.js
@@ -221,19 +221,21 @@ metastrategies.forEach(
               .setMaxWithdrawalSlippage(ousdUnits("0"));
             await tiltToMainToken(fixture);
 
-
-            let error = false
+            let error = false;
             try {
               await vault
                 .connect(sGovernor)
-                .withdrawAllFromStrategy(fixture.metaStrategyProxy.address)
+                .withdrawAllFromStrategy(fixture.metaStrategyProxy.address);
 
               expect.fail("Transaction not reverted");
-            } catch(e) {
-              error = e.message
+            } catch (e) {
+              error = e.message;
             }
 
-            expect(error).to.be.oneOf(["Transaction reverted without a reason string", "Not enough coins removed"])
+            expect(error).to.be.oneOf([
+              "Transaction reverted without a reason string",
+              "Not enough coins removed",
+            ]);
 
             // should not revert when slippage tolerance set to 10%
             await fixture.metaStrategy

--- a/contracts/test/strategies/generalized-meta.fork-test.js
+++ b/contracts/test/strategies/generalized-meta.fork-test.js
@@ -234,7 +234,7 @@ metastrategies.forEach(
 
             expect(error).to.be.oneOf([
               "Transaction reverted without a reason string",
-              `\'Not enough coins removed\'`,
+              `'Not enough coins removed'`,
             ]);
 
             // should not revert when slippage tolerance set to 10%

--- a/contracts/test/strategies/generalized-meta.fork-test.js
+++ b/contracts/test/strategies/generalized-meta.fork-test.js
@@ -234,7 +234,7 @@ metastrategies.forEach(
 
             expect(error).to.be.oneOf([
               "Transaction reverted without a reason string",
-              "VM Exception while processing transaction: reverted with reason string \'Not enough coins removed\'",
+              "VM Exception while processing transaction: reverted with reason string \\'Not enough coins removed\\'",
             ]);
 
             // should not revert when slippage tolerance set to 10%

--- a/contracts/test/strategies/generalized-meta.fork-test.js
+++ b/contracts/test/strategies/generalized-meta.fork-test.js
@@ -234,7 +234,7 @@ metastrategies.forEach(
 
             expect(error).to.be.oneOf([
               "Transaction reverted without a reason string",
-              "VM Exception while processing transaction: reverted with reason string \\'Not enough coins removed\\'",
+              "VM Exception while processing transaction: reverted with reason string 'Not enough coins removed'",
             ]);
 
             // should not revert when slippage tolerance set to 10%

--- a/contracts/test/strategies/generalized-meta.fork-test.js
+++ b/contracts/test/strategies/generalized-meta.fork-test.js
@@ -232,6 +232,10 @@ metastrategies.forEach(
               error = e.message;
             }
 
+            /* Different implementations of Curve's StableSwap pools fail differently when the
+             * the minimum expected token payout threshold is not reached. For that reason we
+             * test the revert error against multiple possible values.
+             */
             expect(error).to.be.oneOf([
               "Transaction reverted without a reason string",
               "VM Exception while processing transaction: reverted with reason string 'Not enough coins removed'",

--- a/contracts/test/strategies/generalized-meta.fork-test.js
+++ b/contracts/test/strategies/generalized-meta.fork-test.js
@@ -27,7 +27,7 @@ const metastrategies = [
     rewardPoolAddress: "0xDBFa6187C79f4fE4Cda20609E75760C5AaE88e52",
     // metapool implementation wont allow tilting of the pools the way this test does it
     // and then withdrawing liquidity
-    skipMewTest: false,
+    skipMewTest: true,
   },
   {
     token: "USDD",

--- a/contracts/test/strategies/generalized-meta.fork-test.js
+++ b/contracts/test/strategies/generalized-meta.fork-test.js
@@ -27,7 +27,7 @@ const metastrategies = [
     rewardPoolAddress: "0xDBFa6187C79f4fE4Cda20609E75760C5AaE88e52",
     // metapool implementation wont allow tilting of the pools the way this test does it
     // and then withdrawing liquidity
-    skipMewTest: true,
+    skipMewTest: false,
   },
   {
     token: "USDD",
@@ -221,13 +221,19 @@ metastrategies.forEach(
               .setMaxWithdrawalSlippage(ousdUnits("0"));
             await tiltToMainToken(fixture);
 
-            await expect(
-              vault
+
+            let error = false
+            try {
+              await vault
                 .connect(sGovernor)
                 .withdrawAllFromStrategy(fixture.metaStrategyProxy.address)
-            ).to.be.revertedWith(
-              "Transaction reverted without a reason string"
-            );
+
+              expect.fail("Transaction not reverted");
+            } catch(e) {
+              error = e.message
+            }
+
+            expect(error).to.be.oneOf(["Transaction reverted without a reason string", "Not enough coins removed"])
 
             // should not revert when slippage tolerance set to 10%
             await fixture.metaStrategy

--- a/contracts/test/strategies/generalized-meta.fork-test.js
+++ b/contracts/test/strategies/generalized-meta.fork-test.js
@@ -234,7 +234,7 @@ metastrategies.forEach(
 
             expect(error).to.be.oneOf([
               "Transaction reverted without a reason string",
-              `\\'Not enough coins removed\\'`,
+              "VM Exception while processing transaction: reverted with reason string \'Not enough coins removed\'",
             ]);
 
             // should not revert when slippage tolerance set to 10%

--- a/contracts/test/strategies/generalized-meta.fork-test.js
+++ b/contracts/test/strategies/generalized-meta.fork-test.js
@@ -234,7 +234,7 @@ metastrategies.forEach(
 
             expect(error).to.be.oneOf([
               "Transaction reverted without a reason string",
-              "Not enough coins removed",
+              `\'Not enough coins removed\'`,
             ]);
 
             // should not revert when slippage tolerance set to 10%


### PR DESCRIPTION
Remove lower bound of `maxWithdrawalSlippage`

Main reason for doing this is so that in test environment we can set the `maxWithdrawalSlippage` to 0% and confirm the correct behaviour of curve StableSwap contracts in combination with generalized metastrategy contract. When doing `withdrawAll` with too small `maxWithdrawalSlippage` the transaction should revert. 