### PR TITLE
Fix rate display wOETH -> OETH

### DIFF
--- a/dapp-oeth/src/components/wrap/WrapOETHPill.js
+++ b/dapp-oeth/src/components/wrap/WrapOETHPill.js
@@ -317,13 +317,17 @@ const WrapOETHPill = ({
         .currency-pill {
           display: flex;
           justify-content: center;
-          padding: 56px 40px;
+          padding: 24px 40px;
           background-color: #1e1f25;
+          min-height: 150px;
+          border-bottom-left-radius: 10px;
+          border-bottom-right-radius: 10px;
         }
 
         .topItem {
           background-color: #18191c;
           border-bottom: solid 1px #141519;
+          border-radius: 0;
         }
 
         .currency-pill-inner {

--- a/dapp-oeth/src/components/wrap/WrapOETHPill.js
+++ b/dapp-oeth/src/components/wrap/WrapOETHPill.js
@@ -262,7 +262,7 @@ const WrapOETHPill = ({
             )}
           </div>
           <div className="d-flex flex-column justify-content-between align-items-end output-holder">
-            {topItem ? (
+            {topItem && (
               <div className="d-flex align-items-center">
                 <div className="d-flex justify-content-between balance">
                   {displayBalance && (
@@ -286,8 +286,14 @@ const WrapOETHPill = ({
                   )}
                 </div>
               </div>
+            )}
+            {topItem ? (
+              <CoinSelect selected={swapMode === 'mint' ? 'oeth' : 'woeth'} />
             ) : (
-              <div className="balance mt-auto">
+              <CoinSelect selected={swapMode === 'mint' ? 'woeth' : 'oeth'} />
+            )}
+            {topItem && (
+              <div className="balance mt-2">
                 {rate !== null
                   ? fbt(
                       '1 wOETH = ' +
@@ -299,11 +305,6 @@ const WrapOETHPill = ({
                   ? ''
                   : '-'}
               </div>
-            )}
-            {topItem ? (
-              <CoinSelect selected={swapMode === 'mint' ? 'oeth' : 'woeth'} />
-            ) : (
-              <CoinSelect selected={swapMode === 'mint' ? 'woeth' : 'oeth'} />
             )}
           </div>
         </div>


### PR DESCRIPTION
The rate display was showing `0.00` for wOETH -> OETH in the `wrap` section. The rate was not showing due to being in the wrong section of the wrap interface.

This PR fixes the rate display as shown below and some minor style tweaks on the input displays.

![Screenshot 2023-05-16 110358](https://github.com/OriginProtocol/origin-dollar/assets/762107/9c07dab4-5ce9-4052-8676-570f5fadebe7)

