### PR TITLE
N05 array length

### DIFF
--- a/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
@@ -93,10 +93,10 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
         );
 
         uint256[] memory strategyAssetAmountsToPoolAssetAmounts = new uint256[](
-            tokens.length
+            _strategyAssets.length
         );
         address[] memory strategyAssetsToPoolAssets = new address[](
-            tokens.length
+            _strategyAssets.length
         );
 
         for (uint256 i = 0; i < _strategyAssets.length; ++i) {


### PR DESCRIPTION
**From audit report:** 
In the _deposit function, the length of mappedAmounts and mappedAssets is initialized
to tokens.length . This is superfluous if only a subset of the Balancer pool's tokens are
supported by the strategy.
While this currently does not present a security risk, consider initializing the array to the correct
length.