### PR TITLE
M03 - missing or misleading documentation

### DIFF
--- a/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
@@ -78,6 +78,13 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
         _deposit(assets, amounts);
     }
 
+    /*
+     * _withdrawal doesn't require a read-only re-entrancy protection since during withdrawal
+     * the function enters the Balancer Vault Context. If this function were called as part of
+     * the attacking contract (while intercepting execution flow upon receiving ETH) the read-only
+     * protection of the Balancer Vault would be triggered. Since the attacking contract would
+     * already be in the Balancer Vault context and wouldn't be able to enter it again.
+     */
     function _deposit(address[] memory _assets, uint256[] memory _amounts)
         internal
     {
@@ -189,6 +196,12 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
      * @param _recipient Address to receive the Vault collateral assets. Typically is the Vault.
      * @param _assets Addresses of the Vault collateral assets
      * @param _amounts The amounts of Vault collateral assets to withdraw
+     *
+     * _withdrawal doesn't require a read-only re-entrancy protection since during withdrawal
+     * the function enters the Balancer Vault Context. If this function were called as part of
+     * the attacking contract (while intercepting execution flow upon receiving ETH) the read-only
+     * protection of the Balancer Vault would be triggered. Since the attacking contract would
+     * already be in the Balancer Vault context and wouldn't be able to enter it again.
      */
     function _withdraw(
         address _recipient,

--- a/contracts/contracts/strategies/balancer/BaseAuraStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BaseAuraStrategy.sol
@@ -80,7 +80,9 @@ abstract contract BaseAuraStrategy is BaseBalancerStrategy {
         onlyHarvester
         nonReentrant
     {
-        // Collect BAL and AURA
+        /* Similar to Convex calling this function collects both of the
+         * accrued BAL and AURA tokens.
+         */
         IRewardStaking(auraRewardPoolAddress).getReward();
         _collectRewardTokens();
     }


### PR DESCRIPTION
Todo: 
- [x] explain how reward tokens are collected
- [ ] improve getBptExpected docs
- [x] explain why read-only re-entrency is not required for deposits /withdrawals

**From Audit:**
Throughout the codebase, there are multiple sections which are difficult to understand, and
would benefit from additional or clearer documentation:
It was difficult to assert that reward tokens are actually rewarded to the strategy.
Consider adding more details around how this happens, especially for the AURA tokens
where the process is more complex and not intuitive to follow.
Given the intricacies of how Balancer works, as well as the need to wrap rebasing
tokens, it was difficult to follow the math behind the getBPTExpected functions.
Consider adding a practical example, as well as explanations regarding what each
variable means and what each price is measured in.
Consider documenting why the Balancer read-only reentrancy check is not needed on
deposit and withdrawal functions.
Additionally, while there was documentation around the addition of strategies using Balancer, it
was at times misleading as it was not specifically targeted towards the
BalancerMetaPoolStrategy , and hence would differ from the implementation that was
audited. Consider creating documentation specific to the strategy at hand, explicitly and
concisely explaining the design decisions behind each important piece.