### PR TITLE
OETH Dapp: Pending Yield display issue

### DIFF
--- a/dapp-oeth/src/components/layout.js
+++ b/dapp-oeth/src/components/layout.js
@@ -24,9 +24,11 @@ const Layout = ({
   storeTransactionError,
 }) => {
   const { data: signer } = useSigner()
+
   const oethContract = useStoreState(ContractStore, (s) =>
     get(s, 'contracts.oeth')
   )
+
   const rebaseOptedOut = useStoreState(AccountStore, (s) =>
     get(s, 'rebaseOptedOut')
   )

--- a/dapp-oeth/src/utils/contracts.js
+++ b/dapp-oeth/src/utils/contracts.js
@@ -412,6 +412,7 @@ export async function setupContracts(account, chainId, fetchId) {
       const credits = await oeth.creditsBalanceOf(account)
       const woethValue = await woeth.maxWithdraw(account)
       const creditsWrapped = woethValue.mul(credits[1])
+
       AccountStore.update((s) => {
         s.creditsBalanceOf = ethers.utils.formatUnits(credits[0], 18)
         s.creditsWrapped = ethers.utils.formatUnits(creditsWrapped, 36)

--- a/dapp-oeth/src/utils/useExpectedYield.js
+++ b/dapp-oeth/src/utils/useExpectedYield.js
@@ -19,9 +19,6 @@ const useExpectedYield = (isWrapped = false) => {
   const expectedIncrease = useStoreState(YieldStore, (s) =>
     isWrapped ? s.expectedIncreaseWrapped : s.expectedIncrease
   )
-  const animatedExpectedIncrease = useStoreState(YieldStore, (s) =>
-    isWrapped ? s.animatedExpectedIncreaseWrapped : s.animatedExpectedIncrease
-  )
 
   const creditsBalanceOf = useStoreState(AccountStore, (s) =>
     isWrapped ? s.creditsWrapped : s.creditsBalanceOf

--- a/dapp-oeth/src/utils/useExpectedYield.js
+++ b/dapp-oeth/src/utils/useExpectedYield.js
@@ -1,8 +1,5 @@
-import React, { useState, useEffect } from 'react'
-import { fbt } from 'fbt-runtime'
+import React, { useEffect } from 'react'
 import { useStoreState } from 'pullstate'
-import { BigNumber } from 'ethers'
-
 import AccountStore from 'stores/AccountStore'
 import YieldStore from 'stores/YieldStore'
 import { animateValue } from 'utils/animation'
@@ -99,7 +96,7 @@ const useExpectedYield = (isWrapped = false) => {
   }, [creditsBalanceOf, currentCreditsPerToken, nextCreditsPerToken])
 
   return {
-    animatedExpectedIncrease,
+    animatedExpectedIncrease: expectedIncrease,
   }
 }
 


### PR DESCRIPTION
There was a calculation display issue for pending yield for low yield relative to the animation sequence thresholds that made the display always show 0. The fix here is to just remove the animation requirement and display the pending yield immediately.

![Screenshot 2023-08-10 111417](https://github.com/OriginProtocol/origin-dollar/assets/762107/23ffbfaf-0391-4fae-bee6-6dc736b0aefe)
