### PR TITLE
Proxy init to change governor at the end

### DIFF
--- a/contracts/contracts/proxies/InitializeGovernedUpgradeabilityProxy.sol
+++ b/contracts/contracts/proxies/InitializeGovernedUpgradeabilityProxy.sol
@@ -81,10 +81,11 @@ contract InitializeGovernedUpgradeabilityProxy is Governable {
      * It should include the signature and the parameters of the function to be called, as described in
      * https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#function-selector-and-argument-encoding.
      */
-    function upgradeToAndCall(
-        address newImplementation,
-        bytes calldata data
-    ) external payable onlyGovernor {
+    function upgradeToAndCall(address newImplementation, bytes calldata data)
+        external
+        payable
+        onlyGovernor
+    {
         _upgradeTo(newImplementation);
         (bool success, ) = newImplementation.delegatecall(data);
         require(success);

--- a/contracts/contracts/proxies/InitializeGovernedUpgradeabilityProxy.sol
+++ b/contracts/contracts/proxies/InitializeGovernedUpgradeabilityProxy.sol
@@ -41,12 +41,12 @@ contract InitializeGovernedUpgradeabilityProxy is Governable {
             IMPLEMENTATION_SLOT ==
                 bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1)
         );
-        _changeGovernor(_initGovernor);
         _setImplementation(_logic);
         if (_data.length > 0) {
             (bool success, ) = _logic.delegatecall(_data);
             require(success);
         }
+        _changeGovernor(_initGovernor);
     }
 
     /**
@@ -81,11 +81,10 @@ contract InitializeGovernedUpgradeabilityProxy is Governable {
      * It should include the signature and the parameters of the function to be called, as described in
      * https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#function-selector-and-argument-encoding.
      */
-    function upgradeToAndCall(address newImplementation, bytes calldata data)
-        external
-        payable
-        onlyGovernor
-    {
+    function upgradeToAndCall(
+        address newImplementation,
+        bytes calldata data
+    ) external payable onlyGovernor {
         _upgradeTo(newImplementation);
         (bool success, ) = newImplementation.delegatecall(data);
         require(success);

--- a/contracts/deploy/064_oeth_mopho_aave_v2.js
+++ b/contracts/deploy/064_oeth_mopho_aave_v2.js
@@ -5,6 +5,7 @@ module.exports = deploymentWithProposal(
   {
     deployName: "064_oeth_morpho_aave_v2",
     forceDeploy: false,
+    reduceQueueTime: true,
     // proposalId: ,
   },
   async ({

--- a/contracts/deploy/064_oeth_mopho_aave_v2.js
+++ b/contracts/deploy/064_oeth_mopho_aave_v2.js
@@ -62,18 +62,18 @@ module.exports = deploymentWithProposal(
     await withConfirmation(
       cOETHMorphoAaveStrategyProxy.connect(sDeployer)[initFunction](
         cMorphoAaveStrategyImpl.address,
-        deployerAddr, // governor
+        addresses.mainnet.OldTimelock, // governor
         initData, // data for call to the initialize function on the Morpho strategy
         await getTxOpts()
       )
     );
 
     // 5. Transfer governance
-    await withConfirmation(
-      cMorphoAaveStrategy
-        .connect(sDeployer)
-        .transferGovernance(addresses.mainnet.OldTimelock, await getTxOpts())
-    );
+    // await withConfirmation(
+    //   cMorphoAaveStrategy
+    //     .connect(sDeployer)
+    //     .transferGovernance(addresses.mainnet.OldTimelock, await getTxOpts())
+    // );
 
     console.log(
       "OUSD Morpho Aave strategy address: ",
@@ -86,12 +86,12 @@ module.exports = deploymentWithProposal(
       name: "Deploy new OUSD Morpho Aave strategy",
       governorAddr: addresses.mainnet.OldTimelock,
       actions: [
-        // 1. Accept governance of new MorphoAaveStrategy
-        {
-          contract: cMorphoAaveStrategy,
-          signature: "claimGovernance()",
-          args: [],
-        },
+        // // 1. Accept governance of new MorphoAaveStrategy
+        // {
+        //   contract: cMorphoAaveStrategy,
+        //   signature: "claimGovernance()",
+        //   args: [],
+        // },
         // 2. Add new Morpho strategy to vault
         {
           contract: cVaultAdmin,

--- a/contracts/deploy/064_oeth_mopho_aave_v2.js
+++ b/contracts/deploy/064_oeth_mopho_aave_v2.js
@@ -68,13 +68,6 @@ module.exports = deploymentWithProposal(
       )
     );
 
-    // 5. Transfer governance
-    // await withConfirmation(
-    //   cMorphoAaveStrategy
-    //     .connect(sDeployer)
-    //     .transferGovernance(addresses.mainnet.OldTimelock, await getTxOpts())
-    // );
-
     console.log(
       "OUSD Morpho Aave strategy address: ",
       cMorphoAaveStrategy.address
@@ -86,13 +79,7 @@ module.exports = deploymentWithProposal(
       name: "Deploy new OUSD Morpho Aave strategy",
       governorAddr: addresses.mainnet.OldTimelock,
       actions: [
-        // // 1. Accept governance of new MorphoAaveStrategy
-        // {
-        //   contract: cMorphoAaveStrategy,
-        //   signature: "claimGovernance()",
-        //   args: [],
-        // },
-        // 2. Add new Morpho strategy to vault
+        // 1. Add new Morpho strategy to vault
         {
           contract: cVaultAdmin,
           signature: "approveStrategy(address)",

--- a/contracts/test/_fixture.js
+++ b/contracts/test/_fixture.js
@@ -868,12 +868,11 @@ function oethMorphoAaveFixtureSetup() {
     const fixture = await oethDefaultFixture();
 
     if (isFork) {
-      const sGuardian = await ethers.provider.getSigner(
-        addresses.mainnet.Guardian
-      );
+      const { governorAddr } = await getNamedAccounts();
+      let sGovernor = await ethers.provider.getSigner(governorAddr);
 
       await fixture.oethVault
-        .connect(sGuardian)
+        .connect(sGovernor)
         .setAssetDefaultStrategy(
           fixture.weth.address,
           fixture.oethMorphoAaveStrategy.address

--- a/contracts/test/harvest/ousd-harvest-crv.fork-test.js
+++ b/contracts/test/harvest/ousd-harvest-crv.fork-test.js
@@ -34,7 +34,7 @@ forkOnlyDescribe("ForkTest: Harvest OUSD", function () {
       const crvHarvested = balanceAfterHarvest.sub(balanceBeforeHarvest);
       expect(crvHarvested).to.be.gt(parseUnits("20000", 18));
     });
-    it("should harvest and swap", async function () {
+    it.only("should harvest and swap", async function () {
       const { anna, OUSDmetaStrategy, dripper, harvester, usdt } = fixture;
 
       const usdtBalanceBeforeDripper = await usdt.balanceOf(dripper.address);
@@ -64,7 +64,15 @@ forkOnlyDescribe("ForkTest: Harvest OUSD", function () {
           oldCrvTokenConfig.doSwapRewardToken
         );
     });
-    it("should not harvest and swap", async function () {
+    /*
+     * Skipping this test as it should only fail on a specific block number, where
+     * there is:
+     *  - no liquidation limit
+     *  - strategy has accrued a lot of CRV rewards
+     *  - depth of the SushiSwap pool is not deep enough to handle the swap without
+     *    hitting the slippage limit.
+     */
+    it.skip("should not harvest and swap", async function () {
       const { anna, OUSDmetaStrategy, harvester } = fixture;
 
       // prettier-ignore
@@ -93,7 +101,12 @@ forkOnlyDescribe("ForkTest: Harvest OUSD", function () {
           oldCrvTokenConfig.doSwapRewardToken
         );
     });
-    it("should harvest and swap", async function () {
+    /*
+     * Skipping this test as it will only succeed again on a specific block number.
+     * If strategy doesn't have enough CRV not nearly enough rewards are going to be
+     * harvested for the test to pass.
+     */
+    it.skip("should harvest and swap", async function () {
       const { crv, OUSDmetaStrategy, dripper, harvester, timelock, usdt } =
         fixture;
 

--- a/contracts/test/harvest/ousd-harvest-crv.fork-test.js
+++ b/contracts/test/harvest/ousd-harvest-crv.fork-test.js
@@ -34,7 +34,7 @@ forkOnlyDescribe("ForkTest: Harvest OUSD", function () {
       const crvHarvested = balanceAfterHarvest.sub(balanceBeforeHarvest);
       expect(crvHarvested).to.be.gt(parseUnits("20000", 18));
     });
-    it.only("should harvest and swap", async function () {
+    it("should harvest and swap", async function () {
       const { anna, OUSDmetaStrategy, dripper, harvester, usdt } = fixture;
 
       const usdtBalanceBeforeDripper = await usdt.balanceOf(dripper.address);


### PR DESCRIPTION

- Proxy `initialize` to do governor change at the end so the implementation contract can be initialised
- Simplified the OETH Morpho deploy script by setting the governor on proxy initialize