### PR TITLE
Geofence modal style touchup

### DIFF
--- a/dapp-oeth/src/components/GeoFenceCheck.js
+++ b/dapp-oeth/src/components/GeoFenceCheck.js
@@ -180,7 +180,7 @@ const GeoFenceCheck = () => {
         }
 
         .geofence-modal .accept-criteria {
-          padding: 12px 24px 12px 24px;
+          padding: 0;
           border-radius: 4px;
           background-color: #51546633;
           font-family: Inter;
@@ -192,7 +192,7 @@ const GeoFenceCheck = () => {
         }
 
         .geofence-modal .accept-criteria .list {
-          padding: 24px 0px 24px 20px;
+          padding: 24px 24px 24px 36px;
           margin: 0;
         }
 
@@ -215,6 +215,7 @@ const GeoFenceCheck = () => {
           line-height: 20px;
           letter-spacing: 0em;
           text-align: left;
+          margin: 0;
         }
 
         .geofence-modal .ack .label-text {

--- a/dapp-oeth/src/components/GeoFenceCheck.js
+++ b/dapp-oeth/src/components/GeoFenceCheck.js
@@ -192,7 +192,7 @@ const GeoFenceCheck = () => {
         }
 
         .geofence-modal .accept-criteria .list {
-          padding: 24px 0px 24px 16px;
+          padding: 24px 0px 24px 20px;
           margin: 0;
         }
 

--- a/dapp-oeth/src/components/GeoFenceCheck.js
+++ b/dapp-oeth/src/components/GeoFenceCheck.js
@@ -167,6 +167,7 @@ const GeoFenceCheck = () => {
           line-height: 23px;
           letter-spacing: 0em;
           text-align: left;
+          margin-bottom: 24px;
         }
 
         .geofence-modal .info.sub {
@@ -191,7 +192,7 @@ const GeoFenceCheck = () => {
         }
 
         .geofence-modal .accept-criteria .list {
-          padding: 0 0 0 24px;
+          padding: 24px 0px 24px 16px;
           margin: 0;
         }
 
@@ -202,7 +203,7 @@ const GeoFenceCheck = () => {
         .geofence-modal .ack {
           display: inline-flex;
           align-items: center;
-          margin: 18px 0;
+          margin: 24px 0;
         }
 
         .geofence-modal .ack .ack-label {

--- a/dapp/src/components/GeoFenceCheck.js
+++ b/dapp/src/components/GeoFenceCheck.js
@@ -175,7 +175,7 @@ const GeoFenceCheck = () => {
         }
 
         .geofence-modal .accept-criteria {
-          padding: 12px 24px 12px 24px;
+          padding: 0;
           border-radius: 4px;
           background-color: #fafbfc;
           font-family: Lato;
@@ -187,7 +187,7 @@ const GeoFenceCheck = () => {
         }
 
         .geofence-modal .accept-criteria .list {
-          padding: 0 0 0 24px;
+          padding: 24px 24px 24px 36px;
           margin: 0;
         }
 
@@ -198,7 +198,7 @@ const GeoFenceCheck = () => {
         .geofence-modal .ack {
           display: inline-flex;
           align-items: center;
-          margin: 18px 0;
+          margin: 24px 0;
         }
 
         .geofence-modal .ack .ack-label {
@@ -210,6 +210,7 @@ const GeoFenceCheck = () => {
           line-height: 20px;
           letter-spacing: 0em;
           text-align: left;
+          margin: 0;
         }
 
         .geofence-modal .ack .label-text {

--- a/dapp/styles/globals.css
+++ b/dapp/styles/globals.css
@@ -424,6 +424,7 @@ section.dim {
 
 .modal-content {
   background-color: transparent !important;
+  border: none !important;
 }
 
 @media (max-width: 992px) {


### PR DESCRIPTION
Fixes 2 issues with the geofence modal


* OETH dapp spacing increased to 24px and list padding reduced
* OUSD dapp removes a border line that should not have been showing

![Screenshot 2023-07-27 092156](https://github.com/OriginProtocol/origin-dollar/assets/762107/4b216c21-6136-4f6d-a5e2-df439de97711)

![Screenshot 2023-07-27 092123](https://github.com/OriginProtocol/origin-dollar/assets/762107/dea1acb3-6f56-41c4-861f-ae6008b8928e)


