### PR TITLE
rename env var

### DIFF
--- a/dapp/lib/gtm.js
+++ b/dapp/lib/gtm.js
@@ -1,4 +1,4 @@
-export const GTM_ID = process.env.NEXT_PUBLIC_GOOGLE_TAG_MANAGER_ID
+export const GTM_ID = process.env.GOOGLE_TAG_MANAGER_ID
 
 export const pageview = () => {
   window?.dataLayer?.push({


### PR DESCRIPTION
rename gtm env var to be available at build time, requires adding new variable in prod