### PR TITLE
Gas optimizations to the OETH AMO strategy

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,4 @@
 /dapp @smitch88 @sparrowDom @shahthepro @rafaelugolini
 /dapp-oeth @smitch88 @sparrowDom @shahthepro @rafaelugolini
 /contracts @sparrowDom @DanielVF @naddison36 @shahthepro
+/brownie @sparrowDom @DanielVF @naddison36 @shahthepro

--- a/brownie/runlogs/2023_07_strategist.py
+++ b/brownie/runlogs/2023_07_strategist.py
@@ -148,3 +148,110 @@ def main():
       print("Transaction ", idx)
       print("To: ", item.receiver)
       print("Data (Hex encoded): ", item.input, "\n")
+# -------------------------------
+# July 13, 2023 - OUSD Allocation
+# -------------------------------
+from world import *
+from allocations import *
+
+txs = []
+
+votes = """
+Morpho Aave USDT  79.46%
+Convex OUSD+3Crv  9.93%
+Morpho Compound DAI 7.06%
+Morpho Compound USDC 2.99%
+Morpho Compound USDT 0.57%
+Morpho Aave DAI 0%
+Morpho Aave USDC  0%
+Convex DAI+USDC+USDT  0%
+Aave DAI  0%
+Convex LUSD+3Crv  0%
+Existing Allocation 0%
+Aave USDC 0%
+Aave USDT 0%
+Compound DAI  0%
+Compound USDC 0%
+Compound USDT 0%
+"""
+
+with TemporaryForkWithVaultStats(votes=votes):
+  # Before
+  txs.append(vault_core.rebase({'from': STRATEGIST}))
+  txs.append(vault_value_checker.takeSnapshot({'from': STRATEGIST}))
+
+  # Withdraw all from Aave
+  txs.append(
+    vault_admin.withdrawAllFromStrategy(AAVE_STRAT, {'from': STRATEGIST})
+  )
+
+  # Deposit 610k USDC and 116k USDT to Morpho Compound
+  txs.append(
+    to_strat(
+      MORPHO_COMP_STRAT,
+      [
+        [610_430.4, usdc],
+        [116_194.6, usdt],
+      ]
+    )
+  )
+
+  # Withdraw all from Morpho Aave
+  txs.append(
+    vault_admin.withdrawAllFromStrategy(MORPHO_AAVE_STRAT, {'from': STRATEGIST})
+  )
+
+  # Deposit 3.61M USDT and USDC to Curve AMO
+  txs.append(
+    to_strat(
+      OUSD_METASTRAT,
+      [
+        [1_335_700, usdc],
+        [2_274_300, usdt],
+      ]
+    )
+  )
+
+  # Withdraw 20% in USDT and rest in DAI from Curve AMO
+  txs.append(
+    from_strat(
+      OUSD_METASTRAT,
+      [
+        [200_000, usdt],
+        [800_000, dai],
+      ]
+    )
+  )
+
+  # Deposit all DAI to Morpho Compound
+  txs.append(
+    to_strat(MORPHO_COMP_STRAT, [[944_382, dai]])
+  )
+
+  # Deposit all USDT to Morpho Aave
+  txs.append(
+    to_strat(MORPHO_AAVE_STRAT, [[16_094_394, usdt]])
+  )
+
+  # Finish it off with a rebase
+  txs.append(vault_core.rebase({'from': STRATEGIST}))
+
+  # Set default strategies
+  txs.append(vault_admin.setAssetDefaultStrategy(usdc, MORPHO_COMP_STRAT,{'from' :STRATEGIST}))
+  txs.append(vault_admin.setAssetDefaultStrategy(dai, MORPHO_COMP_STRAT,{'from': STRATEGIST}))
+
+  # After
+  vault_change = vault_core.totalValue() - vault_value_checker.snapshots(STRATEGIST)[0]
+  supply_change = ousd.totalSupply() - vault_value_checker.snapshots(STRATEGIST)[1]
+  profit = vault_change - supply_change
+
+  txs.append(vault_value_checker.checkDelta(profit, (500 * 10**18), vault_change, (500 * 10**18), {'from': STRATEGIST}))
+  print("-----")
+  print("Profit", "{:.6f}".format(profit / 10**18), profit)
+  print("Vault Change", "{:.6f}".format(vault_change / 10**18), vault_change)
+
+  print("Schedule the following transactions on Gnosis Safe")
+  for idx, item in enumerate(txs):
+    print("Transaction ", idx)
+    print("To: ", item.receiver)
+    print("Data (Hex encoded): ", item.input, "\n")

--- a/contracts/contracts/strategies/ConvexEthMetaStrategy.sol
+++ b/contracts/contracts/strategies/ConvexEthMetaStrategy.sol
@@ -24,13 +24,13 @@ contract ConvexEthMetaStrategy is InitializableAbstractStrategy {
     uint256 internal constant MAX_SLIPPAGE = 1e16; // 1%, same as the Curve UI
     address internal constant ETH_ADDRESS =
         0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
-    address internal cvxDepositorAddress;
-    IRewardStaking public cvxRewardStaker;
-    uint256 internal cvxDepositorPTokenId;
-    ICurveETHPoolV1 internal curvePool;
-    IERC20 internal lpToken;
-    IERC20 internal oeth;
-    IWETH9 internal weth;
+    address immutable cvxDepositorAddress;
+    IRewardStaking public immutable cvxRewardStaker;
+    uint256 immutable cvxDepositorPTokenId;
+    ICurveETHPoolV1 immutable curvePool;
+    IERC20 immutable lpToken;
+    IERC20 immutable oeth;
+    IWETH9 immutable weth;
     // Ordered list of pool assets
     uint128 constant oethCoinIndex = 1;
     uint128 constant ethCoinIndex = 0;
@@ -55,6 +55,17 @@ contract ConvexEthMetaStrategy is InitializableAbstractStrategy {
         address cvxRewardStakerAddress; //Address of the CVX rewards staker
         address curvePoolLpToken; //Address of metapool LP token
         uint256 cvxDepositorPTokenId; //Pid of the pool referred to by Depositor and staker
+        address wethAddress; //Address of WETH
+    }
+
+    constructor(InitializeConfig memory initConfig) {
+        cvxDepositorAddress = initConfig.cvxDepositorAddress;
+        cvxRewardStaker = IRewardStaking(initConfig.cvxRewardStakerAddress);
+        cvxDepositorPTokenId = initConfig.cvxDepositorPTokenId;
+        lpToken = IERC20(initConfig.curvePoolLpToken);
+        curvePool = ICurveETHPoolV1(initConfig.curvePoolAddress);
+        oeth = IERC20(initConfig.oethAddress);
+        weth = IWETH9(initConfig.wethAddress);
     }
 
     /**
@@ -65,31 +76,24 @@ contract ConvexEthMetaStrategy is InitializableAbstractStrategy {
      * @param _assets Addresses of supported assets. MUST be passed in the same
      *                order as returned by coins on the pool contract, i.e.
      *                WETH
-     * @param initConfig Various addresses and info for initialization state
+     * @param _vaultAddress address of the vault proxy contract.
      */
     function initialize(
         address[] calldata _rewardTokenAddresses, // CRV + CVX
         address[] calldata _assets,
-        address[] calldata _pTokens,
-        InitializeConfig calldata initConfig
+        address _vaultAddress
     ) external onlyGovernor initializer {
         require(_assets.length == 1, "Must have exactly one asset");
-        // Should be set prior to abstract initialize call otherwise
-        // abstractSetPToken calls will fail
-        cvxDepositorAddress = initConfig.cvxDepositorAddress;
-        cvxRewardStaker = IRewardStaking(initConfig.cvxRewardStakerAddress);
-        cvxDepositorPTokenId = initConfig.cvxDepositorPTokenId;
-        lpToken = IERC20(initConfig.curvePoolLpToken);
-        curvePool = ICurveETHPoolV1(initConfig.curvePoolAddress);
-        oeth = IERC20(initConfig.oethAddress);
-        weth = IWETH9(_assets[0]); // WETH address
+
+        address[] memory pTokens = new address[](1);
+        pTokens[0] = address(curvePool);
 
         super._initialize(
-            initConfig.curvePoolAddress,
-            initConfig.vaultAddress,
+            address(curvePool),
+            _vaultAddress,
             _rewardTokenAddresses,
             _assets,
-            _pTokens
+            pTokens
         );
 
         /* needs to be called after super._initialize so that the platformAddress

--- a/contracts/contracts/strategies/ConvexEthMetaStrategy.sol
+++ b/contracts/contracts/strategies/ConvexEthMetaStrategy.sol
@@ -32,8 +32,8 @@ contract ConvexEthMetaStrategy is InitializableAbstractStrategy {
     IERC20 internal oeth;
     IWETH9 internal weth;
     // Ordered list of pool assets
-    uint128 internal oethCoinIndex;
-    uint128 internal ethCoinIndex;
+    uint128 constant oethCoinIndex = 1;
+    uint128 constant ethCoinIndex = 0;
 
     /**
      * @dev Verifies that the caller is the Strategist.
@@ -83,8 +83,6 @@ contract ConvexEthMetaStrategy is InitializableAbstractStrategy {
         curvePool = ICurveETHPoolV1(initConfig.curvePoolAddress);
         oeth = IERC20(initConfig.oethAddress);
         weth = IWETH9(_assets[0]); // WETH address
-        ethCoinIndex = uint128(_getCoinIndex(ETH_ADDRESS));
-        oethCoinIndex = uint128(_getCoinIndex(initConfig.oethAddress));
 
         super._initialize(
             initConfig.curvePoolAddress,
@@ -510,16 +508,6 @@ contract ConvexEthMetaStrategy is InitializableAbstractStrategy {
         // so we need separate OETH approve
         _approveAsset(address(oeth));
         lpToken.safeApprove(cvxDepositorAddress, type(uint256).max);
-    }
-
-    /**
-     * @dev Get the index of the coin
-     */
-    function _getCoinIndex(address _asset) internal view returns (uint256) {
-        for (uint256 i = 0; i < 2; i++) {
-            if (curvePool.coins(i) == _asset) return i;
-        }
-        revert("Invalid curve pool asset");
     }
 
     /**

--- a/contracts/contracts/strategies/ConvexEthMetaStrategy.sol
+++ b/contracts/contracts/strategies/ConvexEthMetaStrategy.sol
@@ -21,19 +21,19 @@ contract ConvexEthMetaStrategy is InitializableAbstractStrategy {
     using StableMath for uint256;
     using SafeERC20 for IERC20;
 
-    uint256 internal constant MAX_SLIPPAGE = 1e16; // 1%, same as the Curve UI
-    address internal constant ETH_ADDRESS =
+    uint256 public constant MAX_SLIPPAGE = 1e16; // 1%, same as the Curve UI
+    address public constant ETH_ADDRESS =
         0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
-    address immutable cvxDepositorAddress;
+    address public immutable cvxDepositorAddress;
     IRewardStaking public immutable cvxRewardStaker;
-    uint256 immutable cvxDepositorPTokenId;
-    ICurveETHPoolV1 immutable curvePool;
-    IERC20 immutable lpToken;
-    IERC20 immutable oeth;
-    IWETH9 immutable weth;
+    uint256 public immutable cvxDepositorPTokenId;
+    ICurveETHPoolV1 public immutable curvePool;
+    IERC20 public immutable lpToken;
+    IERC20 public immutable oeth;
+    IWETH9 public immutable weth;
     // Ordered list of pool assets
-    uint128 constant oethCoinIndex = 1;
-    uint128 constant ethCoinIndex = 0;
+    uint128 public constant oethCoinIndex = 1;
+    uint128 public constant ethCoinIndex = 0;
 
     /**
      * @dev Verifies that the caller is the Strategist.

--- a/contracts/deploy/070_oeth_amo_upgrade.js
+++ b/contracts/deploy/070_oeth_amo_upgrade.js
@@ -1,3 +1,5 @@
+const addresses = require("../utils/addresses");
+const { oethPoolLpPID } = require("../utils/constants");
 const { deploymentWithGovernanceProposal } = require("../utils/deploy");
 
 module.exports = deploymentWithGovernanceProposal(
@@ -11,9 +13,21 @@ module.exports = deploymentWithGovernanceProposal(
       "ConvexEthMetaStrategyProxy"
     );
 
+    // Deploy and set the immutable variables
     const dConvexETHMetaStrategy = await deployWithConfirmation(
       "ConvexEthMetaStrategy",
-      [],
+      [
+        [
+          addresses.mainnet.CurveOETHMetaPool,
+          addresses.mainnet.OETHVaultProxy,
+          addresses.mainnet.CVXBooster,
+          addresses.mainnet.OETHProxy,
+          addresses.mainnet.CVXETHRewardsPool,
+          addresses.mainnet.CurveOETHMetaPool,
+          oethPoolLpPID,
+          addresses.mainnet.WETH,
+        ],
+      ],
       null,
       true // force deploy as storage slots have changed
     );
@@ -21,7 +35,7 @@ module.exports = deploymentWithGovernanceProposal(
     // Governance Actions
     // ----------------
     return {
-      name: "Upgrade the OETH AMO.\n\
+      name: "Upgrade the OETH AMO strategy.\n\
       \n\
       Code PR: #",
       actions: [

--- a/contracts/fork-test.sh
+++ b/contracts/fork-test.sh
@@ -73,7 +73,7 @@ main()
     if [ -z "$1" ] || [[ $1 == --* ]]; then
         # Run all files with `.fork-test.js` suffix when no file name param is given
         # pass all other params along
-        if $is_coverage; then
+        if [ $is_coverage ]; then
             # TODO: Debug this later
             # params+="--testfiles 'test/**/*.fork-test.js'"
             params+=""
@@ -85,7 +85,7 @@ main()
         params+="$1"
     fi
 
-    if [ $is_coverage == "true" ]; then
+    if [ $is_coverage ]; then
         echo "Running tests and generating coverage reports..."
         FORK=true IS_TEST=true npx --no-install hardhat coverage --testfiles "test/**/*.fork-test.js"
     else

--- a/contracts/test/strategies/oeth-metapool.fork-test.js
+++ b/contracts/test/strategies/oeth-metapool.fork-test.js
@@ -150,6 +150,20 @@ forkOnlyDescribe("ForkTest: OETH AMO Curve Metapool Strategy", function () {
     expect(supplyDiff).to.be.gte(oethUnits("9.95"));
   });
 
+  it("Should be able to check balance", async () => {
+    const { weth, josh, ConvexEthMetaStrategy } = await loadFixture(
+      convexOETHMetaVaultFixture
+    );
+
+    expect(await ConvexEthMetaStrategy.checkBalance(weth.address)).eq(0);
+
+    // This uses a transaction to call a view function so the gas usage can be reported.
+    const tx = await ConvexEthMetaStrategy.connect(
+      josh
+    ).populateTransaction.checkBalance(weth.address);
+    await josh.sendTransaction(tx);
+  });
+
   it("Should redeem", async () => {
     const { oethVault, oeth, weth, josh, ConvexEthMetaStrategy } =
       await loadFixture(convexOETHMetaVaultFixture);

--- a/contracts/test/strategies/oeth-metapool.fork-test.js
+++ b/contracts/test/strategies/oeth-metapool.fork-test.js
@@ -105,6 +105,22 @@ forkOnlyDescribe("ForkTest: OETH AMO Curve Metapool Strategy", function () {
       .checkDelta(profit, variance, valueChange, variance);
   });
 
+  it("Should be able to check balance", async () => {
+    const { weth, josh, ConvexEthMetaStrategy } = await loadFixture(
+      convexOETHMetaVaultFixture
+    );
+
+    const balance = await ConvexEthMetaStrategy.checkBalance(weth.address);
+    log(`check balance ${balance}`);
+    expect(balance).gt(0);
+
+    // This uses a transaction to call a view function so the gas usage can be reported.
+    const tx = await ConvexEthMetaStrategy.connect(
+      josh
+    ).populateTransaction.checkBalance(weth.address);
+    await josh.sendTransaction(tx);
+  });
+
   it("Should deposit to Metapool", async function () {
     // TODO: should have differently balanced metapools
     const fixture = await loadFixture(convexOETHMetaVaultFixture);
@@ -148,20 +164,6 @@ forkOnlyDescribe("ForkTest: OETH AMO Curve Metapool Strategy", function () {
     const supplyDiff = currentSupply.sub(newSupply);
 
     expect(supplyDiff).to.be.gte(oethUnits("9.95"));
-  });
-
-  it("Should be able to check balance", async () => {
-    const { weth, josh, ConvexEthMetaStrategy } = await loadFixture(
-      convexOETHMetaVaultFixture
-    );
-
-    expect(await ConvexEthMetaStrategy.checkBalance(weth.address)).eq(0);
-
-    // This uses a transaction to call a view function so the gas usage can be reported.
-    const tx = await ConvexEthMetaStrategy.connect(
-      josh
-    ).populateTransaction.checkBalance(weth.address);
-    await josh.sendTransaction(tx);
   });
 
   it("Should redeem", async () => {

--- a/dapp-oeth/src/hooks/useSwapEstimator.js
+++ b/dapp-oeth/src/hooks/useSwapEstimator.js
@@ -10,6 +10,7 @@ import ContractStore from 'stores/ContractStore'
 import { calculateSwapAmounts } from 'utils/math'
 import fetchWithTimeout from 'utils/fetchWithTimeout'
 import { find } from 'lodash'
+import { useSigner } from 'wagmi'
 
 const parseFloatBN = (value) => parseFloat(ethers.utils.formatEther(value))
 
@@ -47,6 +48,7 @@ const useSwapEstimator = ({
     (s) => s.isGasPriceUserOverriden
   )
 
+  const { data: signer } = useSigner()
   const balances = useStoreState(AccountStore, (s) => s.balances)
 
   const { contract: coinToSwapContract, decimals: coinToSwapDecimals } =
@@ -263,7 +265,7 @@ const useSwapEstimator = ({
       estimation.gasEstimateEth =
         (parseFloat(ethers.utils.formatUnits(gasPrice, 'gwei')) *
           parseFloat(estimation.gasUsed)) /
-        100000000
+        1000000000
 
       if (estimation.approveAllowanceNeeded) {
         estimation.gasEstimateSwap = getGasUsdCost(
@@ -319,7 +321,7 @@ const useSwapEstimator = ({
     const gasInGwei = ethers.utils.formatUnits(gasPrice, 'gwei')
     // gwei offset
     return (
-      (parseFloat(gasLimit) * parseFloat(gasInGwei) * flooredEth) / 100000000
+      (parseFloat(gasLimit) * parseFloat(gasInGwei) * flooredEth) / 1000000000
     )
   }
 
@@ -347,7 +349,13 @@ const useSwapEstimator = ({
     }
 
     if (selectedCoin === 'eth') {
-      const swapGasUsage = 90000 // TODO: Update this
+      const hasEnoughBalance = parseFloat(balances?.eth) > amount
+
+      const swapGasUsage = hasEnoughBalance
+        ? await contracts.zapper.connect(signer).estimateGas.deposit({
+            value: ethers.utils.parseEther(String(amount)),
+          })
+        : 200000
 
       return {
         canDoSwap: true,
@@ -430,8 +438,21 @@ const useSwapEstimator = ({
         }
       }
 
+      const { minSwapAmount: minSwapAmountQuoted } = calculateSwapAmounts(
+        amountReceived,
+        coinToReceiveDecimals,
+        priceToleranceValue
+      )
+
+      const hasEnoughBalance = userHasEnoughStablecoin(
+        coinToSwap,
+        parseFloat(inputAmountRaw)
+      )
+
       if (coinToSwap === 'eth' && swapMode === 'mint') {
-        const swapGasUsage = 90000 // TODO: Update this
+        const swapGasUsage = hasEnoughBalance
+          ? await swapCurveGasEstimate(swapAmount, minSwapAmountQuoted)
+          : 180000
 
         return {
           canDoSwap: true,
@@ -466,11 +487,6 @@ const useSwapEstimator = ({
           parseFloat(inputAmountRaw)
         : true
 
-      const hasEnoughBalance = userHasEnoughStablecoin(
-        coinToSwap,
-        parseFloat(inputAmountRaw)
-      )
-
       if (approveAllowanceNeeded || !hasEnoughBalance) {
         const swapGasUsage = 350000
         const approveGasUsage = approveAllowanceNeeded
@@ -494,15 +510,6 @@ const useSwapEstimator = ({
           hasEnoughBalance,
         }
       }
-
-      const {
-        swapAmount: swapAmountQuoted,
-        minSwapAmount: minSwapAmountQuoted,
-      } = calculateSwapAmounts(
-        amountReceived,
-        coinToReceiveDecimals,
-        priceToleranceValue
-      )
 
       const gasEstimate = await swapCurveGasEstimate(
         swapAmount,


### PR DESCRIPTION
If you made a contract change, make sure to complete the checklist below before merging it in master.

Refer to our [documentation](https://github.com/OriginProtocol/security) for more details about contract security best practices.

Contract change checklist:
  - [ ] Code reviewed by 2 reviewers. 
  - [ ] Copy & paste code review [security checklist](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md) below this checklist.
  - [x] Unit tests pass
  - [x] Slither tests pass with no warning
  - [ ] Echidna tests pass if PR includes changes to OUSD contract (not automated, run manually on local)

The main contract changes to `ConvexEthMetaStrategy` were
* Used constants for coin index positions
* Used immutables for config that can't be changed.

Some notable gas improvements:
* `mint` 14,376
* `redeem` 14,659
* `allocate` 10,219
* `rebase` 6,507
* `depositToStrategy` 16,134
* `withdrawAllFromStrategy` 10,355
* `takeSnapshot` 6,507

Gas usage before the changes running `REPORT_GAS=true yarn test:fork test/strategies/oeth-metapool.fork-test.js`
```
|  Methods                                                                                                                               │
··························|······································|·············|·············|·············|···············|··············
|  Contract               ·  Method                              ·  Min        ·  Max        ·  Avg        ·  # calls      ·  eur (avg)  │
··························|······································|·············|·············|·············|···············|··············
|  ERC20                  ·  approve                             ·      26174  ·      60107  ·      40933  ·           76  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  ERC20                  ·  transfer                            ·      28541  ·      88327  ·      58273  ·          101  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  Flipper                ·  withdrawAll                         ·          -  ·          -  ·    1295417  ·            1  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  Harvester              ·  harvestAndSwap                      ·          -  ·          -  ·     446883  ·            1  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  MockVault              ·  allocate                            ·     351883  ·    1481801  ·     765553  ·            8  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  MockVault              ·  mint                                ·     453459  ·    1584025  ·    1297097  ·            4  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  MockVault              ·  rebase                              ·     350149  ·     396471  ·     384051  ·            4  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  MockVault              ·  redeem                              ·          -  ·          -  ·    1712822  ·            1  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  OETHVault              ·  depositToStrategy                   ·          -  ·          -  ·    1383071  ·            1  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  OETHVault              ·  setAssetDefaultStrategy             ·          -  ·          -  ·      75426  ·            1  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  OETHVault              ·  setNetOusdMintForStrategyThreshold  ·          -  ·          -  ·      40208  ·            1  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  OETHVault              ·  withdrawAllFromStrategy             ·          -  ·          -  ·    1382824  ·            2  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  OETHVaultValueChecker  ·  checkDelta                          ·          -  ·          -  ·     352299  ·            1  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  OETHVaultValueChecker  ·  takeSnapshot                        ·          -  ·          -  ·     409439  ·            1  ·          -  │
```

Gas usage after 
```
|  Methods                                                                                                                               │
··························|······································|·············|·············|·············|···············|··············
|  Contract               ·  Method                              ·  Min        ·  Max        ·  Avg        ·  # calls      ·  eur (avg)  │
··························|······································|·············|·············|·············|···············|··············
|  ERC20                  ·  approve                             ·      26174  ·      60107  ·      40933  ·           76  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  ERC20                  ·  transfer                            ·      28541  ·      88327  ·      58273  ·          101  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  Flipper                ·  withdrawAll                         ·          -  ·          -  ·    1285062  ·            1  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  Harvester              ·  harvestAndSwap                      ·          -  ·          -  ·     444798  ·            1  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  MockVault              ·  allocate                            ·     345376  ·    1465310  ·     755334  ·            8  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  MockVault              ·  checkBalance                        ·          -  ·          -  ·      59902  ·            1  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  MockVault              ·  mint                                ·     446952  ·    1567027  ·    1282721  ·            4  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  MockVault              ·  rebase                              ·     343642  ·     389964  ·     377544  ·            4  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  MockVault              ·  redeem                              ·          -  ·          -  ·    1698163  ·            1  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  OETHVault              ·  depositToStrategy                   ·          -  ·          -  ·    1366937  ·            1  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  OETHVault              ·  setAssetDefaultStrategy             ·          -  ·          -  ·      73370  ·            1  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  OETHVault              ·  setNetOusdMintForStrategyThreshold  ·          -  ·          -  ·      40208  ·            1  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  OETHVault              ·  withdrawAllFromStrategy             ·          -  ·          -  ·    1372469  ·            2  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  OETHVaultValueChecker  ·  checkDelta                          ·          -  ·          -  ·     345792  ·            1  ·          -  │
··························|······································|·············|·············|·············|···············|··············
|  OETHVaultValueChecker  ·  takeSnapshot                        ·          -  ·          -  ·     402932  ·            1  ·          -  │
```

