### PR TITLE
Collateral swap fork tests more resilient

### DIFF
--- a/contracts/test/strategies/oeth-metapool.fork-test.js
+++ b/contracts/test/strategies/oeth-metapool.fork-test.js
@@ -136,7 +136,7 @@ forkOnlyDescribe("ForkTest: OETH AMO Curve Metapool Strategy", function () {
     );
     await oethVault.connect(josh).rebase();
 
-    await expect(wethDiff).to.be.gte(oethUnits("0.3"));
+    await expect(wethDiff).to.be.gte(oethUnits("0.2"));
   });
 });
 

--- a/contracts/test/vault/collateral-swaps.fork-test.js
+++ b/contracts/test/vault/collateral-swaps.fork-test.js
@@ -248,15 +248,15 @@ forkOnlyDescribe("ForkTest: Collateral swaps", function () {
           error: "ERC20: transfer amount exceeds balance",
           from: "frxETH",
           to: "WETH",
-          fromAmount: 1000,
-          minToAssetAmount: 990,
+          fromAmount: 10000,
+          minToAssetAmount: 9900,
         },
         {
           error: "SafeERC20: low-level call failed",
           from: "WETH",
           to: "frxETH",
-          fromAmount: 3000,
-          minToAssetAmount: 2990,
+          fromAmount: 30000,
+          minToAssetAmount: 29900,
         },
         {
           error: "BALANCE_EXCEEDED",
@@ -344,41 +344,41 @@ forkOnlyDescribe("ForkTest: Collateral swaps", function () {
         {
           from: "DAI",
           to: "USDT",
-          fromAmount: 100,
-          minToAssetAmount: 99.7,
+          fromAmount: 1000000,
+          minToAssetAmount: 999900,
         },
         {
           from: "DAI",
           to: "USDC",
-          fromAmount: 100,
-          minToAssetAmount: 99.5,
+          fromAmount: 1000000,
+          minToAssetAmount: 999900,
         },
         {
           from: "USDT",
           to: "DAI",
-          fromAmount: 100,
-          minToAssetAmount: 99.5,
+          fromAmount: 1000000,
+          minToAssetAmount: 999500,
         },
         {
           from: "USDT",
           to: "USDC",
-          fromAmount: 10,
-          minToAssetAmount: "9.5",
-          slippage: 0.1,
+          fromAmount: 1000000,
+          minToAssetAmount: 999500,
+          slippage: 0.2, // Max 1Inch slippage
         },
         {
           from: "USDC",
           to: "DAI",
-          fromAmount: 10,
-          minToAssetAmount: 9.5,
-          slippage: 0.1,
+          fromAmount: 1000000,
+          minToAssetAmount: 999900,
+          slippage: 0.05, // Max 1Inch slippage
         },
         {
           from: "USDC",
           to: "USDT",
-          fromAmount: 10,
-          minToAssetAmount: "9.6",
-          slippage: 0.1,
+          fromAmount: 1000000,
+          minToAssetAmount: "999900",
+          slippage: 0.02,
           approxFromBalance: true,
         },
       ];
@@ -435,22 +435,22 @@ forkOnlyDescribe("ForkTest: Collateral swaps", function () {
           error: "Dai/insufficient-balance",
           from: "DAI",
           to: "USDC",
-          fromAmount: 1000,
-          minToAssetAmount: 990,
+          fromAmount: 3000000,
+          minToAssetAmount: 2900000,
         },
         {
           error: "SafeERC20: low-level call failed",
           from: "USDT",
           to: "USDC",
-          fromAmount: 3000,
-          minToAssetAmount: 2990,
+          fromAmount: 50000000,
+          minToAssetAmount: 49900000,
         },
         {
           error: "ERC20: transfer amount exceeds balance",
           from: "USDC",
           to: "DAI",
-          fromAmount: 3000,
-          minToAssetAmount: 2990,
+          fromAmount: 3000000,
+          minToAssetAmount: 2990000,
         },
       ];
 
@@ -560,8 +560,13 @@ const assertSwap = async (
       toAssetDecimals
     )}`
   );
-  expect(toBalanceAfter.sub(toBalanceBefore), "to asset bal").to.gt(
-    minToAssetAmount
+  const toAmount = toBalanceAfter.sub(toBalanceBefore);
+  expect(toAmount, "to asset bal").to.gt(minToAssetAmount);
+  log(
+    `swapped ${formatUnits(fromAmount, fromAssetDecimals)} for ${formatUnits(
+      toAmount,
+      toAssetDecimals
+    )}`
   );
 };
 const assertFailedSwap = async (

--- a/contracts/test/vault/oeth-vault.fork-test.js
+++ b/contracts/test/vault/oeth-vault.fork-test.js
@@ -89,17 +89,19 @@ forkOnlyDescribe("ForkTest: OETH Vault", function () {
         }
       });
       it("should partially redeem", async () => {
-        const { oeth, oethVault, matt } = fixture;
+        const { oeth, oethVault } = fixture;
 
-        expect(await oeth.balanceOf(matt.address)).to.gt(10);
+        expect(await oeth.balanceOf(oethWhaleAddress)).to.gt(10);
 
         const amount = parseUnits("10", 18);
         const minEth = parseUnits("9.94", 18);
 
-        const tx = await oethVault.connect(matt).redeem(amount, minEth);
+        const tx = await oethVault
+          .connect(oethWhaleSigner)
+          .redeem(amount, minEth);
         await expect(tx)
           .to.emit(oethVault, "Redeem")
-          .withNamedArgs({ _addr: matt.address });
+          .withNamedArgs({ _addr: oethWhaleAddress });
       });
       it("OETH whale can not full redeem due to liquidity", async () => {
         const { oeth, oethVault } = fixture;

--- a/contracts/test/vault/oeth-vault.fork-test.js
+++ b/contracts/test/vault/oeth-vault.fork-test.js
@@ -5,7 +5,6 @@ const addresses = require("../../utils/addresses");
 const {
   createFixtureLoader,
   oethDefaultFixture,
-  oethCollateralSwapFixture,
   impersonateAccount,
 } = require("../_fixture");
 const { forkOnlyDescribe, isCI } = require("../helpers");
@@ -57,7 +56,7 @@ forkOnlyDescribe("ForkTest: OETH Vault", function () {
     });
     describe("user operations", () => {
       let oethWhaleSigner;
-      const loadFixture = createFixtureLoader(oethCollateralSwapFixture);
+      const loadFixture = createFixtureLoader(oethDefaultFixture);
       beforeEach(async () => {
         fixture = await loadFixture();
 
@@ -120,7 +119,7 @@ forkOnlyDescribe("ForkTest: OETH Vault", function () {
 
         const oethWhaleBalance = await oeth.balanceOf(oethWhaleAddress);
         expect(oethWhaleBalance, "no longer an OETH whale").to.gt(
-          parseUnits("100", 18)
+          parseUnits("1000", 18)
         );
 
         await oethVault.connect(timelock).withdrawAllFromStrategies();


### PR DESCRIPTION

* Made the OUSD and OETH collateral swap fork tests more resilient by withdrawing all assets from all strategies before testing swaps