### PR TITLE
L02 improve naming 

### DIFF
--- a/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
@@ -72,7 +72,7 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
         for (uint256 i = 0; i < assetsLength; ++i) {
             strategyAssets[i] = assetsMapped[i];
             // Get the asset balance in this strategy contract
-            strategyAmounts[i] = IERC20(assets[i]).balanceOf(address(this));
+            strategyAmounts[i] = IERC20(strategyAssets[i]).balanceOf(address(this));
         }
         _deposit(strategyAssets, strategyAmounts);
     }

--- a/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
@@ -65,16 +65,16 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
      */
     function depositAll() external override onlyVault nonReentrant {
         uint256 assetsLength = assetsMapped.length;
-        address[] memory assets = new address[](assetsLength);
-        uint256[] memory amounts = new uint256[](assetsLength);
+        address[] memory strategyAssets = new address[](assetsLength);
+        uint256[] memory strategyAmounts = new uint256[](assetsLength);
 
         // For each vault collateral asset
         for (uint256 i = 0; i < assetsLength; ++i) {
-            assets[i] = assetsMapped[i];
+            strategyAssets[i] = assetsMapped[i];
             // Get the asset balance in this strategy contract
-            amounts[i] = IERC20(assets[i]).balanceOf(address(this));
+            strategyAmounts[i] = IERC20(assets[i]).balanceOf(address(this));
         }
-        _deposit(assets, amounts);
+        _deposit(strategyAssets, strategyAmounts);
     }
 
     function _deposit(


### PR DESCRIPTION
**From audit report:**
Throughout the codebase, there are multiple variables named similarly but with vastly different

meanings, which makes it difficult for the reader to understand the context. A non-
comprehensive list of these is:

When depositing or withdrawing, _assets and _amounts could be changed to
_strategyAssets and _strategyAssetsAmounts .
mappedAmounts and mappedAssets could be changed to
strategyAssetsToPoolAssets and
strategyAssetsAmountsToPoolAssetsAmounts . mappedAssets is especially
confusing, as it is very similar to the strategy's assetsMapped , which has a completely
different function.
asset and amount could be changed to strategyAsset and
strategyAssetAmount .
wrappedAssetAmounts could be changed to
strategyAssetsAmountsToPoolAssetsAmounts .
vaultAsset could be changed to strategyAsset .
asset could be changed to strategyAsset , or something consistent with the
naming previously used.
assetAmount could be changed to poolAssetAmountToStrategyAssetAmount .
poolAmountsOut could be changed to poolAssetsAmountsOut .
In order to improve readability and better convey the code's intentions to the reader, consider
modifying variable names to be more aligned with the codebase, while using these suggestions
as potential guidelines.