### PR TITLE
L-04 Can Withdraw Unsupported Assets

### DIFF
--- a/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
@@ -197,6 +197,10 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
     ) internal {
         require(_assets.length == _amounts.length, "Invalid input arrays");
 
+        for (uint256 i = 0; i < _assets.length; ++i) {
+            require(assetToPToken[_assets] != address(0), "Unsupported asset");
+        }
+
         // STEP 1 - Calculate the max about of Balancer Pool Tokens (BPT) to withdraw
 
         // Estimate the required amount of Balancer Pool Tokens (BPT) for the assets


### PR DESCRIPTION
**From audit report:**
In the _deposit function, tokens are checked to ensure they are supported before being
deposited into Balancer pools. However, the _withdraw function lacks this check. If the
assets supported in the strategy are a subset of the tokens in the Balancer pool, it can result in
withdrawing an asset that is not supported by the strategy.
Consider only allowing callers to withdraw assets that are supported by the strategy.