### PR TITLE
Use correct license identifier

### DIFF
--- a/contracts/contracts/buyback/Buyback.sol
+++ b/contracts/contracts/buyback/Buyback.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { Strategizable } from "../governance/Strategizable.sol";

--- a/contracts/contracts/compensation/CompensationClaims.sol
+++ b/contracts/contracts/compensation/CompensationClaims.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/contracts/crytic/PropertiesOUSDTransferable.sol
+++ b/contracts/contracts/crytic/PropertiesOUSDTransferable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "./interfaces.sol";

--- a/contracts/contracts/crytic/TestOUSDTransferable.sol
+++ b/contracts/contracts/crytic/TestOUSDTransferable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "./PropertiesOUSDTransferable.sol";

--- a/contracts/contracts/crytic/interfaces.sol
+++ b/contracts/contracts/crytic/interfaces.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 contract CryticInterface {

--- a/contracts/contracts/flipper/Flipper.sol
+++ b/contracts/contracts/flipper/Flipper.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "../governance/Governable.sol";

--- a/contracts/contracts/governance/Governable.sol
+++ b/contracts/contracts/governance/Governable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/governance/Governor.sol
+++ b/contracts/contracts/governance/Governor.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "./../timelock/Timelock.sol";

--- a/contracts/contracts/governance/InitializableGovernable.sol
+++ b/contracts/contracts/governance/InitializableGovernable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/governance/Strategizable.sol
+++ b/contracts/contracts/governance/Strategizable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { Governable } from "./Governable.sol";

--- a/contracts/contracts/harvest/Dripper.sol
+++ b/contracts/contracts/harvest/Dripper.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/contracts/harvest/Harvester.sol
+++ b/contracts/contracts/harvest/Harvester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/contracts/interfaces/IBasicToken.sol
+++ b/contracts/contracts/interfaces/IBasicToken.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IBasicToken {

--- a/contracts/contracts/interfaces/IBuyback.sol
+++ b/contracts/contracts/interfaces/IBuyback.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IBuyback {

--- a/contracts/contracts/interfaces/IComptroller.sol
+++ b/contracts/contracts/interfaces/IComptroller.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IComptroller {

--- a/contracts/contracts/interfaces/IEthUsdOracle.sol
+++ b/contracts/contracts/interfaces/IEthUsdOracle.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IEthUsdOracle {

--- a/contracts/contracts/interfaces/IHarvester.sol
+++ b/contracts/contracts/interfaces/IHarvester.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IHarvester {

--- a/contracts/contracts/interfaces/IMinMaxOracle.sol
+++ b/contracts/contracts/interfaces/IMinMaxOracle.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IMinMaxOracle {

--- a/contracts/contracts/interfaces/IOracle.sol
+++ b/contracts/contracts/interfaces/IOracle.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IOracle {

--- a/contracts/contracts/interfaces/IPriceOracle.sol
+++ b/contracts/contracts/interfaces/IPriceOracle.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IPriceOracle {

--- a/contracts/contracts/interfaces/IStrategy.sol
+++ b/contracts/contracts/interfaces/IStrategy.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/interfaces/IVault.sol
+++ b/contracts/contracts/interfaces/IVault.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IVault {

--- a/contracts/contracts/interfaces/Tether.sol
+++ b/contracts/contracts/interfaces/Tether.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface Tether {

--- a/contracts/contracts/interfaces/UniswapV3Router.sol
+++ b/contracts/contracts/interfaces/UniswapV3Router.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 // -- Solididy v0.5.x compatible interface

--- a/contracts/contracts/interfaces/chainlink/AggregatorV3Interface.sol
+++ b/contracts/contracts/interfaces/chainlink/AggregatorV3Interface.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface AggregatorV3Interface {

--- a/contracts/contracts/interfaces/uniswap/IUniswapV2Pair.sol
+++ b/contracts/contracts/interfaces/uniswap/IUniswapV2Pair.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IUniswapV2Pair {

--- a/contracts/contracts/interfaces/uniswap/IUniswapV2Router02.sol
+++ b/contracts/contracts/interfaces/uniswap/IUniswapV2Router02.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IUniswapV2Router {

--- a/contracts/contracts/liquidity/LiquidityReward.sol
+++ b/contracts/contracts/liquidity/LiquidityReward.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/contracts/mocks/BurnableERC20.sol
+++ b/contracts/contracts/mocks/BurnableERC20.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/contracts/contracts/mocks/MintableERC20.sol
+++ b/contracts/contracts/mocks/MintableERC20.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/contracts/contracts/mocks/MockAAVEToken.sol
+++ b/contracts/contracts/mocks/MockAAVEToken.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "./MintableERC20.sol";

--- a/contracts/contracts/mocks/MockAave.sol
+++ b/contracts/contracts/mocks/MockAave.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/contracts/mocks/MockAaveIncentivesController.sol
+++ b/contracts/contracts/mocks/MockAaveIncentivesController.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { MockStkAave } from "./MockStkAave.sol";

--- a/contracts/contracts/mocks/MockCOMP.sol
+++ b/contracts/contracts/mocks/MockCOMP.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "./MintableERC20.sol";

--- a/contracts/contracts/mocks/MockCToken.sol
+++ b/contracts/contracts/mocks/MockCToken.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { IERC20, ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/contracts/contracts/mocks/MockChainlinkOracleFeed.sol
+++ b/contracts/contracts/mocks/MockChainlinkOracleFeed.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "../interfaces/chainlink/AggregatorV3Interface.sol";

--- a/contracts/contracts/mocks/MockComptroller.sol
+++ b/contracts/contracts/mocks/MockComptroller.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 contract MockComptroller {

--- a/contracts/contracts/mocks/MockDAI.sol
+++ b/contracts/contracts/mocks/MockDAI.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "./MintableERC20.sol";

--- a/contracts/contracts/mocks/MockEvilDAI.sol
+++ b/contracts/contracts/mocks/MockEvilDAI.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "./MintableERC20.sol";

--- a/contracts/contracts/mocks/MockMintableUniswapPair.sol
+++ b/contracts/contracts/mocks/MockMintableUniswapPair.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "./MintableERC20.sol";

--- a/contracts/contracts/mocks/MockNonRebasing.sol
+++ b/contracts/contracts/mocks/MockNonRebasing.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/contracts/mocks/MockOGN.sol
+++ b/contracts/contracts/mocks/MockOGN.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "./BurnableERC20.sol";

--- a/contracts/contracts/mocks/MockOGV.sol
+++ b/contracts/contracts/mocks/MockOGV.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "./MintableERC20.sol";

--- a/contracts/contracts/mocks/MockOracle.sol
+++ b/contracts/contracts/mocks/MockOracle.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "../interfaces/IPriceOracle.sol";

--- a/contracts/contracts/mocks/MockRebornMinter.sol
+++ b/contracts/contracts/mocks/MockRebornMinter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { IVault } from "../interfaces/IVault.sol";

--- a/contracts/contracts/mocks/MockStkAave.sol
+++ b/contracts/contracts/mocks/MockStkAave.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/contracts/mocks/MockTUSD.sol
+++ b/contracts/contracts/mocks/MockTUSD.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "./MintableERC20.sol";

--- a/contracts/contracts/mocks/MockUSDC.sol
+++ b/contracts/contracts/mocks/MockUSDC.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "./MintableERC20.sol";

--- a/contracts/contracts/mocks/MockUSDT.sol
+++ b/contracts/contracts/mocks/MockUSDT.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "./MintableERC20.sol";

--- a/contracts/contracts/mocks/MockUniswapPair.sol
+++ b/contracts/contracts/mocks/MockUniswapPair.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { IUniswapV2Pair } from "../interfaces/uniswap/IUniswapV2Pair.sol";

--- a/contracts/contracts/mocks/MockUniswapRouter.sol
+++ b/contracts/contracts/mocks/MockUniswapRouter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/contracts/mocks/MockVault.sol
+++ b/contracts/contracts/mocks/MockVault.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { VaultCore } from "../vault/VaultCore.sol";

--- a/contracts/contracts/mocks/MockWETH.sol
+++ b/contracts/contracts/mocks/MockWETH.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "./MintableERC20.sol";

--- a/contracts/contracts/mocks/curve/Mock3CRV.sol
+++ b/contracts/contracts/mocks/curve/Mock3CRV.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "../MintableERC20.sol";

--- a/contracts/contracts/mocks/curve/MockBooster.sol
+++ b/contracts/contracts/mocks/curve/MockBooster.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/contracts/mocks/curve/MockCRV.sol
+++ b/contracts/contracts/mocks/curve/MockCRV.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "../MintableERC20.sol";

--- a/contracts/contracts/mocks/curve/MockCRVMinter.sol
+++ b/contracts/contracts/mocks/curve/MockCRVMinter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/contracts/mocks/curve/MockCVX.sol
+++ b/contracts/contracts/mocks/curve/MockCVX.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "../MintableERC20.sol";

--- a/contracts/contracts/mocks/curve/MockCurveAbstractMetapool.sol
+++ b/contracts/contracts/mocks/curve/MockCurveAbstractMetapool.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/contracts/mocks/curve/MockCurveGauge.sol
+++ b/contracts/contracts/mocks/curve/MockCurveGauge.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/contracts/contracts/mocks/curve/MockCurveLUSDMetapool.sol
+++ b/contracts/contracts/mocks/curve/MockCurveLUSDMetapool.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { MockCurveAbstractMetapool } from "./MockCurveAbstractMetapool.sol";

--- a/contracts/contracts/mocks/curve/MockCurveMetapool.sol
+++ b/contracts/contracts/mocks/curve/MockCurveMetapool.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { MockCurveAbstractMetapool } from "./MockCurveAbstractMetapool.sol";

--- a/contracts/contracts/mocks/curve/MockCurvePool.sol
+++ b/contracts/contracts/mocks/curve/MockCurvePool.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/contracts/mocks/curve/MockLUSD.sol
+++ b/contracts/contracts/mocks/curve/MockLUSD.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "../MintableERC20.sol";

--- a/contracts/contracts/mocks/curve/MockRewardPool.sol
+++ b/contracts/contracts/mocks/curve/MockRewardPool.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/contracts/oracle/MixOracle.sol
+++ b/contracts/contracts/oracle/MixOracle.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 // DEPRECATED - This contract is no longer used in production
 pragma solidity ^0.8.0;
 

--- a/contracts/contracts/oracle/OracleRouter.sol
+++ b/contracts/contracts/oracle/OracleRouter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "../interfaces/chainlink/AggregatorV3Interface.sol";

--- a/contracts/contracts/proxies/InitializeGovernedUpgradeabilityProxy.sol
+++ b/contracts/contracts/proxies/InitializeGovernedUpgradeabilityProxy.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";

--- a/contracts/contracts/proxies/Proxies.sol
+++ b/contracts/contracts/proxies/Proxies.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { InitializeGovernedUpgradeabilityProxy } from "./InitializeGovernedUpgradeabilityProxy.sol";

--- a/contracts/contracts/staking/SingleAssetStaking.sol
+++ b/contracts/contracts/staking/SingleAssetStaking.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/contracts/strategies/AaveStrategy.sol
+++ b/contracts/contracts/strategies/AaveStrategy.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/strategies/BaseCompoundStrategy.sol
+++ b/contracts/contracts/strategies/BaseCompoundStrategy.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/strategies/BaseConvexMetaStrategy.sol
+++ b/contracts/contracts/strategies/BaseConvexMetaStrategy.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/strategies/BaseCurveStrategy.sol
+++ b/contracts/contracts/strategies/BaseCurveStrategy.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/strategies/CompoundStrategy.sol
+++ b/contracts/contracts/strategies/CompoundStrategy.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/strategies/ConvexGeneralizedMetaStrategy.sol
+++ b/contracts/contracts/strategies/ConvexGeneralizedMetaStrategy.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/strategies/ConvexOUSDMetaStrategy.sol
+++ b/contracts/contracts/strategies/ConvexOUSDMetaStrategy.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/strategies/ConvexStrategy.sol
+++ b/contracts/contracts/strategies/ConvexStrategy.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/strategies/IAave.sol
+++ b/contracts/contracts/strategies/IAave.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/strategies/IAaveIncentivesController.sol
+++ b/contracts/contracts/strategies/IAaveIncentivesController.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IAaveIncentivesController {

--- a/contracts/contracts/strategies/IAaveStakeToken.sol
+++ b/contracts/contracts/strategies/IAaveStakeToken.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IAaveStakedToken {

--- a/contracts/contracts/strategies/ICRVMinter.sol
+++ b/contracts/contracts/strategies/ICRVMinter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface ICRVMinter {

--- a/contracts/contracts/strategies/ICompound.sol
+++ b/contracts/contracts/strategies/ICompound.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/strategies/IConvexDeposits.sol
+++ b/contracts/contracts/strategies/IConvexDeposits.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IConvexDeposits {

--- a/contracts/contracts/strategies/ICurveGauge.sol
+++ b/contracts/contracts/strategies/ICurveGauge.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface ICurveGauge {

--- a/contracts/contracts/strategies/ICurveMetaPool.sol
+++ b/contracts/contracts/strategies/ICurveMetaPool.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
 interface ICurveMetaPool {

--- a/contracts/contracts/strategies/ICurvePool.sol
+++ b/contracts/contracts/strategies/ICurvePool.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface ICurvePool {

--- a/contracts/contracts/strategies/IRewardStaking.sol
+++ b/contracts/contracts/strategies/IRewardStaking.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IRewardStaking {

--- a/contracts/contracts/strategies/MorphoAaveStrategy.sol
+++ b/contracts/contracts/strategies/MorphoAaveStrategy.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/strategies/MorphoCompoundStrategy.sol
+++ b/contracts/contracts/strategies/MorphoCompoundStrategy.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/strategies/ThreePoolStrategy.sol
+++ b/contracts/contracts/strategies/ThreePoolStrategy.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/strategies/VaultValueChecker.sol
+++ b/contracts/contracts/strategies/VaultValueChecker.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { VaultCore } from "../vault/VaultCore.sol";

--- a/contracts/contracts/timelock/Timelock.sol
+++ b/contracts/contracts/timelock/Timelock.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/token/OETH.sol
+++ b/contracts/contracts/token/OETH.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/token/OUSD.sol
+++ b/contracts/contracts/token/OUSD.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/token/WOETH.sol
+++ b/contracts/contracts/token/WOETH.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/utils/Helpers.sol
+++ b/contracts/contracts/utils/Helpers.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { IBasicToken } from "../interfaces/IBasicToken.sol";

--- a/contracts/contracts/utils/Initializable.sol
+++ b/contracts/contracts/utils/Initializable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 abstract contract Initializable {

--- a/contracts/contracts/utils/InitializableAbstractStrategy.sol
+++ b/contracts/contracts/utils/InitializableAbstractStrategy.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/contracts/utils/InitializableERC20Detailed.sol
+++ b/contracts/contracts/utils/InitializableERC20Detailed.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/contracts/utils/StableMath.sol
+++ b/contracts/contracts/utils/StableMath.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import { SafeMath } from "@openzeppelin/contracts/utils/math/SafeMath.sol";

--- a/contracts/contracts/vault/Vault.sol
+++ b/contracts/contracts/vault/Vault.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/vault/VaultAdmin.sol
+++ b/contracts/contracts/vault/VaultAdmin.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/vault/VaultCore.sol
+++ b/contracts/contracts/vault/VaultCore.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/vault/VaultInitializer.sol
+++ b/contracts/contracts/vault/VaultInitializer.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**

--- a/contracts/contracts/vault/VaultStorage.sol
+++ b/contracts/contracts/vault/VaultStorage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: agpl-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /**


### PR DESCRIPTION
Contract licenses comment tags were inadvertently set to AGPL during the upgrade to solidity 0.8. The repository LICENSE file has always been MIT.

This PR updates the SPDX identifiers.

https://github.com/OriginProtocol/origin-dollar/issues/1294