### PR TITLE
Balancer fork tests

### DIFF
--- a/contracts/contracts/strategies/balancer/BaseAuraStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BaseAuraStrategy.sol
@@ -81,6 +81,7 @@ abstract contract BaseAuraStrategy is BaseBalancerStrategy {
      */
     function _lpWithdraw(uint256 numBPTTokens) internal virtual override {
         // Get all the strategy's BPTs in Aura
+        // maxRedeem is implemented as balanceOf(address) in Aura
         uint256 maxBPTTokens = IERC4626(auraRewardPoolAddress).maxRedeem(
             address(this)
         );
@@ -97,6 +98,7 @@ abstract contract BaseAuraStrategy is BaseBalancerStrategy {
      */
     function _lpWithdrawAll() internal virtual override {
         // Get all the strategy's BPTs in Aura
+        // maxRedeem is implemented as balanceOf(address) in Aura
         uint256 bptBalance = IERC4626(auraRewardPoolAddress).maxRedeem(
             address(this)
         );
@@ -131,6 +133,7 @@ abstract contract BaseAuraStrategy is BaseBalancerStrategy {
     {
         balancerPoolTokens =
             IERC20(platformAddress).balanceOf(address(this)) +
+            // maxRedeem is implemented as balanceOf(address) in Aura
             IERC4626(auraRewardPoolAddress).maxRedeem(address(this));
     }
 

--- a/contracts/contracts/strategies/balancer/BaseAuraStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BaseAuraStrategy.sol
@@ -6,7 +6,6 @@ pragma solidity ^0.8.0;
  * @author Origin Protocol Inc
  */
 
-import "@openzeppelin/contracts/utils/math/Math.sol";
 import { BaseBalancerStrategy } from "./BaseBalancerStrategy.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { IRateProvider } from "../../interfaces/balancer/IRateProvider.sol";
@@ -80,14 +79,8 @@ abstract contract BaseAuraStrategy is BaseBalancerStrategy {
      * @param numBPTTokens Number of Balancer Pool Tokens (BPT) to withdraw
      */
     function _lpWithdraw(uint256 numBPTTokens) internal virtual override {
-        // Get all the strategy's BPTs in Aura
-        // maxRedeem is implemented as balanceOf(address) in Aura
-        uint256 maxBPTTokens = IERC4626(auraRewardPoolAddress).maxRedeem(
-            address(this)
-        );
-
         IRewardStaking(auraRewardPoolAddress).withdrawAndUnwrap(
-            Math.min(numBPTTokens, maxBPTTokens),
+            numBPTTokens,
             true // also claim reward tokens
         );
     }

--- a/contracts/test/_fixture.js
+++ b/contracts/test/_fixture.js
@@ -860,6 +860,11 @@ function balancerREthFixtureSetup(config = { defaultStrategy: true }) {
     );
     fixture.balancerREthPID = balancer_rETH_WETH_PID;
 
+    fixture.auraPool = await ethers.getContractAt(
+      "IERC4626",
+      addresses.mainnet.rETH_WETH_AuraRewards
+    );
+
     fixture.balancerVault = await ethers.getContractAt(
       "IBalancerVault",
       addresses.mainnet.balancerVault,

--- a/contracts/test/_fixture.js
+++ b/contracts/test/_fixture.js
@@ -184,6 +184,7 @@ const defaultFixture = deployments.createFixture(async () => {
     LUSDMetaStrategy,
     oethHarvester,
     oethDripper,
+    oethZapper,
     swapper,
     mockSwapper,
     swapper1Inch,
@@ -296,6 +297,8 @@ const defaultFixture = deployments.createFixture(async () => {
       "OETHDripper",
       oethDripperProxy.address
     );
+
+    oethZapper = await ethers.getContract("OETHZapper");
 
     // Replace OracelRouter to disable staleness
     const dMockOracleRouterNoStale = await deployWithConfirmation(
@@ -558,6 +561,7 @@ const defaultFixture = deployments.createFixture(async () => {
     ConvexEthMetaStrategy,
     oethDripper,
     oethHarvester,
+    oethZapper,
     swapper,
     mockSwapper,
     swapper1Inch,
@@ -834,18 +838,20 @@ async function convexVaultFixture() {
 /**
  * Configure a Vault with the balancerREthStrategy
  */
-function balancerREthFixtureSetup() {
+function balancerREthFixtureSetup(config = { defaultStrategy: true }) {
   return deployments.createFixture(async () => {
     const fixture = await defaultFixture();
     const { oethVault, timelock, weth, reth, balancerREthStrategy, josh } =
       fixture;
 
-    await oethVault
-      .connect(timelock)
-      .setAssetDefaultStrategy(reth.address, balancerREthStrategy.address);
-    await oethVault
-      .connect(timelock)
-      .setAssetDefaultStrategy(weth.address, balancerREthStrategy.address);
+    if (config.defaultStrategy) {
+      await oethVault
+        .connect(timelock)
+        .setAssetDefaultStrategy(reth.address, balancerREthStrategy.address);
+      await oethVault
+        .connect(timelock)
+        .setAssetDefaultStrategy(weth.address, balancerREthStrategy.address);
+    }
 
     fixture.rEthBPT = await ethers.getContractAt(
       "IERC20Metadata",
@@ -858,6 +864,19 @@ function balancerREthFixtureSetup() {
       "IBalancerVault",
       addresses.mainnet.balancerVault,
       josh
+    );
+
+    // Get some rETH from most loaded contracts/wallets
+    await impersonateAndFundAddress(
+      addresses.mainnet.rETH,
+      [
+        "0xCc9EE9483f662091a1de4795249E24aC0aC2630f",
+        "0xC6424e862f1462281B0a5FAc078e4b63006bDEBF",
+        "0x7d6149aD9A573A6E2Ca6eBf7D4897c1B766841B4",
+        "0x7C5aaA2a20b01df027aD032f7A768aC015E77b86",
+        "0x1BeE69b7dFFfA4E2d53C2a2Df135C388AD25dCD2",
+      ],
+      josh.getAddress()
     );
 
     return fixture;

--- a/contracts/test/strategies/balancerMetaStablePool.fork-test.js
+++ b/contracts/test/strategies/balancerMetaStablePool.fork-test.js
@@ -377,7 +377,7 @@ forkOnlyDescribe(
             [withdrawAmountUnits, withdrawAmountUnits]
           );
         log(
-          `Vault withdraws ${withdrawAmount} WETH and ${depositAmount} RETH together`
+          `Vault withdraws ${withdrawAmount} WETH and ${withdrawAmount} RETH together`
         );
 
         const stratValueAfter = await oethVault.totalValue();

--- a/contracts/test/strategies/balancerMetaStablePool.fork-test.js
+++ b/contracts/test/strategies/balancerMetaStablePool.fork-test.js
@@ -369,7 +369,7 @@ forkOnlyDescribe(
           weth,
         } = fixture;
 
-        const withdrawAmount = 29996;
+        const withdrawAmount = 29950;
         const withdrawAmountUnits = oethUnits(withdrawAmount.toString(), 18);
 
         const stratValueBefore = await oethVault.totalValue();
@@ -429,7 +429,7 @@ forkOnlyDescribe(
         );
         log(`Aura BPTs before: ${formatUnits(bptBefore)}`);
 
-        const withdrawAmount = 29996;
+        const withdrawAmount = 29800;
         const withdrawAmountUnits = oethUnits(withdrawAmount.toString(), 18);
 
         await balancerREthStrategy

--- a/contracts/test/strategies/balancerMetaStablePool.fork-test.js
+++ b/contracts/test/strategies/balancerMetaStablePool.fork-test.js
@@ -360,9 +360,16 @@ forkOnlyDescribe(
         );
       });
       it(`withdraw close to ${depositAmount} of both assets using multi asset withdraw`, async () => {
-        const { balancerREthStrategy, oethVault, reth, weth } = fixture;
+        const {
+          auraPool,
+          balancerREthStrategy,
+          rEthBPT,
+          oethVault,
+          reth,
+          weth,
+        } = fixture;
 
-        const withdrawAmount = 29999;
+        const withdrawAmount = 29996;
         const withdrawAmountUnits = oethUnits(withdrawAmount.toString(), 18);
 
         const stratValueBefore = await oethVault.totalValue();
@@ -378,6 +385,16 @@ forkOnlyDescribe(
           );
         log(
           `Vault withdraws ${withdrawAmount} WETH and ${withdrawAmount} RETH together`
+        );
+
+        const bptAfterReth = await auraPool.balanceOf(
+          balancerREthStrategy.address
+        );
+        log(`Aura BPTs after withdraw: ${formatUnits(bptAfterReth)}`);
+        log(
+          `Strategy BPTs after withdraw: ${formatUnits(
+            await rEthBPT.balanceOf(balancerREthStrategy.address)
+          )}`
         );
 
         const stratValueAfter = await oethVault.totalValue();
@@ -457,12 +474,6 @@ forkOnlyDescribe(
 
         log(`Vault withdraws ${withdrawAmount} RETH`);
 
-        const stratValueAfterReth = await oethVault.totalValue();
-        log(
-          `Vault total value after RETH withdraw: ${formatUnits(
-            stratValueAfterReth
-          )}`
-        );
         const bptAfterReth = await auraPool.balanceOf(
           balancerREthStrategy.address
         );
@@ -470,6 +481,13 @@ forkOnlyDescribe(
         log(
           `Strategy BPTs after RETH withdraw: ${formatUnits(
             await rEthBPT.balanceOf(balancerREthStrategy.address)
+          )}`
+        );
+
+        const stratValueAfterReth = await oethVault.totalValue();
+        log(
+          `Vault total value after RETH withdraw: ${formatUnits(
+            stratValueAfterReth
           )}`
         );
 


### PR DESCRIPTION
* `BaseAuraStrategy` handle withdraws close to the BPT limit in Aura by checking the max BPT is <= the balance of Aura Pool shares.
* Using `maxRedeem` instead of `balanceOf` as that's more technically correct for 4626 vaults. The balance can be greater than what's allowed to be redeemed.
* Fixed bug Balancer in fork tests