### PR TITLE
Remove Argent from RainbowKit

### DIFF
--- a/dapp-oeth/pages/_app.js
+++ b/dapp-oeth/pages/_app.js
@@ -21,7 +21,6 @@ import {
   darkTheme,
 } from '@rainbow-me/rainbowkit'
 import {
-  argentWallet,
   ledgerWallet,
   phantomWallet,
   safeWallet,
@@ -62,7 +61,6 @@ const connectors = connectorsForWallets([
   {
     groupName: 'Other',
     wallets: [
-      argentWallet({ projectId, chains }),
       mewWallet({ projectId, chains }),
       okxWallet({ projectId, chains }),
       ledgerWallet({ projectId, chains }),

--- a/dapp/pages/_app.js
+++ b/dapp/pages/_app.js
@@ -22,7 +22,6 @@ import {
   lightTheme,
 } from '@rainbow-me/rainbowkit'
 import {
-  argentWallet,
   ledgerWallet,
   phantomWallet,
   safeWallet,
@@ -63,7 +62,6 @@ const connectors = connectorsForWallets([
   {
     groupName: 'Other',
     wallets: [
-      argentWallet({ projectId, chains }),
       mewWallet({ projectId, chains }),
       okxWallet({ projectId, chains }),
       ledgerWallet({ projectId, chains }),


### PR DESCRIPTION
Unless something has changed, Argent does not support rebasing because it's a "smart wallet". See https://github.com/OriginProtocol/origin-dollar/issues/735#issuecomment-915590467. As such, we should not encourage users to connect this type of wallet.