### PR TITLE
N03 - Todo comments

### DIFF
--- a/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
@@ -72,7 +72,9 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
         for (uint256 i = 0; i < assetsLength; ++i) {
             strategyAssets[i] = assetsMapped[i];
             // Get the asset balance in this strategy contract
-            strategyAmounts[i] = IERC20(strategyAssets[i]).balanceOf(address(this));
+            strategyAmounts[i] = IERC20(strategyAssets[i]).balanceOf(
+                address(this)
+            );
         }
         _deposit(strategyAssets, strategyAmounts);
     }
@@ -320,8 +322,9 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
         balancerVault.exitPool(
             balancerPoolId,
             address(this),
-            // TODO: this is incorrect and should be altered when/if we intend to support
-            // pools that deal with native ETH
+            /* Payable keyword is required because of the IBalancerVault interface even though
+             * this strategy shall never be receiving native ETH
+             */
             payable(address(this)),
             request
         );
@@ -418,8 +421,9 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
         balancerVault.exitPool(
             balancerPoolId,
             address(this),
-            // TODO: this is incorrect and should be altered when/if we intend to support
-            // pools that deal with native ETH
+            /* Payable keyword is required because of the IBalancerVault interface even though
+             * this strategy shall never be receiving native ETH
+             */
             payable(address(this)),
             request
         );


### PR DESCRIPTION
Replaced TODO comments with an explanation comment

**From audit report:**
The following instances of TODO comments were found in the codebase:
The TODO comment on line 296 in BalancerMetaPoolStrategy.sol
The TODO comment on line 380 in BalancerMetaPoolStrategy.sol
During development, having well-described TODO comments will facilitate the process of
tracking and solving them. Without this information these comments may age and important
information for the security of the system could be forgotten by the time it is released to
production.

Consider removing all instances of TODO comments and instead tracking them in the issues
backlog. Alternatively, consider linking each inline TODO to the corresponding issues backlog
entry.