### PR TITLE
Hardhat light cache clean

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -31,6 +31,7 @@
     "slither": "yarn run clean && slither . --filter-paths \"crytic|mocks|openzeppelin|@openzeppelin\" --exclude-low --exclude-informational --exclude conformance-to-solidity-naming-conventions,different-pragma-directives-are-used,external-function,assembly,incorrect-equality",
     "slither:triage": "yarn run clean && slither . --triage --filter-paths \"crytic|mocks|openzeppelin|@openzeppelin\" --exclude-low --exclude-informational --exclude conformance-to-solidity-naming-conventions,different-pragma-directives-are-used,external-function,assembly,incorrect-equality",
     "clean": "rm -rf build crytic-export artifacts cache deployments/local*",
+    "cache-clean:light": "rm -rf cache/hardhat-network-fork/network-1337/*",
     "test:coverage": "IS_TEST=true npx hardhat coverage",
     "test:coverage:fork": "REPORT_COVERAGE=true ./fork-test.sh"
   },


### PR DESCRIPTION
We've been having issues with hardhat ignoring solidity contract code changes between runs. I've narrowed it down to not being an issue with the compiler, rather the 1337 hardhat network that gets created contains cached calls that somehow interfere with the freshly compiled contract changes. 

Run the node by pretending it with `yarn run cache-clean:light` to fix the issue. Or in 1 command: 
`yarn run cache-clean:light && yarn run node`

I've measured the speed impact of running node with and without cleaning the cache and it is almost not noticeable. 