### PR TITLE
Balancer off chain min BPT check

### DIFF
--- a/contracts/contracts/interfaces/IStrategy.sol
+++ b/contracts/contracts/interfaces/IStrategy.sol
@@ -19,6 +19,12 @@ interface IStrategy {
     function depositAll() external;
 
     /**
+     * @dev Deposit the entire balance of all supported assets in the Strategy
+     *      to the platform. Pass along _userData for custom / per strategy checks.
+     */
+    function depositAll(bytes calldata _userData) external;
+
+    /**
      * @dev Withdraw given asset from Lending platform
      */
     function withdraw(

--- a/contracts/contracts/interfaces/IVault.sol
+++ b/contracts/contracts/interfaces/IVault.sol
@@ -141,6 +141,13 @@ interface IVault {
         uint256[] calldata _amounts
     ) external;
 
+    function depositToStrategy(
+        address _strategyToAddress,
+        address[] calldata _assets,
+        uint256[] calldata _amounts,
+        bytes calldata userData
+    ) external;
+
     // VaultCore.sol
     function mint(
         address _asset,

--- a/contracts/contracts/strategies/AaveStrategy.sol
+++ b/contracts/contracts/strategies/AaveStrategy.sol
@@ -94,6 +94,15 @@ contract AaveStrategy is InitializableAbstractStrategy {
         }
     }
 
+    function depositAll(bytes calldata _depositData)
+        external
+        override
+        onlyVault
+        nonReentrant
+    {
+        require(false, "Not supported");
+    }
+
     /**
      * @dev Withdraw asset from Aave
      * @param _recipient Address to receive withdrawn asset

--- a/contracts/contracts/strategies/BaseCurveStrategy.sol
+++ b/contracts/contracts/strategies/BaseCurveStrategy.sol
@@ -100,6 +100,15 @@ abstract contract BaseCurveStrategy is InitializableAbstractStrategy {
         _lpDepositAll();
     }
 
+    function depositAll(bytes calldata _depositData)
+        external
+        override
+        onlyVault
+        nonReentrant
+    {
+        require(false, "Not supported");
+    }
+
     function _lpWithdraw(uint256 numCrvTokens) internal virtual;
 
     function _lpWithdrawAll() internal virtual;

--- a/contracts/contracts/strategies/CompoundStrategy.sol
+++ b/contracts/contracts/strategies/CompoundStrategy.sol
@@ -96,6 +96,15 @@ contract CompoundStrategy is BaseCompoundStrategy {
         }
     }
 
+    function depositAll(bytes calldata _depositData)
+        external
+        override
+        onlyVault
+        nonReentrant
+    {
+        require(false, "Not supported");
+    }
+
     /**
      * @notice Withdraw an asset from the underlying platform
      * @param _recipient Address to receive withdrawn assets

--- a/contracts/contracts/strategies/ConvexEthMetaStrategy.sol
+++ b/contracts/contracts/strategies/ConvexEthMetaStrategy.sol
@@ -170,6 +170,15 @@ contract ConvexEthMetaStrategy is InitializableAbstractStrategy {
         }
     }
 
+    function depositAll(bytes calldata _depositData)
+        external
+        override
+        onlyVault
+        nonReentrant
+    {
+        require(false, "Not supported");
+    }
+
     /**
      * @dev Withdraw asset from Curve ETH pool
      * @param _recipient Address to receive withdrawn asset

--- a/contracts/contracts/strategies/FraxETHStrategy.sol
+++ b/contracts/contracts/strategies/FraxETHStrategy.sol
@@ -105,6 +105,15 @@ contract FraxETHStrategy is Generalized4626Strategy {
         }
     }
 
+    function depositAll(bytes calldata _depositData)
+        external
+        override
+        onlyVault
+        nonReentrant
+    {
+        require(false, "Not supported");
+    }
+
     /**
      * @dev Accept ETH
      */

--- a/contracts/contracts/strategies/Generalized4626Strategy.sol
+++ b/contracts/contracts/strategies/Generalized4626Strategy.sol
@@ -91,6 +91,16 @@ contract Generalized4626Strategy is InitializableAbstractStrategy {
         }
     }
 
+    function depositAll(bytes calldata _depositData)
+        external
+        virtual
+        override
+        onlyVault
+        nonReentrant
+    {
+        require(false, "Not supported");
+    }
+
     /**
      * @dev Withdraw asset by burning shares
      * @param _recipient Address to receive withdrawn asset

--- a/contracts/contracts/strategies/MorphoAaveStrategy.sol
+++ b/contracts/contracts/strategies/MorphoAaveStrategy.sol
@@ -140,6 +140,15 @@ contract MorphoAaveStrategy is InitializableAbstractStrategy {
         }
     }
 
+    function depositAll(bytes calldata _depositData)
+        external
+        override
+        onlyVault
+        nonReentrant
+    {
+        require(false, "Not supported");
+    }
+
     /**
      * @dev Withdraw asset from Morpho
      * @param _recipient Address to receive withdrawn asset

--- a/contracts/contracts/strategies/MorphoCompoundStrategy.sol
+++ b/contracts/contracts/strategies/MorphoCompoundStrategy.sol
@@ -176,6 +176,15 @@ contract MorphoCompoundStrategy is BaseCompoundStrategy {
         }
     }
 
+    function depositAll(bytes calldata _depositData)
+        external
+        override
+        onlyVault
+        nonReentrant
+    {
+        require(false, "Not supported");
+    }
+
     /**
      * @dev Withdraw asset from Morpho
      * @param _recipient Address to receive withdrawn asset

--- a/contracts/contracts/utils/InitializableAbstractStrategy.sol
+++ b/contracts/contracts/utils/InitializableAbstractStrategy.sol
@@ -33,6 +33,17 @@ abstract contract InitializableAbstractStrategy is Initializable, Governable {
         address _newHarvesterAddress
     );
 
+    /* @notice Defines how the bytes _depositData is encoded in
+     * depositAll function. Encoding types:
+     *
+     * BPT_EXPECTED_DEPOSIT_ALL:
+     * (uint256, uint256)
+     * (BPT_EXPECTED_DEPOSIT_ALL, uint256 minBptExpected)
+     */
+    enum DepositDataType {
+        BPT_EXPECTED_DEPOSIT_ALL
+    }
+
     /// @notice Address of the underlying platform
     address public immutable platformAddress;
     /// @notice Address of the OToken vault
@@ -321,6 +332,14 @@ abstract contract InitializableAbstractStrategy is Initializable, Governable {
      * @notice Deposit all supported assets in this strategy contract to the platform
      */
     function depositAll() external virtual;
+
+    /**
+     * @notice Deposit all supported assets in this strategy contract to the platform
+     * @param _depositData       Encoded deposit data providing additional information
+     *                           depending on the strategy in question. E.g. for Balancer
+     *                           strategy it holds minBPTexpected information.
+     */
+    function depositAll(bytes calldata _depositData) external virtual;
 
     /**
      * @notice Withdraw an `amount` of assets from the platform and

--- a/contracts/contracts/vault/VaultAdmin.sol
+++ b/contracts/contracts/vault/VaultAdmin.sol
@@ -423,13 +423,31 @@ contract VaultAdmin is VaultStorage {
         address[] calldata _assets,
         uint256[] calldata _amounts
     ) external onlyGovernorOrStrategist nonReentrant {
-        _depositToStrategy(_strategyToAddress, _assets, _amounts);
+        bytes memory empty = "";
+        _depositToStrategy(_strategyToAddress, _assets, _amounts, empty);
+    }
+
+    /**
+     * @notice Deposit multiple assets from the vault into the strategy.
+     * @param _strategyToAddress Address of the Strategy to deposit assets into.
+     * @param _assets Array of asset address that will be deposited into the strategy.
+     * @param _amounts Array of amounts of each corresponding asset to deposit.
+     * @param _amounts Array of amounts of each corresponding asset to deposit.
+     */
+    function depositToStrategy(
+        address _strategyToAddress,
+        address[] calldata _assets,
+        uint256[] calldata _amounts,
+        bytes calldata _userData
+    ) external onlyGovernorOrStrategist nonReentrant {
+        _depositToStrategy(_strategyToAddress, _assets, _amounts, _userData);
     }
 
     function _depositToStrategy(
         address _strategyToAddress,
         address[] calldata _assets,
-        uint256[] calldata _amounts
+        uint256[] calldata _amounts,
+        bytes memory _userData
     ) internal {
         require(
             strategies[_strategyToAddress].isSupported,
@@ -448,8 +466,13 @@ contract VaultAdmin is VaultStorage {
             IERC20(assetAddr).safeTransfer(_strategyToAddress, _amounts[i]);
         }
 
-        // Deposit all the funds that have been sent to the strategy
-        IStrategy(_strategyToAddress).depositAll();
+        if (_userData.length == 0) {
+            // Deposit all the funds that have been sent to the strategy
+            IStrategy(_strategyToAddress).depositAll();
+        } else {
+            // Deposit all the funds that have been sent to the strategy
+            IStrategy(_strategyToAddress).depositAll(_userData);
+        }
     }
 
     /**

--- a/contracts/test/strategies/balancerPoolReentrancy.fork-test.js
+++ b/contracts/test/strategies/balancerPoolReentrancy.fork-test.js
@@ -29,7 +29,7 @@ forkOnlyDescribe(
       fixture = await loadFixture();
     });
 
-    it.only("Should not allow read-only reentrancy", async () => {
+    it("Should not allow read-only reentrancy", async () => {
       const { weth, reth, oethVault, rEthBPT, balancerREthPID, daniel } =
         fixture;
 


### PR DESCRIPTION
Do a dry-run of how much BPT should depositing liquidity yield, and then pass it along to VaultAdmin's `depositToStrategy`.  This PR also disables withdraw / deposit functions on Balancer strategy since this is never going to be a default strategy. 

Things left to do: 
- make it possible to withdraw using multiple assets with 1 transaction
- make it possible to pass min expected assets on withdrawal

TBD: 
we need a sanity check if strategist is hijacked. We could: 
- still calculate price of BPT on chain and leave ~2% of wiggle room when strategist defines expected BPT on deposit / assets on withdrawal
- limit a number of TX a strategist can execute in a give time interval -> so a circular transactions of depositing / withdrawing to/from strategy can't drain too much funds
- something else?