### PR TITLE
fix stake transfer bug

### DIFF
--- a/dapp/src/components/SignTransferAuth.js
+++ b/dapp/src/components/SignTransferAuth.js
@@ -25,7 +25,7 @@ const SignTransferAuth = ({}) => {
     <>
       <div>
         <div className="content-holder flex-grow d-flex flex-column shadow-div">
-          {active && (
+          {active && ognStaking && (
             <div>
               {' '}
               on {ognStaking.address} Transfer stakes from {account} to:


### PR DESCRIPTION
Fix bug on /signTransfer page. If visiting the page with an already connected account, contract data won't be fetch in time crashing the page - fix by adding a check for contract data alongside account data