### PR TITLE
last minute collateral swap changes to the Vault

### DIFF
--- a/contracts/contracts/vault/VaultAdmin.sol
+++ b/contracts/contracts/vault/VaultAdmin.sol
@@ -367,7 +367,7 @@ contract VaultAdmin is VaultStorage {
      */
     function approveStrategy(address _addr) external onlyGovernor {
         require(!strategies[_addr].isSupported, "Strategy already approved");
-        strategies[_addr] = Strategy({ isSupported: true, _deprecated: 0 });
+        strategies[_addr] = Strategy({ isSupported: true });
         allStrategies.push(_addr);
         emit StrategyApproved(_addr);
     }

--- a/contracts/contracts/vault/VaultCore.sol
+++ b/contracts/contracts/vault/VaultCore.sol
@@ -411,7 +411,7 @@ contract VaultCore is VaultStorage {
 
     /**
      * @dev Internal to calculate total value of all assets held in Vault.
-     * @return value Total value in ETH (1e18)
+     * @return value Total value in base currency. eg USD or ETH (1e18)
      */
     function _totalValueInVault() internal view returns (uint256 value) {
         uint256 assetCount = allAssets.length;
@@ -426,7 +426,7 @@ contract VaultCore is VaultStorage {
 
     /**
      * @dev Internal to calculate total value of all assets held in Strategies.
-     * @return value Total value in ETH (1e18)
+     * @return value Total value in base currency. eg USD or ETH (1e18)
      */
     function _totalValueInStrategies() internal view returns (uint256 value) {
         uint256 stratCount = allStrategies.length;
@@ -438,7 +438,7 @@ contract VaultCore is VaultStorage {
     /**
      * @dev Internal to calculate total value of all assets held by strategy.
      * @param _strategyAddr Address of the strategy
-     * @return value Total value in ETH (1e18)
+     * @return value Total value in base currency. eg USD or ETH (1e18)
      */
     function _totalValueInStrategy(address _strategyAddr)
         internal

--- a/contracts/contracts/vault/VaultStorage.sol
+++ b/contracts/contracts/vault/VaultStorage.sol
@@ -77,7 +77,6 @@ contract VaultStorage is Initializable, Governable {
     // Strategies approved for use by the Vault
     struct Strategy {
         bool isSupported;
-        uint256 _deprecated; // Deprecated storage slot
     }
     /// @dev mapping of strategy contracts to their configiration
     mapping(address => Strategy) internal strategies;

--- a/contracts/deploy/052_upgrade_ousd_vault_harvester.js
+++ b/contracts/deploy/052_upgrade_ousd_vault_harvester.js
@@ -21,8 +21,19 @@ module.exports = deploymentWithGovernanceProposal(
 
     // Deploy VaultAdmin and VaultCore contracts
     const cVaultProxy = await ethers.getContract("VaultProxy");
-    const dVaultAdmin = await deployWithConfirmation("VaultAdmin");
-    const dVaultCore = await deployWithConfirmation("VaultCore");
+    const dVaultAdmin = await deployWithConfirmation(
+      "VaultAdmin",
+      [],
+      undefined,
+      true // incompatible storage layout
+    );
+    const dVaultCore = await deployWithConfirmation(
+      "VaultCore",
+      [],
+      undefined,
+      true // incompatible storage layout
+    );
+
     const cVault = await ethers.getContractAt("Vault", cVaultProxy.address);
 
     // Deploy Oracle Router

--- a/contracts/deploy/057_drip_all.js
+++ b/contracts/deploy/057_drip_all.js
@@ -23,8 +23,18 @@ module.exports = deploymentWithGovernanceProposal(
     const cVaultProxy = await ethers.getContract("VaultProxy");
     // const cHarvester = await ethers.getContract("Harvester");
 
-    const dVaultCore = await deployWithConfirmation("VaultCore");
-    const dVaultAdmin = await deployWithConfirmation("VaultAdmin");
+    const dVaultAdmin = await deployWithConfirmation(
+      "VaultAdmin",
+      [],
+      undefined,
+      true // incompatible storage layout
+    );
+    const dVaultCore = await deployWithConfirmation(
+      "VaultCore",
+      [],
+      undefined,
+      true // incompatible storage layout
+    );
 
     const cVaultCore = await ethers.getContract(
       "VaultCore",


### PR DESCRIPTION
When reviewing the Uniswap V3 Strategy PR, it was clear we need to remove the `_deprecated` property from the `Strategy` struct that is used by the Vault's `strategies` mapping.

Looking at both the OETH and OUSD vault storage, there is no impact in removing this

OUSD `strategies` storage https://evm.storage/eth/17540105/0xe75d77b1865ae93c7eaa3040b038d7aa7bc02f70/strategies#map

OETH `strategies` storage 
https://evm.storage/eth/17540186/0x39254033945aa2e4809cc2977e7087bee48bd7ab/strategies#map