### PR TITLE
Fix remaining dust on oToken when burning all

### DIFF
--- a/contracts/test/vault/redeem.js
+++ b/contracts/test/vault/redeem.js
@@ -431,9 +431,7 @@ describe("Vault Redeem", function () {
     await dai.connect(anna).approve(vault.address, newDaiBalance);
     await vault.connect(anna).mint(dai.address, newDaiBalance, 0);
     await vault.connect(anna).redeemAll(0);
-    // FIXME - this is failing as a balance of 1 is being returned instead of 0
-    // Tracking issue https://github.com/OriginProtocol/origin-dollar/issues/1495
-    // await expect(anna).has.a.balanceOf("0.00", ousd);
+    await expect(anna).has.a.balanceOf("0.00", ousd);
   });
 
   it("Should respect minimum unit amount argument in redeem", async () => {


### PR DESCRIPTION
Makes OUSD/OETH not leave dust when the entire balance of an account is redeemed. Closes #1495

To detect when we were burning the entire funds for an account, the old code did this:

`currentCredits == creditAmount || currentCredits - 1 == creditAmount`

This would not detect the problem if the creditAmount rounding error differed by more than 1.

Changed the code to the much more direct:

`amount == balanceOf(account)`

Maybe 1K gas more, but we only burn on redeems (super rare), and some AMO allocations.

Also:
- Added some helpful comments around the rounding behavior in the function
- Removed safe math from this function

Contract change checklist:
  - [ ] Code reviewed by 2 reviewers. 
  - [ ] Copy & paste code review [security checklist](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md) below this checklist.
  - [ ] Unit tests pass
  - [ ] Slither tests pass with no warning
  - [ ] Echidna tests pass if PR includes changes to OUSD contract (not automated, run manually on local)
