### PR TITLE
N01 - magic numbers

### DIFF
--- a/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
@@ -444,10 +444,10 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
         address poolAsset = toPoolAsset(_asset);
         if (_asset == stETH) {
             // slither-disable-next-line unused-return
-            IERC20(stETH).approve(wstETH, 1e50);
+            IERC20(stETH).approve(wstETH, type(uint256).max);
         } else if (_asset == frxETH) {
             // slither-disable-next-line unused-return
-            IERC20(frxETH).approve(sfrxETH, 1e50);
+            IERC20(frxETH).approve(sfrxETH, type(uint256).max);
         }
         _approveAsset(poolAsset);
     }


### PR DESCRIPTION
Replaced the magic number with max uint256

**From Audit:**
In the BalancerMetaPoolStrategy contract, the value of 1e50 is used for setting
approvals on both stETH and frxETH . There is no clear motivation as to why this number is
selected, and the contract lacks inline documentation to clarify its significance.
Consider defining and documenting a constant variable to represent this number, as it is used
in multiple places. Following Solidity's style guide, constants should be named in
UPPER_CASE_WITH_UNDERSCORES format.