### PR TITLE
fix: show error `reason` or `message` in bottom `SwapCurrencyPill`

### DIFF
--- a/dapp-oeth/src/components/buySell/SwapCurrencyPill.js
+++ b/dapp-oeth/src/components/buySell/SwapCurrencyPill.js
@@ -478,6 +478,7 @@ const SwapCurrencyPill = ({
   selectedCoin,
   selectedSwap,
   swapsLoading,
+  swapsError,
   priceToleranceValue,
   swapMode,
   onErrorChange,
@@ -667,13 +668,17 @@ const SwapCurrencyPill = ({
                   <span className="text-loading">
                     {fbt('Loading...', 'Swaps Loading...')}
                   </span>
+                ) : swapsError ? (
+                  <span className="text-error">{'Error'}</span>
                 ) : (
                   <span>{expectedAmount || '0.00'}</span>
                 )}
               </div>
             )}
             <div className="usd-balance mt-auto">
-              {bottomItem
+              {swapsError
+                ? swapsError
+                : bottomItem
                 ? `$${formatCurrency(
                     truncateDecimals(expectedAmount, 18) * usdPrice,
                     2

--- a/dapp-oeth/src/components/buySell/SwapHomepage.js
+++ b/dapp-oeth/src/components/buySell/SwapHomepage.js
@@ -29,6 +29,10 @@ const SwapHomepage = ({
   isMobile,
 }) => {
   const swapEstimations = useStoreState(ContractStore, (s) => s.swapEstimations)
+  const swapEstimationsError = useStoreState(
+    ContractStore,
+    (s) => s.swapEstimationsError
+  )
   const swapsLoaded = swapEstimations && typeof swapEstimations === 'object'
   const selectedSwap = useStoreState(ContractStore, (s) => s.selectedSwap)
   const { data: prices } = useTokenPrices()
@@ -347,6 +351,7 @@ const SwapHomepage = ({
                 swapMode={swapMode}
                 selectedSwap={selectedSwap}
                 swapsLoading={swapEstimations === 'loading'}
+                swapsError={swapEstimations === 'error' && swapEstimationsError}
                 priceToleranceValue={priceToleranceValue}
                 selectedCoin={selectedRedeemCoin}
                 onSelectChange={userSelectsRedeemCoin}

--- a/dapp-oeth/src/stores/ContractStore.js
+++ b/dapp-oeth/src/stores/ContractStore.js
@@ -25,6 +25,7 @@ const ContractStore = new Store({
   },
   // 'null' -> default zero state, 'loading' -> loading the estimates
   swapEstimations: null,
+  swapEstimationsError: null,
   selectedSwap: undefined,
   coinInfoList: {
     eth: {


### PR DESCRIPTION
Proposal to fix the stuck on 'Loading...' issue by showing the error seen in the calculation instead.

![Screenshot 2023-09-07 at 1 47 19 PM](https://github.com/OriginProtocol/origin-dollar/assets/564815/b61e7c38-fa31-4509-8201-f2c68d479ab3)
