### PR TITLE
OETH - Allow initialize time control of OUSD resolution

### DIFF
--- a/contracts/contracts/token/OUSD.sol
+++ b/contracts/contracts/token/OUSD.sol
@@ -56,10 +56,11 @@ contract OUSD is Initializable, InitializableERC20Detailed, Governable {
     function initialize(
         string calldata _nameArg,
         string calldata _symbolArg,
-        address _vaultAddress
+        address _vaultAddress,
+        uint256 _initialCreditsPerToken
     ) external onlyGovernor initializer {
         InitializableERC20Detailed._initialize(_nameArg, _symbolArg, 18);
-        _rebasingCreditsPerToken = 1e18;
+        _rebasingCreditsPerToken = _initialCreditsPerToken;
         vaultAddress = _vaultAddress;
     }
 

--- a/contracts/deploy/001_core.js
+++ b/contracts/deploy/001_core.js
@@ -798,7 +798,6 @@ const deployCore = async () => {
 
   // Initialize OUSD
   const resolution = ethers.utils.parseUnits("1", 18);
-  console.log(resolution.toString());
   await withConfirmation(
     cOUSD
       .connect(sGovernor)

--- a/contracts/deploy/001_core.js
+++ b/contracts/deploy/001_core.js
@@ -797,10 +797,12 @@ const deployCore = async () => {
   log("Initialized VaultAdmin implementation");
 
   // Initialize OUSD
+  const resolution = ethers.utils.parseUnits("1", 18);
+  console.log(resolution.toString());
   await withConfirmation(
     cOUSD
       .connect(sGovernor)
-      .initialize("Origin Dollar", "OUSD", cVaultProxy.address)
+      .initialize("Origin Dollar", "OUSD", cVaultProxy.address, resolution)
   );
 
   log("Initialized OUSD");


### PR DESCRIPTION
OUSD original launched with a resolution too low. This later required redoing all OUSD accounts. In the past, we've kept the resolution at 1e18 in the code, since this lets the unit tests run against areas where rounding matters.

When we launch OETH, we should use a resolution of (1e27 - 1), not 1e27, for backwards compatible reasons with the old OUSD resolution upgrade.

This PR allows the resolution of OUSD to be set during initialization, so that OUSD, OETH, and the unit tests can all work off the exact same contract code.

Contract change checklist:
  - [ ] Code reviewed by 2 reviewers. 
  - [ ] Copy & paste code review [security checklist](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md) below this checklist.
  - [ ] Unit tests pass
  - [x] Slither tests pass with no warning
  - [ ] Echidna tests pass if PR includes changes to OUSD contract (not automated, run manually on local)
