### PR TITLE
CI and Contract Dev docs

### DIFF
--- a/.github/workflows/defi.yml
+++ b/.github/workflows/defi.yml
@@ -39,6 +39,9 @@ jobs:
   contracts-test:
     name: "Contracts Unit Tests"
     runs-on: ubuntu-latest
+    env:
+      GAS_REPORT: true
+      CONTRACT_SIZE: true
     steps:
       - uses: actions/checkout@v3
 
@@ -72,6 +75,7 @@ jobs:
     env:
       HARDHAT_CACHE_DIR: ./cache
       PROVIDER_URL: ${{ secrets.PROVIDER_URL }}
+      GAS_REPORT: true
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/defi.yml
+++ b/.github/workflows/defi.yml
@@ -30,6 +30,12 @@ jobs:
       - run: yarn install --frozen-lockfile
         working-directory: ./contracts
 
+      # this will compile and output the contract sizes
+      - run: npx hardhat compile
+        env:
+          CONTRACT_SIZE: true
+        working-directory: ./contracts
+
       - run: yarn run lint
         working-directory: ./contracts
 
@@ -39,9 +45,6 @@ jobs:
   contracts-test:
     name: "Contracts Unit Tests"
     runs-on: ubuntu-latest
-    env:
-      GAS_REPORT: true
-      CONTRACT_SIZE: true
     steps:
       - uses: actions/checkout@v3
 
@@ -55,7 +58,14 @@ jobs:
       - run: yarn install --frozen-lockfile
         working-directory: ./contracts
 
-      - name: Run Tests
+      # this will run the unit tests and report the gas usage
+      - name: Run Unit Tests
+        env:
+          REPORT_GAS: true
+        run: yarn run test
+        working-directory: ./contracts
+
+      - name: Run Unit Coverage
         run: yarn run test:coverage
         working-directory: ./contracts
 
@@ -67,15 +77,12 @@ jobs:
             ./contracts/coverage/**/*
           retention-days: 1
 
-      # - uses: codecov/codecov-action@v3
-
   contracts-forktest:
     name: "Contracts Fork Tests"
     runs-on: ubuntu-latest
     env:
       HARDHAT_CACHE_DIR: ./cache
       PROVIDER_URL: ${{ secrets.PROVIDER_URL }}
-      GAS_REPORT: true
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/defi.yml
+++ b/.github/workflows/defi.yml
@@ -65,6 +65,22 @@ jobs:
         run: yarn run test
         working-directory: ./contracts
 
+  contracts-unit-coverage:
+    name: "Contracts Unit Coverage"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          cache: "yarn"
+          cache-dependency-path: contracts/yarn.lock
+
+      - run: yarn install --frozen-lockfile
+        working-directory: ./contracts
+
       - name: Run Unit Coverage
         run: yarn run test:coverage
         working-directory: ./contracts

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -185,6 +185,8 @@ There are separate actions for:
 
 ## Coverage
 
+The Hardhat plug-in [solidity-coverage](https://github.com/sc-forks/solidity-coverage#solidity-coverage) is used to gather Solidity code coverage. The configuration is in [.solcover.js](./.solcover.js). The coverage output is written to `coverage.json`.
+
 [Codecov](https://about.codecov.io/) is used to report Solidity code coverage. The coverage reports for this repository can be found [here](https://app.codecov.io/gh/OriginProtocol/origin-dollar).
 
 ```

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -151,6 +151,22 @@ This is not enabled by default. To enable, export the `CONTRACT_SIZE` environmen
 export CONTRACT_SIZE=true
 ```
 
+The contract sizes will be output after the contracts are compiled. Here's a sample of the first few.
+
+```
+Compiled 155 Solidity files successfully
+ ·-----------------------------------------|--------------------------------|--------------------------------·
+ |  Solc version: 0.8.7                    ·  Optimizer enabled: true       ·  Runs: 200                     │
+ ··········································|································|·································
+ |  Contract Name                          ·  Deployed size (KiB) (change)  ·  Initcode size (KiB) (change)  │
+ ··········································|································|·································
+ |  AaveStrategy                           ·                     11.427 ()  ·                     11.583 ()  │
+ ··········································|································|·································
+ |  AaveStrategyProxy                      ·                      2.438 ()  ·                      2.591 ()  │
+ ··········································|································|·································
+ |  Address                                ·                      0.084 ()  ·                      0.138 ()  │
+```
+
 ## Gas Usage
 
 The Hardhat plug-in [hardhat-gas-reporter](https://github.com/cgewecke/hardhat-gas-reporter#hardhat-gas-reporter) is used to report gas usage of unit and fork tests.
@@ -159,6 +175,35 @@ This is not enabled by default. To enable, export the `REPORT_GAS` environment v
 
 ```
 export REPORT_GAS=true
+```
+
+If enabled, the gas usage will be output in a table after the tests have executed. For example
+
+```
+·--------------------------------|---------------------------|-------------|-----------------------------·
+|      Solc version: 0.8.7       ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 30000000 gas  │
+·································|···························|·············|······························
+|  Methods                                                                                               │
+··············|··················|·············|·············|·············|···············|··············
+|  Contract   ·  Method          ·  Min        ·  Max        ·  Avg        ·  # calls      ·  eur (avg)  │
+··············|··················|·············|·············|·············|···············|··············
+|  ERC20      ·  approve         ·      26080  ·      65406  ·      39783  ·           96  ·          -  │
+··············|··················|·············|·············|·············|···············|··············
+|  ERC20      ·  transfer        ·      51427  ·      88327  ·      61066  ·           90  ·          -  │
+··············|··················|·············|·············|·············|···············|··············
+|  MockVault  ·  mint            ·     554883  ·     576124  ·     564880  ·            4  ·          -  │
+··············|··················|·············|·············|·············|···············|··············
+|  MockWETH   ·  deposit         ·          -  ·          -  ·      27938  ·           10  ·          -  │
+··············|··················|·············|·············|·············|···············|··············
+|  OETHVault  ·  setVaultBuffer  ·      34984  ·      56956  ·      45970  ·            2  ·          -  │
+··············|··················|·············|·············|·············|···············|··············
+|  OETHVault  ·  swapCollateral  ·     482418  ·    1018400  ·     705017  ·           57  ·          -  │
+··············|··················|·············|·············|·············|···············|··············
+|  Deployments                   ·                                         ·  % of limit   ·             │
+·································|·············|·············|·············|···············|··············
+|  MockOETHOracleRouterNoStale   ·          -  ·          -  ·     529194  ·        1.8 %  ·          -  │
+·································|·············|·············|·············|···············|··············
+|  MockOracleRouterNoStale       ·          -  ·          -  ·     743016  ·        2.5 %  ·          -  │
 ```
 
 ## Contract Verification
@@ -173,7 +218,7 @@ npx hardhat --network mainnet verify --contract contracts/vault/VaultAdmin.sol:V
 
 ## Continuous Integration
 
-[GitHub Actions](https://github.com/features/actions) are used for the build. The configuration for GitHub Actions is in [.github/workflows/defi.yml](../.github/workflows/defi.yml).
+[GitHub Actions](https://github.com/features/actions) are used for the build. The configuration for GitHub Actions is in [.github/workflows/defi.yml](../.github/workflows/defi.yml). The action workflows can be found at https://github.com/OriginProtocol/origin-dollar/actions.
 
 There are separate actions for:
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,198 @@
+# Contract Development
+
+## Prettier
+
+Both Solidity and JavaScript code is formatted using [Prettier](https://prettier.io/).
+
+The configuration for Prettier is in [.prettierrc](./.prettierrc).
+This should already be configured in the VS Code settings file [.vscode/settings.json](../.vscode/settings.json). [.prettierignore](./.prettierignore) is used to ignore files from being formatted.
+
+The following package scripts can be used to format code:
+
+```
+# Check for any formatting issues
+yarn prettier:check
+
+# Format all Solidity files
+yarn prettier:sol
+
+# Format all JavaScript files
+yarn prettier:js
+
+# Format both Solidity and JavaScript files
+yarn prettier
+```
+
+## Linter
+
+[solhit](https://protofire.github.io/solhint/) is used to lint Solidity code. The configuration for solhint is in [.solhint.json](./.solhint.json). [.solhintignore](./.solhintignore) is used to ignore Solidity files from being linted.
+
+[eslint](https://eslint.org/) is used to lint JavaScript code. The configuration for eslint is in [.eslintrc.js](./.eslintrc.js).
+
+```
+# Check for any Solidity linting issues
+yarn lint:sol
+
+# Check for any JavaScript linting issues
+yarn lint:sol
+
+# Check for any Solidity or JavaScript linting issues
+yarn lint
+```
+
+## Slither
+
+[Slither](https://github.com/crytic/slither#slither-the-solidity-source-analyzer) is used to for Solidity static analysis.
+
+The [Slither installation](https://github.com/crytic/slither#how-to-install) instruction.
+
+```
+## Run Slither
+yarn slither
+```
+
+## Hardhat
+
+[Hardhat](https://hardhat.org/) is used to compile, test, and deploy contracts. The configuration for Hardhat is in [hardhat.config.js](./hardhat.config.js).
+
+```
+# Compile changed contracts
+npx hardhat compile
+
+# Recompile all contracts
+yarn clean
+npx hardhat compile
+```
+
+Alternatively, the Hardhat companion npm package [hardhat-shorthand](https://www.npmjs.com/package/hardhat-shorthand) can be used as a shorthand for npx hardhat. Installation instructions can be found [here](https://hardhat.org/hardhat-runner/docs/guides/command-line-completion#installation).
+
+```
+## Compile
+hh compile
+
+## Tasks
+hh task
+```
+
+## Testing
+
+### Unit Tests
+
+Hardhat tests are used for contract unit tests which are under the [test](./test) folder. Contract mocks are under the [contracts/mocks](./contracts/mocks) folder.
+
+```
+# Run all unit tests
+yarn test
+```
+
+### Fork Tests
+
+Set your `PROVIDER_URL` and desired `BLOCK_NUMBER` in your [.env](./.env) file. The can be copied from [dev.env](./dev.env).
+
+```
+# in one terminal
+yarn run node
+
+# in another terminal
+yarn test:fork
+```
+
+See [Fork Tests](./fork-test.md) for more information.
+
+### Echidna tests
+
+[Echidna](https://github.com/crytic/echidna#echidna-a-fast-smart-contract-fuzzer-) is used for fuzzing tests.
+
+Installation instructions can be found [here](https://github.com/crytic/echidna#installation).
+
+```
+# Run Echidna tests
+yarn echidna
+```
+
+## Logger
+
+A logger using the [debug](https://www.npmjs.com/package/debug) packages is used for logging tests and tasks.
+
+To use, import the [utils/logger.js](./utils/logger.js) file and specify the module you are logging from. For example
+
+```js
+const log = require("../utils/logger")("module-name");
+log("something interesting happened");
+```
+
+The module name is appended to `origin:`, so the above example would log `origin:module-name something interesting happened`.
+
+To enable, export the `DEBUG` environment variable.
+
+```
+# enable all logging
+export DEBUG=origin*
+
+# enable logging for a specific module
+export DEBUG=origin:module-name*
+```
+
+Example module names
+
+- utils:1inch
+- utils:curve
+- test:unit:vault
+- test:fork:vault
+- test:fork:oeth:metapool
+
+## Contract Sizes
+
+The Hardhat plug-in [hardhat-contract-sizer](https://www.npmjs.com/package/hardhat-contract-sizer) is used to report the size of contracts.
+
+This is not enabled by default. To enable, export the `CONTRACT_SIZE` environment variable.
+
+```
+export CONTRACT_SIZE=true
+```
+
+## Gas Usage
+
+The Hardhat plug-in [hardhat-gas-reporter](https://github.com/cgewecke/hardhat-gas-reporter#hardhat-gas-reporter) is used to report gas usage of unit and fork tests.
+
+This is not enabled by default. To enable, export the `REPORT_GAS` environment variable.
+
+```
+export REPORT_GAS=true
+```
+
+## Contract Verification
+
+The Hardhat plug-in [@nomiclabs/hardhat-etherscan](https://www.npmjs.com/package/@nomiclabs/hardhat-etherscan) is used to verify contracts on Etherscan.
+
+There's an example
+
+```
+npx hardhat --network mainnet verify --contract contracts/vault/VaultAdmin.sol:VaultAdmin 0x31a91336414d3B955E494E7d485a6B06b55FC8fB
+```
+
+## Continuous Integration
+
+[GitHub Actions](https://github.com/features/actions) are used for the build. The configuration for GitHub Actions is in [.github/workflows/defi.yml](../.github/workflows/defi.yml).
+
+There are separate actions for:
+
+- Contract formatting and linting
+- Dapp formatting and linting
+- Slither static analysis
+- Unit tests
+- Fork tests
+
+## Coverage
+
+[Codecov](https://about.codecov.io/) is used to report Solidity code coverage. The coverage reports for this repository can be found [here](https://app.codecov.io/gh/OriginProtocol/origin-dollar).
+
+```
+# Unit test coverage
+yarn test:coverage
+
+# For test coverage
+yarn test:fork:coverage
+```
+
+The CI will upload the coverage reports to Codecov if they complete successfully.

--- a/contracts/fork-test.sh
+++ b/contracts/fork-test.sh
@@ -85,10 +85,11 @@ main()
         params+="$1"
     fi
 
-    if $is_coverage; then
+    if [ $is_coverage == "true" ]; then
         echo "Running tests and generating coverage reports..."
         FORK=true IS_TEST=true npx --no-install hardhat coverage --testfiles "test/**/*.fork-test.js"
     else
+        echo "Running fork tests..."
         FORK=true IS_TEST=true npx --no-install hardhat test ${params[@]}
     fi
 

--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -341,7 +341,7 @@ module.exports = {
   },
   contractSizer: {
     alphaSort: true,
-    runOnCompile: true,
+    runOnCompile: process.env.CONTRACT_SIZE ? true : false,
   },
   etherscan: {
     apiKey: process.env.ETHERSCAN_API_KEY,


### PR DESCRIPTION
CI changes
- Added compile step to Linter workflow to get contract sizes
- Add separate unit testing from unit coverage to get gas usage of unit tests
- Disabled contract size reporting by default. It can be enabled with env var `CONTRACT_SIZE=true` 

Documentation changes
- Add contracts README with developer docs

Testing
- Fixed fork test script which was always running the slower code coverage