### PR TITLE
fix dapp crash from undefined

### DIFF
--- a/dapp-oeth/src/hooks/useCurrencySwapper.js
+++ b/dapp-oeth/src/hooks/useCurrencySwapper.js
@@ -16,7 +16,7 @@ import {
 import { useWeb3React } from '@web3-react/core'
 import addresses from 'constants/contractAddresses'
 import curveRoutes from 'constants/curveRoutes'
-
+import { get } from 'lodash'
 import { calculateSwapAmounts } from 'utils/math'
 
 const useCurrencySwapper = ({
@@ -140,7 +140,7 @@ const useCurrencySwapper = ({
       }
 
       const allowance = parseFloat(
-        allowances[coinNeedingApproval][allowanceCheckKey]
+        get(allowances, 'coinNeedingApproval[allowanceCheckKey]')
       )
 
       setNeedsApproval(


### PR DESCRIPTION
The dapp is crashing becuase of an `undefined` error.

I needed to replace 
```
const allowance = parseFloat(
        allowances.coinNeedingApproval.allowanceCheckKey
      )
```
with
```
const allowance = parseFloat(
        get(allowances, 'coinNeedingApproval[allowanceCheckKey]')
      )
```