### PR TITLE
Vault Natspec

### DIFF
--- a/contracts/contracts/governance/Governable.sol
+++ b/contracts/contracts/governance/Governable.sol
@@ -45,7 +45,7 @@ contract Governable {
     }
 
     /**
-     * @dev Returns the address of the current Governor.
+     * @notice Returns the address of the current Governor.
      */
     function governor() public view returns (address) {
         return _governor();
@@ -86,7 +86,7 @@ contract Governable {
     }
 
     /**
-     * @dev Returns true if the caller is the current Governor.
+     * @notice Returns true if the caller is the current Governor.
      */
     function isGovernor() public view returns (bool) {
         return msg.sender == _governor();
@@ -163,7 +163,7 @@ contract Governable {
     }
 
     /**
-     * @dev Transfers Governance of the contract to a new account (`newGovernor`).
+     * @notice Transfers Governance of the contract to a new account (`newGovernor`).
      * Can only be called by the current Governor. Must be claimed for this to complete
      * @param _newGovernor Address of the new Governor
      */
@@ -173,7 +173,7 @@ contract Governable {
     }
 
     /**
-     * @dev Claim Governance of the contract to a new account (`newGovernor`).
+     * @notice Claim Governance of the contract to a new account (`newGovernor`).
      * Can only be called by the new Governor.
      */
     function claimGovernance() external {

--- a/contracts/contracts/vault/VaultAdmin.sol
+++ b/contracts/contracts/vault/VaultAdmin.sol
@@ -30,6 +30,9 @@ contract VaultAdmin is VaultStorage {
         _;
     }
 
+    /**
+     * @dev Verifies that the caller is the Governor or Strategist.
+     */
     modifier onlyGovernorOrStrategist() {
         require(
             msg.sender == strategistAddr || isGovernor(),
@@ -43,7 +46,7 @@ contract VaultAdmin is VaultStorage {
     ****************************************/
 
     /**
-     * @dev Set address of price provider.
+     * @notice Set address of price provider.
      * @param _priceProvider Address of price provider
      */
     function setPriceProvider(address _priceProvider) external onlyGovernor {
@@ -52,7 +55,7 @@ contract VaultAdmin is VaultStorage {
     }
 
     /**
-     * @dev Set a fee in basis points to be charged for a redeem.
+     * @notice Set a fee in basis points to be charged for a redeem.
      * @param _redeemFeeBps Basis point fee to be charged
      */
     function setRedeemFeeBps(uint256 _redeemFeeBps) external onlyGovernor {
@@ -62,32 +65,34 @@ contract VaultAdmin is VaultStorage {
     }
 
     /**
-     * @dev Set a buffer of assets to keep in the Vault to handle most
+     * @notice Set a buffer of assets to keep in the Vault to handle most
      * redemptions without needing to spend gas unwinding assets from a Strategy.
      * @param _vaultBuffer Percentage using 18 decimals. 100% = 1e18.
      */
-    function setVaultBuffer(
-        uint256 _vaultBuffer
-    ) external onlyGovernorOrStrategist {
+    function setVaultBuffer(uint256 _vaultBuffer)
+        external
+        onlyGovernorOrStrategist
+    {
         require(_vaultBuffer <= 1e18, "Invalid value");
         vaultBuffer = _vaultBuffer;
         emit VaultBufferUpdated(_vaultBuffer);
     }
 
     /**
-     * @dev Sets the minimum amount of OTokens in a mint to trigger an
+     * @notice Sets the minimum amount of OTokens in a mint to trigger an
      * automatic allocation of funds afterwords.
      * @param _threshold OToken amount with 18 fixed decimals.
      */
-    function setAutoAllocateThreshold(
-        uint256 _threshold
-    ) external onlyGovernor {
+    function setAutoAllocateThreshold(uint256 _threshold)
+        external
+        onlyGovernor
+    {
         autoAllocateThreshold = _threshold;
         emit AllocateThresholdUpdated(_threshold);
     }
 
     /**
-     * @dev Set a minimum amount of OTokens in a mint or redeem that triggers a
+     * @notice Set a minimum amount of OTokens in a mint or redeem that triggers a
      * rebase
      * @param _threshold OToken amount with 18 fixed decimals.
      */
@@ -97,7 +102,7 @@ contract VaultAdmin is VaultStorage {
     }
 
     /**
-     * @dev Set address of Strategist
+     * @notice Set address of Strategist
      * @param _address Address of Strategist
      */
     function setStrategistAddr(address _address) external onlyGovernor {
@@ -106,15 +111,15 @@ contract VaultAdmin is VaultStorage {
     }
 
     /**
-     * @dev Set the default Strategy for an asset, i.e. the one which the asset
+     * @notice Set the default Strategy for an asset, i.e. the one which the asset
             will be automatically allocated to and withdrawn from
      * @param _asset Address of the asset
      * @param _strategy Address of the Strategy
      */
-    function setAssetDefaultStrategy(
-        address _asset,
-        address _strategy
-    ) external onlyGovernorOrStrategist {
+    function setAssetDefaultStrategy(address _asset, address _strategy)
+        external
+        onlyGovernorOrStrategist
+    {
         emit AssetDefaultStrategyUpdated(_asset, _strategy);
         // If its a zero address being passed for the strategy we are removing
         // the default strategy
@@ -132,13 +137,14 @@ contract VaultAdmin is VaultStorage {
     }
 
     /**
-     * @dev Set maximum amount of OTokens that can at any point be minted and deployed
+     * @notice Set maximum amount of OTokens that can at any point be minted and deployed
      * to strategy (used only by ConvexOUSDMetaStrategy for now).
      * @param _threshold OToken amount with 18 fixed decimals.
      */
-    function setNetOusdMintForStrategyThreshold(
-        uint256 _threshold
-    ) external onlyGovernor {
+    function setNetOusdMintForStrategyThreshold(uint256 _threshold)
+        external
+        onlyGovernor
+    {
         /**
          * Because `netOusdMintedForStrategy` check in vault core works both ways
          * (positive and negative) the actual impact of the amount of OToken minted
@@ -159,14 +165,14 @@ contract VaultAdmin is VaultStorage {
     }
 
     /**
-     * @dev Add a supported asset to the contract, i.e. one that can be
+     * @notice Add a supported asset to the contract, i.e. one that can be
      *         to mint OTokens.
      * @param _asset Address of asset
      */
-    function supportAsset(
-        address _asset,
-        uint8 _unitConversion
-    ) external onlyGovernor {
+    function supportAsset(address _asset, uint8 _unitConversion)
+        external
+        onlyGovernor
+    {
         require(!assets[_asset].isSupported, "Asset already supported");
 
         assets[_asset] = Asset({
@@ -186,7 +192,7 @@ contract VaultAdmin is VaultStorage {
     }
 
     /**
-     * @dev Cache decimals on OracleRouter for a particular asset. This action
+     * @notice Cache decimals on OracleRouter for a particular asset. This action
      *      is required before that asset's price can be accessed.
      * @param _asset Address of asset
      */
@@ -195,7 +201,7 @@ contract VaultAdmin is VaultStorage {
     }
 
     /**
-     * @dev Add a strategy to the Vault.
+     * @notice Add a strategy to the Vault.
      * @param _addr Address of the strategy to add
      */
     function approveStrategy(address _addr) external onlyGovernor {
@@ -206,7 +212,7 @@ contract VaultAdmin is VaultStorage {
     }
 
     /**
-     * @dev Remove a strategy from the Vault.
+     * @notice Remove a strategy from the Vault.
      * @param _addr Address of the strategy to remove
      */
 
@@ -248,7 +254,7 @@ contract VaultAdmin is VaultStorage {
     }
 
     /**
-     * @dev Deposit multiple assets from the vault into the strategy.
+     * @notice Deposit multiple assets from the vault into the strategy.
      * @param _strategyToAddress Address of the Strategy to deposit assets into.
      * @param _assets Array of asset address that will be deposited into the strategy.
      * @param _amounts Array of amounts of each corresponding asset to deposit.
@@ -288,7 +294,7 @@ contract VaultAdmin is VaultStorage {
     }
 
     /**
-     * @dev Withdraw multiple assets from the strategy to the vault.
+     * @notice Withdraw multiple assets from the strategy to the vault.
      * @param _strategyFromAddress Address of the Strategy to withdraw assets from.
      * @param _assets Array of asset address that will be withdrawn from the strategy.
      * @param _amounts Array of amounts of each corresponding asset to withdraw.
@@ -333,7 +339,7 @@ contract VaultAdmin is VaultStorage {
     }
 
     /**
-     * @dev Sets the maximum allowable difference between
+     * @notice Sets the maximum allowable difference between
      * total supply and backing assets' value.
      */
     function setMaxSupplyDiff(uint256 _maxSupplyDiff) external onlyGovernor {
@@ -342,7 +348,7 @@ contract VaultAdmin is VaultStorage {
     }
 
     /**
-     * @dev Sets the trusteeAddress that can receive a portion of yield.
+     * @notice Sets the trusteeAddress that can receive a portion of yield.
      *      Setting to the zero address disables this feature.
      */
     function setTrusteeAddress(address _address) external onlyGovernor {
@@ -351,7 +357,7 @@ contract VaultAdmin is VaultStorage {
     }
 
     /**
-     * @dev Sets the TrusteeFeeBps to the percentage of yield that should be
+     * @notice Sets the TrusteeFeeBps to the percentage of yield that should be
      *      received in basis points.
      */
     function setTrusteeFeeBps(uint256 _basis) external onlyGovernor {
@@ -361,12 +367,13 @@ contract VaultAdmin is VaultStorage {
     }
 
     /**
-     * @dev Set OToken Metapool strategy
+     * @notice Set OToken Metapool strategy
      * @param _ousdMetaStrategy Address of OToken metapool strategy
      */
-    function setOusdMetaStrategy(
-        address _ousdMetaStrategy
-    ) external onlyGovernor {
+    function setOusdMetaStrategy(address _ousdMetaStrategy)
+        external
+        onlyGovernor
+    {
         ousdMetaStrategy = _ousdMetaStrategy;
         emit OusdMetaStrategyUpdated(_ousdMetaStrategy);
     }
@@ -376,7 +383,7 @@ contract VaultAdmin is VaultStorage {
     ****************************************/
 
     /**
-     * @dev Set the deposit paused flag to true to prevent rebasing.
+     * @notice Set the deposit paused flag to true to prevent rebasing.
      */
     function pauseRebase() external onlyGovernorOrStrategist {
         rebasePaused = true;
@@ -384,7 +391,7 @@ contract VaultAdmin is VaultStorage {
     }
 
     /**
-     * @dev Set the deposit paused flag to true to allow rebasing.
+     * @notice Set the deposit paused flag to true to allow rebasing.
      */
     function unpauseRebase() external onlyGovernorOrStrategist {
         rebasePaused = false;
@@ -392,7 +399,7 @@ contract VaultAdmin is VaultStorage {
     }
 
     /**
-     * @dev Set the deposit paused flag to true to prevent capital movement.
+     * @notice Set the deposit paused flag to true to prevent capital movement.
      */
     function pauseCapital() external onlyGovernorOrStrategist {
         capitalPaused = true;
@@ -400,7 +407,7 @@ contract VaultAdmin is VaultStorage {
     }
 
     /**
-     * @dev Set the deposit paused flag to false to enable capital movement.
+     * @notice Set the deposit paused flag to false to enable capital movement.
      */
     function unpauseCapital() external onlyGovernorOrStrategist {
         capitalPaused = false;
@@ -412,15 +419,15 @@ contract VaultAdmin is VaultStorage {
     ****************************************/
 
     /**
-     * @dev Transfer token to governor. Intended for recovering tokens stuck in
+     * @notice Transfer token to governor. Intended for recovering tokens stuck in
      *      contract, i.e. mistaken sends.
      * @param _asset Address for the asset
      * @param _amount Amount of the asset to transfer
      */
-    function transferToken(
-        address _asset,
-        uint256 _amount
-    ) external onlyGovernor {
+    function transferToken(address _asset, uint256 _amount)
+        external
+        onlyGovernor
+    {
         require(!assets[_asset].isSupported, "Only unsupported assets");
         IERC20(_asset).safeTransfer(governor(), _amount);
     }
@@ -430,12 +437,13 @@ contract VaultAdmin is VaultStorage {
     ****************************************/
 
     /**
-     * @dev Withdraws all assets from the strategy and sends assets to the Vault.
+     * @notice Withdraws all assets from the strategy and sends assets to the Vault.
      * @param _strategyAddr Strategy address.
      */
-    function withdrawAllFromStrategy(
-        address _strategyAddr
-    ) external onlyGovernorOrStrategist {
+    function withdrawAllFromStrategy(address _strategyAddr)
+        external
+        onlyGovernorOrStrategist
+    {
         require(
             strategies[_strategyAddr].isSupported,
             "Strategy is not supported"
@@ -445,7 +453,7 @@ contract VaultAdmin is VaultStorage {
     }
 
     /**
-     * @dev Withdraws all assets from all the strategies and sends assets to the Vault.
+     * @notice Withdraws all assets from all the strategies and sends assets to the Vault.
      */
     function withdrawAllFromStrategies() external onlyGovernorOrStrategist {
         uint256 stratCount = allStrategies.length;

--- a/contracts/contracts/vault/VaultCore.sol
+++ b/contracts/contracts/vault/VaultCore.sol
@@ -52,7 +52,7 @@ contract VaultCore is VaultStorage {
     }
 
     /**
-     * @dev Deposit a supported asset and mint OTokens.
+     * @notice Deposit a supported asset and mint OTokens.
      * @param _asset Address of the asset being deposited
      * @param _amount Amount of the asset being deposited
      * @param _minimumOusdAmount Minimum OTokens to mint
@@ -96,7 +96,7 @@ contract VaultCore is VaultStorage {
     }
 
     /**
-     * @dev Mint OTokens for a Metapool Strategy
+     * @notice Mint OTokens for a Metapool Strategy
      * @param _amount Amount of the asset being deposited
      *
      * Notice: can't use `nonReentrant` modifier since the `mint` function can
@@ -138,7 +138,7 @@ contract VaultCore is VaultStorage {
     // In memoriam
 
     /**
-     * @dev Withdraw a supported asset and burn OTokens.
+     * @notice Withdraw a supported asset and burn OTokens.
      * @param _amount Amount of OTokens to burn
      * @param _minimumUnitAmount Minimum stablecoin units to receive in return
      */
@@ -151,7 +151,7 @@ contract VaultCore is VaultStorage {
     }
 
     /**
-     * @dev Withdraw a supported asset and burn OTokens.
+     * @notice Withdraw a supported asset and burn OTokens.
      * @param _amount Amount of OTokens to burn
      * @param _minimumUnitAmount Minimum stablecoin units to receive in return
      */
@@ -221,10 +221,10 @@ contract VaultCore is VaultStorage {
     }
 
     /**
-     * @dev Burn OTokens for Metapool Strategy
+     * @notice Burn OTokens for Metapool Strategy
      * @param _amount Amount of OUSD to burn
      *
-     * Notice: can't use `nonReentrant` modifier since the `redeem` function could
+     * @dev Notice: can't use `nonReentrant` modifier since the `redeem` function could
      * require withdrawal on `ConvexOUSDMetaStrategy` and that one can call `burnForStrategy`
      * while the execution of the `redeem` has not yet completed -> causing a `nonReentrant` collision.
      *
@@ -276,14 +276,12 @@ contract VaultCore is VaultStorage {
 
     /**
      * @notice Allocate unallocated funds on Vault to strategies.
-     * @dev Allocate unallocated funds on Vault to strategies.
      **/
     function allocate() external whenNotCapitalPaused nonReentrant {
         _allocate();
     }
 
     /**
-     * @notice Allocate unallocated funds on Vault to strategies.
      * @dev Allocate unallocated funds on Vault to strategies.
      **/
     function _allocate() internal {
@@ -352,7 +350,7 @@ contract VaultCore is VaultStorage {
     }
 
     /**
-     * @dev Calculate the total value of assets held by the Vault and all
+     * @notice Calculate the total value of assets held by the Vault and all
      *      strategies and update the supply of OTokens.
      */
     function rebase() external virtual nonReentrant {
@@ -393,7 +391,7 @@ contract VaultCore is VaultStorage {
     }
 
     /**
-     * @dev Determine the total value of assets held by the vault and its
+     * @notice Determine the total value of assets held by the vault and its
      *         strategies.
      * @return value Total value in USD (1e18)
      */
@@ -509,7 +507,7 @@ contract VaultCore is VaultStorage {
     }
 
     /**
-     * @notice Calculate the outputs for a redeem function, i.e. the mix of
+     * @dev Calculate the outputs for a redeem function, i.e. the mix of
      * coins that will be returned.
      * @return outputs Array of amounts respective to the supported assets
      */
@@ -587,7 +585,7 @@ contract VaultCore is VaultStorage {
     ****************************************/
 
     /**
-     * @dev Returns the total price in 18 digit units for a given asset.
+     * @notice Returns the total price in 18 digit units for a given asset.
      *      Never goes above 1, since that is how we price mints.
      * @param asset address of the asset
      * @return price uint256: unit (USD / ETH) price for 1 unit of the asset, in 18 decimal fixed
@@ -609,7 +607,7 @@ contract VaultCore is VaultStorage {
     }
 
     /**
-     * @dev Returns the total price in 18 digit unit for a given asset.
+     * @notice Returns the total price in 18 digit unit for a given asset.
      *      Never goes below 1, since that is how we price redeems
      * @param asset Address of the asset
      * @return price uint256: unit (USD / ETH) price for 1 unit of the asset, in 18 decimal fixed
@@ -727,6 +725,9 @@ contract VaultCore is VaultStorage {
         return decimals;
     }
 
+    /**
+     * @notice Gets the vault configuration of a supported asset.
+     */
     function getAssetConfig(address _asset)
         public
         view
@@ -736,35 +737,35 @@ contract VaultCore is VaultStorage {
     }
 
     /**
-     * @dev Return the number of assets supported by the Vault.
+     * @notice Return the number of assets supported by the Vault.
      */
     function getAssetCount() public view returns (uint256) {
         return allAssets.length;
     }
 
     /**
-     * @dev Return all asset addresses in order
+     * @notice Return all vault asset addresses in order
      */
     function getAllAssets() external view returns (address[] memory) {
         return allAssets;
     }
 
     /**
-     * @dev Return the number of strategies active on the Vault.
+     * @notice Return the number of strategies active on the Vault.
      */
     function getStrategyCount() external view returns (uint256) {
         return allStrategies.length;
     }
 
     /**
-     * @dev Return the array of all strategies
+     * @notice Return the array of all strategies
      */
     function getAllStrategies() external view returns (address[] memory) {
         return allStrategies;
     }
 
     /**
-     * @dev Returns whether the vault supports the asset
+     * @notice Returns whether the vault supports the asset
      * @param _asset address of the asset
      * @return true if supported
      */

--- a/contracts/contracts/vault/VaultStorage.sol
+++ b/contracts/contracts/vault/VaultStorage.sol
@@ -60,8 +60,10 @@ contract VaultStorage is Initializable, Governable {
         uint256 decimals;
     }
 
+    /// @dev mapping of supported vault assets to their configuration
     // slither-disable-next-line uninitialized-state
     mapping(address => Asset) internal assets;
+    /// @dev list of all assets supported by the vault.
     address[] internal allAssets;
 
     // Strategies approved for use by the Vault
@@ -69,24 +71,29 @@ contract VaultStorage is Initializable, Governable {
         bool isSupported;
         uint256 _deprecated; // Deprecated storage slot
     }
+    /// @dev mapping of strategy contracts to their configiration
     mapping(address => Strategy) internal strategies;
+    /// @dev list of all vault strategies
     address[] internal allStrategies;
 
-    // Address of the Oracle price provider contract
+    /// @notice Address of the Oracle price provider contract
     // slither-disable-next-line uninitialized-state
     address public priceProvider;
-    // Pausing bools
+    /// @notice pause rebasing if true
     bool public rebasePaused = false;
+    /// @notice pause operations that change the OToken supply.
+    /// eg mint, redeem, allocate, mint/burn for strategy
     bool public capitalPaused = true;
-    // Redemption fee in basis points
+    /// @notice Redemption fee in basis points. eg 50 = 0.5%
     uint256 public redeemFeeBps;
-    // Buffer of assets to keep in Vault to handle (most) withdrawals
+    /// @notice Percentage of assets to keep in Vault to handle (most) withdrawals. 100% = 1e18.
     uint256 public vaultBuffer;
-    // Mints over this amount automatically allocate funds. 18 decimals.
+    /// @notice OToken mints over this amount automatically allocate funds. 18 decimals.
     uint256 public autoAllocateThreshold;
-    // Mints over this amount automatically rebase. 18 decimals.
+    /// @notice OToken mints over this amount automatically rebase. 18 decimals.
     uint256 public rebaseThreshold;
 
+    /// @dev Address of the OToken token. eg OUSD or OETH.
     OUSD internal oUSD;
 
     //keccak256("OUSD.vault.governor.admin.impl");
@@ -100,40 +107,41 @@ contract VaultStorage is Initializable, Governable {
     // slither-disable-next-line constable-states
     address private _deprecated_uniswapAddr = address(0);
 
-    // Address of the Strategist
+    /// @notice Address of the Strategist
     address public strategistAddr = address(0);
 
-    // Mapping of asset address to the Strategy that they should automatically
+    /// @notice Mapping of asset address to the Strategy that they should automatically
     // be allocated to
     mapping(address => address) public assetDefaultStrategies;
 
+    /// @notice Max difference between total supply and total value of assets. 18 decimals.
     uint256 public maxSupplyDiff;
 
-    // Trustee contract that can collect a percentage of yield
+    /// @notice Trustee contract that can collect a percentage of yield
     address public trusteeAddress;
 
-    // Amount of yield collected in basis points
+    /// @notice Amount of yield collected in basis points. eg 2000 = 20%
     uint256 public trusteeFeeBps;
 
-    // Deprecated: Tokens that should be swapped for stablecoins
+    /// @dev Deprecated: Tokens that should be swapped for stablecoins
     address[] private _deprecated_swapTokens;
 
     uint256 constant MINT_MINIMUM_UNIT_PRICE = 0.998e18;
 
-    // Metapool strategy that is allowed to mint/burn OTokens without changing collateral
+    /// @notice Metapool strategy that is allowed to mint/burn OTokens without changing collateral
     address public ousdMetaStrategy = address(0);
 
-    // How much OTokens are currently minted by the strategy
+    /// @notice How much OTokens are currently minted by the strategy
     int256 public netOusdMintedForStrategy = 0;
 
-    // How much net total OTokens are allowed to be minted by all strategies
+    /// @notice How much net total OTokens are allowed to be minted by all strategies
     uint256 public netOusdMintForStrategyThreshold = 0;
 
     uint256 constant MIN_UNIT_PRICE_DRIFT = 0.7e18;
     uint256 constant MAX_UNIT_PRICE_DRIFT = 1.3e18;
 
     /**
-     * @dev set the implementation for the admin, this needs to be in a base class else we cannot set it
+     * @notice set the implementation for the admin, this needs to be in a base class else we cannot set it
      * @param newImpl address of the implementation
      */
     function setAdminImpl(address newImpl) external onlyGovernor {


### PR DESCRIPTION
Updated the Vault Natspec 

- Use `@notice` for public and external functions instead of `@dev` as most Natspec parsers ignore `@dev`. eg Etherscan
- Changed `VaultStorage` variables comments to Natspec 
- There are no Solidity changes - only Natspec.
