### PR TITLE
Helper, Handle empty arg'd gov actions

### DIFF
--- a/brownie/world.py
+++ b/brownie/world.py
@@ -395,6 +395,8 @@ def show_governance_action(i, to, sig, data):
   print("{}) {}".format(i+1, nice_contract_address(to)))
   print("     "+ORANGE+sig+ENDC)
   # print("Post Sig Data: ", data)
+  if re.match(".*\(\)", sig):
+    return
   stypes = re.split(",|\)|\(", sig)[1:-1]
   decodes = abi.decode_abi(stypes, data)
   for j in range(0, len(stypes)):


### PR DESCRIPTION
My last python governance action printer would fail when a governance action had no arguments. Fixed.