### PR TITLE
OETH N 09 - Decimals

### DIFF
--- a/contracts/contracts/vault/VaultStorage.sol
+++ b/contracts/contracts/vault/VaultStorage.sol
@@ -57,7 +57,7 @@ contract VaultStorage is Initializable, Governable {
     struct Asset {
         bool isSupported;
         UnitConversion unitConversion;
-        uint256 decimals;
+        uint8 decimals;
     }
 
     // slither-disable-next-line uninitialized-state


### PR DESCRIPTION
change decimal type to uint8

**Important deploy considerations: (DON'T MERGE YET)**
- This changes VaultAdmin code in a way where existing decimals of supported assets will not be readable
- when merging this in a deploy script should be created that: 
  - updates the VaultAdmin
  - calls `cacheDecimals` on VaultAdmin for all of the currently supported assets  of the Vault

** connected issue:** https://github.com/OriginProtocol/origin-dollar/issues/1534