### PR TITLE
erase hardhat deployments folder if present

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -4,9 +4,9 @@
   "description": "Origin Dollar Contracts",
   "main": "index.js",
   "scripts": {
-    "deploy": "(npx hardhat deploy --export '../dapp/network.json') && yarn run copy-interface-artifacts",
+    "deploy": "(rm -rf deployments/hardhat && npx hardhat deploy --export '../dapp/network.json') && yarn run copy-interface-artifacts",
     "deploy:mainnet": "(npx hardhat deploy --network mainnet --verbose --export '../dapp/network.mainnet.json') && yarn run copy-interface-artifacts",
-    "deploy:oeth": "(npx hardhat deploy --export '../dapp-oeth/network.json') && yarn run copy-interface-artifacts:oeth",
+    "deploy:oeth": "(rm -rf deployments/hardhat && npx hardhat deploy --export '../dapp-oeth/network.json') && yarn run copy-interface-artifacts:oeth",
     "deploy:oeth:mainnet": "(npx hardhat deploy --network mainnet --verbose --export '../dapp-oeth/network.mainnet.json') && yarn run copy-interface-artifacts",
     "node": "yarn run node:fork",
     "node:fork": "./node.sh fork",


### PR DESCRIPTION
If you've ran a node in forkTest environment locally it will copy mainnet deployments to hardhat deployments folder. Also containing the `.chainId` file with value `1`. This makes the command `yarn run deploy:(oeth)` error out with the following error: 
![Screenshot 2023-06-29 at 11 40 42](https://github.com/OriginProtocol/origin-dollar/assets/579910/1a877b42-368c-42cf-ad43-183eb2f644f9)

This PR fixes the issue. Also worthy to note this affects only local environments and not "clean" environments like CI. 