### PR TITLE
Fix bug in set reward token

### DIFF
--- a/contracts/contracts/utils/InitializableAbstractStrategy.sol
+++ b/contracts/contracts/utils/InitializableAbstractStrategy.sol
@@ -193,7 +193,7 @@ abstract contract InitializableAbstractStrategy is Initializable, Governable {
         external
         onlyGovernor
     {
-        uint256 rewardTokenCount = rewardTokenAddresses.length;
+        uint256 rewardTokenCount = _rewardTokenAddresses.length;
         for (uint256 i = 0; i < rewardTokenCount; ++i) {
             require(
                 _rewardTokenAddresses[i] != address(0),

--- a/contracts/test/strategies/compound.js
+++ b/contracts/test/strategies/compound.js
@@ -142,6 +142,30 @@ describe("Compound strategy", function () {
     );
   });
 
+  it("Should block Governor from adding more reward token address with zero address", async () => {
+    const { cStandalone, governor } = fixture;
+
+    await expect(
+      cStandalone
+        .connect(governor)
+        .setRewardTokenAddresses([
+          cStandalone.address,
+          "0x0000000000000000000000000000000000000000",
+        ])
+    ).to.be.revertedWith("Can not set an empty address as a reward token");
+  });
+
+  it("Should allow Governor to remove reward token addresses", async () => {
+    const { cStandalone, governor, comp } = fixture;
+
+    // Add so we can remove
+    await cStandalone
+      .connect(governor)
+      .setRewardTokenAddresses([cStandalone.address, comp.address]);
+    // Remove all
+    await cStandalone.connect(governor).setRewardTokenAddresses([]);
+  });
+
   it("Should not allow non-Governor to set reward token address", async () => {
     const { cStandalone, anna } = fixture;
     await expect(


### PR DESCRIPTION
Fixed the bug in setRewardTokenAddresses that would either crash if the new array was smaller, or skipping validation if the new arrays was larger.

Closes #1834

----

If you made a contract change, make sure to complete the checklist below before merging it in master.

Refer to our [documentation](https://github.com/OriginProtocol/security) for more details about contract security best practices.

Contract change checklist:
  - [ ] Code reviewed by 2 reviewers. 
  - [ ] Copy & paste code review [security checklist](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md) below this checklist.
  - [ ] Unit tests pass
  - [ ] Slither tests pass with no warning
  - [ ] Echidna tests pass if PR includes changes to OUSD contract (not automated, run manually on local)
