### PR TITLE
Allow for withdrawAll on empty strategy

### DIFF
--- a/contracts/contracts/strategies/Generalized4626Strategy.sol
+++ b/contracts/contracts/strategies/Generalized4626Strategy.sol
@@ -129,11 +129,14 @@ contract Generalized4626Strategy is InitializableAbstractStrategy {
         nonReentrant
     {
         uint256 shareBalance = shareToken.balanceOf(address(this));
-        uint256 assetAmount = IERC4626(platformAddress).redeem(
-            shareBalance,
-            vaultAddress,
-            address(this)
-        );
+        uint256 assetAmount = 0;
+        if (shareBalance > 0) {
+            assetAmount = IERC4626(platformAddress).redeem(
+                shareBalance,
+                vaultAddress,
+                address(this)
+            );
+        }
         emit Withdrawal(address(assetToken), address(shareToken), assetAmount);
     }
 

--- a/contracts/test/strategies/fraxeth.fork-test.js
+++ b/contracts/test/strategies/fraxeth.fork-test.js
@@ -96,6 +96,31 @@ forkOnlyDescribe("ForkTest: FraxETH Strategy", function () {
           .withdraw(weth.address, weth.address, oethUnits("12"))
       ).to.be.revertedWith("Unexpected asset address");
     });
+    it("Should allow withdrawAll twice", async () => {
+      const { oethVault, fraxEthStrategy } = fixture;
+      const fakeVaultSigner = await impersonateAndFundContract(
+        oethVault.address
+      );
+
+      // Do a withdrawAll with impersonated Vault
+      await fraxEthStrategy.connect(fakeVaultSigner).withdrawAll();
+
+      // Do a second withdrawAll, both should work.
+      await fraxEthStrategy.connect(fakeVaultSigner).withdrawAll();
+    });
+
+    it("Should not allow withdrawing WETH", async () => {
+      const { oethVault, fraxEthStrategy, weth } = fixture;
+      const fakeVaultSigner = await impersonateAndFundContract(
+        oethVault.address
+      );
+
+      await expect(
+        fraxEthStrategy
+          .connect(fakeVaultSigner)
+          .withdraw(weth.address, weth.address, oethUnits("12"))
+      ).to.be.revertedWith("Unexpected asset address");
+    });
   });
 
   describe("Balance/Assets", function () {


### PR DESCRIPTION
Allow our 4626 based strategies to call withdrawAll() successfully, even if there are no funds currently in the strategy.

The deploy params for the the FraxStrategy have changed, so please make sure the deploy code is correct.

Closes #1813

----

Refer to our [documentation](https://github.com/OriginProtocol/security) for more details about contract security best practices.

Contract change checklist:
  - [ ] Code reviewed by 2 reviewers. 
  - [ ] Copy & paste code review [security checklist](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review-Example.md) below this checklist.
  - [ ] Unit tests pass
  - [ ] Slither tests pass with no warning
  - [ ] Echidna tests pass if PR includes changes to OUSD contract (not automated, run manually on local)
