### PR TITLE
Add back deprecated methods to interface

### DIFF
--- a/contracts/contracts/interfaces/IVault.sol
+++ b/contracts/contracts/interfaces/IVault.sol
@@ -120,6 +120,11 @@ interface IVault {
 
     function priceUnitRedeem(address asset) external view returns (uint256);
 
+    // The following two function definitions exist for backward compatibility
+    function priceUSDMint(address asset) external view returns (uint256);
+
+    function priceUSDRedeem(address asset) external view returns (uint256);
+
     function withdrawAllFromStrategy(address _strategyAddr) external;
 
     function withdrawAllFromStrategies() external;


### PR DESCRIPTION
Fixes the build issue blocking the OUSD DApp. This should be reverted after the OUSD Vault is upgraded. Related issue: #1368 

--------

If you made a contract change, make sure to complete the checklist below before merging it in master.

Refer to our [documentation](https://github.com/OriginProtocol/security) for more details about contract security best practices.

Contract change checklist:
  - [ ] Code reviewed by 2 reviewers. 
  - [ ] Copy & paste code review [security checklist](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md) below this checklist.
  - [ ] Unit tests pass
  - [ ] Slither tests pass with no warning
  - [ ] Echidna tests pass if PR includes changes to OUSD contract (not automated, run manually on local)
