### PR TITLE
Add reentrancy guards to our strategist allocation methods

### DIFF
--- a/contracts/contracts/governance/Governable.sol
+++ b/contracts/contracts/governance/Governable.sol
@@ -134,6 +134,26 @@ contract Governable {
         }
     }
 
+    /**
+     * @dev Prevents a view contract function from being called
+     * while the contract is inside a reentrant protected method.
+     * This can prevent third party contracts from being attacked
+     * via working with partially updated data.
+     */
+    modifier nonReentrantView() {
+        bytes32 position = reentryStatusPosition;
+        uint256 _reentry_status;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            _reentry_status := sload(position)
+        }
+
+        // On the first call to nonReentrant, _notEntered will be true
+        require(_reentry_status != _ENTERED, "Reentrant call");
+
+        _;
+    }
+
     function _setPendingGovernor(address newGovernor) internal {
         bytes32 position = pendingGovernorPosition;
         // solhint-disable-next-line no-inline-assembly

--- a/contracts/contracts/vault/VaultAdmin.sol
+++ b/contracts/contracts/vault/VaultAdmin.sol
@@ -288,7 +288,7 @@ contract VaultAdmin is VaultStorage {
         address _strategyToAddress,
         address[] calldata _assets,
         uint256[] calldata _amounts
-    ) external onlyGovernorOrStrategist {
+    ) external onlyGovernorOrStrategist nonReentrant {
         _depositToStrategy(_strategyToAddress, _assets, _amounts);
     }
 
@@ -325,7 +325,7 @@ contract VaultAdmin is VaultStorage {
         address _strategyFromAddress,
         address[] calldata _assets,
         uint256[] calldata _amounts
-    ) external onlyGovernorOrStrategist {
+    ) external onlyGovernorOrStrategist nonReentrant {
         _withdrawFromStrategy(
             address(this),
             _strategyFromAddress,

--- a/contracts/contracts/vault/VaultCore.sol
+++ b/contracts/contracts/vault/VaultCore.sol
@@ -401,7 +401,13 @@ contract VaultCore is VaultStorage {
      *         strategies.
      * @return value Total value in USD (1e18)
      */
-    function totalValue() external view virtual returns (uint256 value) {
+    function totalValue()
+        external
+        view
+        virtual
+        nonReentrantView
+        returns (uint256 value)
+    {
         value = _totalValue();
     }
 


### PR DESCRIPTION
Our user facing, state changing vault methods have reentrancy protection guards on them. This PR adds the same protection to the vault admin's `depositTo()` and `withdrawFrom()`. In this way if an attacker gets execution during an admin reallocation, they cannot make writes to the vault during that.

Note that in theory we don't need reentrancy guards in the vault (currently none of our strategies allow handing off execution beyond the strategies they invest in), but they provide a second layer of protection against reentrancy in case something is missed somewhere during future development, or a compromise of an underlying strategy.

This PR also makes the vault `totalVault()` method revert if read while the vault is inside reentrant protected code. This will prevent a third party from getting wrong data if read while inside our vault executing code. https://twitter.com/danielvf/status/1657019677544001536

Closes [1366](https://github.com/OriginProtocol/origin-dollar/issues/1366)