### PR TITLE
N01 - unused files

### DIFF
--- a/contracts/contracts/interfaces/IERC20Details.sol
+++ b/contracts/contracts/interfaces/IERC20Details.sol
@@ -1,4 +1,0 @@
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
-
-import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";

--- a/contracts/contracts/strategies/balancer/BaseBalancerStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BaseBalancerStrategy.sol
@@ -12,7 +12,6 @@ import { IRateProvider } from "../../interfaces/balancer/IRateProvider.sol";
 import { VaultReentrancyLib } from "./VaultReentrancyLib.sol";
 import { IOracle } from "../../interfaces/IOracle.sol";
 import { IVault } from "../../interfaces/IVault.sol";
-import { IRETH } from "../../interfaces/IRETH.sol";
 import { IWstETH } from "../../interfaces/IWstETH.sol";
 import { IERC4626 } from "../../../lib/openzeppelin/interfaces/IERC4626.sol";
 import { StableMath } from "../../utils/StableMath.sol";


### PR DESCRIPTION
We are keeping the IERC20Details file as it is used by the fixtures

**From audit report:**
The IERC20Details and IRETH files are unused.