### PR TITLE
VS Code workspace settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ Thumbs.db
 ########
 .idea
 
+bin
 node_modules
 contracts/cache/**
 contracts/.env

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "solidity.packageDefaultDependenciesContractsDirectory": "contracts/contracts",
+    "solidity.packageDefaultDependenciesDirectory": "contracts/node_modules",
+    "solidity.compileUsingRemoteVersion": "v0.8.7+commit.e28d00a7",
+    "solidity.monoRepoSupport": false,
+    "prettier.configPath": "./contracts/.prettierrc",
+    "plantuml.exportOutDir": "contracts/docs/plantuml",
+    "plantuml.exportFormat": "png",
+    "plantuml.exportIncludeFolderHeirarchy": false,
+    "plantuml.exportSubFolder": false,
+}


### PR DESCRIPTION
I've moved my VS Code settings into the workspace level so others can reuse for this repo

The git ignore for `bin` is for the `prettier-plugin-solidity` extension that outputs to `bin` when compiling contracts. I haven't found a way to configure that to somewhere else. Generally, you don't compile the Solidity contracts using the plug-in so its not a biggie.
