### PR TITLE
possible contract moves to circumvent delegate calls

### DIFF
--- a/contracts/contracts/strategies/uniswap/UniswapV3LiquidityManager.sol
+++ b/contracts/contracts/strategies/uniswap/UniswapV3LiquidityManager.sol
@@ -787,15 +787,10 @@ contract UniswapV3LiquidityManager is UniswapV3StrategyStorage {
      */
     function withdrawAll() external override onlyVault nonReentrant {
         if (activeTokenId > 0) {
-            // TODO: This method is only callable from Vault directly
-            // and by Governor or Strategist indirectly.
-            // Changing the Vault code to pass a minAmount0 and minAmount1 will
-            // make things complex. We could perhaps make sure that there're no
-            // active position when withdrawingAll rather than passing zero values?
-
             _closePosition(activeTokenId, 0, 0);
         }
 
+        // saves 100B of contract size to loop through these 2 tokens
         address[2] memory tokens = [token0, token1];
         for(uint256 i = 0; i < 2; i++) {
             IERC20 tokenContract = IERC20(tokens[i]);    

--- a/contracts/contracts/strategies/uniswap/UniswapV3LiquidityManager.sol
+++ b/contracts/contracts/strategies/uniswap/UniswapV3LiquidityManager.sol
@@ -14,10 +14,16 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
 contract UniswapV3LiquidityManager is UniswapV3StrategyStorage {
     using SafeERC20 for IERC20;
 
-    // TODO: Intentionally left out non-reentrant modifier since otherwise Vault would throw
     function withdrawAssetFromActivePosition(address _asset, uint256 amount)
-        public
+        external
         onlyVault
+        nonReentrant
+    {
+        _withdrawAssetFromActivePosition(_asset, amount);
+    }
+
+    function _withdrawAssetFromActivePosition(address _asset, uint256 amount)
+        internal
     {
         Position memory position = tokenIdToPosition[activeTokenId];
         require(position.exists && position.liquidity > 0, "Liquidity error");
@@ -774,7 +780,7 @@ contract UniswapV3LiquidityManager is UniswapV3StrategyStorage {
         uint256 selfBalance = asset.balanceOf(address(this));
 
         if (selfBalance < amount) {
-            withdrawAssetFromActivePosition(_asset, amount - selfBalance);
+            _withdrawAssetFromActivePosition(_asset, amount - selfBalance);
         }
 
         // Transfer requested amount

--- a/contracts/contracts/strategies/uniswap/UniswapV3Strategy.sol
+++ b/contracts/contracts/strategies/uniswap/UniswapV3Strategy.sol
@@ -234,14 +234,7 @@ contract UniswapV3Strategy is UniswapV3StrategyStorage {
 
     /// @inheritdoc InitializableAbstractStrategy
     function depositAll() external override onlyVault nonReentrant {
-        _depositAll();
-    }
-
-    /**
-     * @notice Deposits all undeployed balances of the contract to the reserve strategies
-     */
-    function _depositAll() internal {
-        UniswapV3Library.depositAll(
+        _depositAll(
             token0,
             token1,
             vaultAddress,
@@ -258,64 +251,15 @@ contract UniswapV3Strategy is UniswapV3StrategyStorage {
         address _asset,
         uint256 amount
     ) external override onlyVault onlyPoolTokens(_asset) nonReentrant {
-        IERC20 asset = IERC20(_asset);
-        uint256 selfBalance = asset.balanceOf(address(this));
-
-        if (selfBalance < amount) {
-            (bool success, bytes memory data) = address(this).delegatecall(
-                abi.encodeWithSignature(
-                    "withdrawAssetFromActivePosition(asset,uint256)",
-                    _asset,
-                    amount - selfBalance
-                )
-            );
-
-            require(success, "Failed to liquidate active position");
-        }
-
-        // Transfer requested amount
-        asset.safeTransfer(recipient, amount);
-        emit Withdrawal(_asset, _asset, amount);
+        revert("NO_IMPL");
     }
 
     /**
      * @notice Closes active LP position, if any, and transfer all token balance to Vault
      * @inheritdoc InitializableAbstractStrategy
      */
-    function withdrawAll() external override onlyVault nonReentrant {
-        if (activeTokenId > 0) {
-            // TODO: This method is only callable from Vault directly
-            // and by Governor or Strategist indirectly.
-            // Changing the Vault code to pass a minAmount0 and minAmount1 will
-            // make things complex. We could perhaps make sure that there're no
-            // active position when withdrawingAll rather than passing zero values?
-
-            (bool success, bytes memory data) = address(this).delegatecall(
-                abi.encodeWithSignature(
-                    "closePositionOnlyVault(uint256,uint256,uint256)",
-                    activeTokenId,
-                    0,
-                    0
-                )
-            );
-
-            require(success, "Failed to close active position");
-        }
-
-        IERC20 token0Contract = IERC20(token0);
-        IERC20 token1Contract = IERC20(token1);
-
-        uint256 token0Balance = token0Contract.balanceOf(address(this));
-        if (token0Balance > 0) {
-            token0Contract.safeTransfer(vaultAddress, token0Balance);
-            emit Withdrawal(token0, token0, token0Balance);
-        }
-
-        uint256 token1Balance = token1Contract.balanceOf(address(this));
-        if (token1Balance > 0) {
-            token1Contract.safeTransfer(vaultAddress, token1Balance);
-            emit Withdrawal(token1, token1, token1Balance);
-        }
+    function withdrawAll() external virtual override {
+        revert("NO_IMPL");
     }
 
     /***************************************

--- a/contracts/deploy/049_uniswap_usdc_usdt_strategy.js
+++ b/contracts/deploy/049_uniswap_usdc_usdt_strategy.js
@@ -50,17 +50,11 @@ module.exports = deploymentWithGovernanceProposal(
       "UniswapV3Strategy",
       undefined,
       undefined,
-      {
-        UniswapV3Library: dUniV3Lib.address,
-      }
     );
     const dUniV3PoolLiquidityManager = await deployWithConfirmation(
       "UniswapV3LiquidityManager",
       undefined,
       undefined,
-      {
-        UniswapV3Library: dUniV3Lib.address,
-      }
     );
     const cUniV3_USDC_USDT_Strategy = await ethers.getContractAt(
       "UniswapV3Strategy",

--- a/contracts/test/_fixture.js
+++ b/contracts/test/_fixture.js
@@ -112,7 +112,6 @@ async function defaultFixture() {
 
   const buyback = await ethers.getContract("Buyback");
 
-  const UniV3Lib = await ethers.getContract("UniswapV3Library");
   const UniV3_USDC_USDT_Proxy = await ethers.getContract(
     "UniV3_USDC_USDT_Proxy"
   );
@@ -120,18 +119,10 @@ async function defaultFixture() {
     Array.from(
       new Set([
         ...(
-          await ethers.getContractFactory("UniswapV3Strategy", {
-            libraries: {
-              UniswapV3Library: UniV3Lib.address,
-            },
-          })
+          await ethers.getContractFactory("UniswapV3Strategy")
         ).interface.format("full"),
         ...(
-          await ethers.getContractFactory("UniswapV3LiquidityManager", {
-            libraries: {
-              UniswapV3Library: UniV3Lib.address,
-            },
-          })
+          await ethers.getContractFactory("UniswapV3LiquidityManager")
         ).interface.format("full"),
       ])
     ),


### PR DESCRIPTION
these changes: 
- remove the need for uniswap library
- move the `withdraw` and the `withdrawAll` from strategy contract to liquidityManager

pros: 
- no more delegate call
- no more need for library

cons: 
size increase of Liquidity Manager from
![Screenshot 2023-03-17 at 09 55 52](https://user-images.githubusercontent.com/579910/225869906-8bbb5026-ba54-4aff-9eab-0d828eb76792.png)
to
![Screenshot 2023-03-17 at 10 42 25](https://user-images.githubusercontent.com/579910/225869978-e763f07b-65d1-4880-9c5d-6ea5935d1fcf.png)

