### PR TITLE
Transfer OETH governance to OGV

### DIFF
--- a/contracts/deploy/068_oeth_to_ogv_governance_p1.js
+++ b/contracts/deploy/068_oeth_to_ogv_governance_p1.js
@@ -1,0 +1,70 @@
+const { deploymentWithProposal } = require("../utils/deploy");
+const addresses = require("../utils/addresses");
+
+module.exports = deploymentWithProposal(
+  {
+    deployName: "068_oeth_to_ogv_governance_p1",
+    forceDeploy: false
+  },
+  async ({
+    ethers,
+  }) => {
+    const cOETHProxy = await ethers.getContract("OETHProxy");
+    const cOETHVaultProxy = await ethers.getContract("OETHVaultProxy");
+    const cWOETHProxy = await ethers.getContract("WOETHProxy");
+    const cOETHDripperProxy = await ethers.getContract("OETHDripperProxy");
+    const cConvexEthMetaStrategyProxy = await ethers.getContract("ConvexEthMetaStrategyProxy");
+    const cOETHHarvesterProxy = await ethers.getContract("OETHHarvesterProxy");
+    const cOETHMorphoAaveStrategyProxy = await ethers.getContract("OETHMorphoAaveStrategyProxy");
+    const cFraxETHStrategyProxy = await ethers.getContract("FraxETHStrategyProxy");
+
+    // Governance Actions
+    // ----------------
+    return {
+      name: "Transfer governance to OGV Governance timelock",
+      actions: [
+        // Transfer governance for all OETH contracts
+        {
+          contract: cOETHProxy,
+          signature: "transferGovernance(address)",
+          args: [addresses.mainnet.Timelock],
+        },
+        {
+          contract: cOETHVaultProxy,
+          signature: "transferGovernance(address)",
+          args: [addresses.mainnet.Timelock],
+        },
+        {
+          contract: cWOETHProxy,
+          signature: "transferGovernance(address)",
+          args: [addresses.mainnet.Timelock],
+        },
+        {
+          contract: cOETHDripperProxy,
+          signature: "transferGovernance(address)",
+          args: [addresses.mainnet.Timelock],
+        },
+        {
+          contract: cConvexEthMetaStrategyProxy,
+          signature: "transferGovernance(address)",
+          args: [addresses.mainnet.Timelock],
+        },
+        {
+          contract: cOETHHarvesterProxy,
+          signature: "transferGovernance(address)",
+          args: [addresses.mainnet.Timelock],
+        },
+        {
+          contract: cOETHMorphoAaveStrategyProxy,
+          signature: "transferGovernance(address)",
+          args: [addresses.mainnet.Timelock],
+        },
+        {
+          contract: cFraxETHStrategyProxy,
+          signature: "transferGovernance(address)",
+          args: [addresses.mainnet.Timelock],
+        },
+      ],
+    };
+  }
+);

--- a/contracts/deploy/069_oeth_to_ogv_governance_p2.js
+++ b/contracts/deploy/069_oeth_to_ogv_governance_p2.js
@@ -1,0 +1,70 @@
+const { deploymentWithGovernanceProposal } = require("../utils/deploy");
+const addresses = require("../utils/addresses");
+
+module.exports = deploymentWithGovernanceProposal(
+  {
+    deployName: "069_oeth_to_ogv_governance_p2",
+    forceDeploy: false
+  },
+  async ({
+    ethers,
+  }) => {
+    const cOETHProxy = await ethers.getContract("OETHProxy");
+    const cOETHVaultProxy = await ethers.getContract("OETHVaultProxy");
+    const cWOETHProxy = await ethers.getContract("WOETHProxy");
+    const cOETHDripperProxy = await ethers.getContract("OETHDripperProxy");
+    const cConvexEthMetaStrategyProxy = await ethers.getContract("ConvexEthMetaStrategyProxy");
+    const cOETHHarvesterProxy = await ethers.getContract("OETHHarvesterProxy");
+    const cOETHMorphoAaveStrategyProxy = await ethers.getContract("OETHMorphoAaveStrategyProxy");
+    const cFraxETHStrategyProxy = await ethers.getContract("FraxETHStrategyProxy");
+
+    // Governance Actions
+    // ----------------
+    return {
+      name: "Transfer governance to OGV Governance timelock",
+      actions: [
+        // Claim governance by the OGV Timelock
+        {
+          contract: cOETHProxy,
+          signature: "claimGovernance()",
+          args: [],
+        },
+        {
+          contract: cOETHVaultProxy,
+          signature: "claimGovernance()",
+          args: [],
+        },
+        {
+          contract: cWOETHProxy,
+          signature: "claimGovernance()",
+          args: [],
+        },
+        {
+          contract: cOETHDripperProxy,
+          signature: "claimGovernance()",
+          args: [],
+        },
+        {
+          contract: cConvexEthMetaStrategyProxy,
+          signature: "claimGovernance()",
+          args: [],
+        },
+        {
+          contract: cOETHHarvesterProxy,
+          signature: "claimGovernance()",
+          args: [],
+        },
+        {
+          contract: cOETHMorphoAaveStrategyProxy,
+          signature: "claimGovernance()",
+          args: [],
+        },
+        {
+          contract: cFraxETHStrategyProxy,
+          signature: "claimGovernance()",
+          args: [],
+        },
+      ],
+    };
+  }
+);


### PR DESCRIPTION
2 deploy scripts to transfer the OETH governance to OGV. The second script acts as an OGV Timelock claiming the governance of OETH contracts. Need to create an actual OGV governance proposal for that.

**TODO:**
- create OGV governance proposal to claim OETH contracts