### PR TITLE
Fix FraxETH strategy tests

### DIFF
--- a/contracts/contracts/mocks/MocksfrxETH.sol
+++ b/contracts/contracts/mocks/MocksfrxETH.sol
@@ -5,8 +5,6 @@ import "./MintableERC20.sol";
 
 contract MocksfrxETH is MintableERC20 {
     address public frxETH;
-    address public sfrxETH;
-    mapping(address => uint256) public assetBalance;
 
     constructor(address _frxETH) ERC20("sfrxETH", "sfrxETH") {
         frxETH = _frxETH;
@@ -22,19 +20,24 @@ contract MocksfrxETH is MintableERC20 {
     {
         ERC20(frxETH).transferFrom(msg.sender, address(this), assets);
 
-        assetBalance[receiver] += assets;
+        _mint(receiver, assets);
 
         return assets;
     }
 
     function maxWithdraw(address owner) external view returns (uint256) {
-        return assetBalance[owner];
+        return balanceOf(owner);
     }
 
     function setMaxWithdrawableBalance(address owner, uint256 balance)
         external
     {
-        assetBalance[owner] = balance;
+        uint256 currentBalance = balanceOf(owner);
+        if (currentBalance > balance) {
+            _burn(owner, currentBalance - balance);
+        } else if (balance > currentBalance) {
+            _mint(owner, balance - currentBalance);
+        }
     }
 
     function redeem(
@@ -42,7 +45,7 @@ contract MocksfrxETH is MintableERC20 {
         address receiver,
         address owner
     ) external returns (uint256 assets) {
-        assetBalance[owner] -= shares;
+        _burn(owner, shares);
 
         ERC20(frxETH).transfer(receiver, shares);
 
@@ -54,7 +57,7 @@ contract MocksfrxETH is MintableERC20 {
         address receiver,
         address owner
     ) external returns (uint256 shares) {
-        assetBalance[owner] -= shares;
+        _burn(owner, shares);
 
         ERC20(frxETH).transfer(receiver, shares);
 
@@ -66,8 +69,7 @@ contract MocksfrxETH is MintableERC20 {
         payable
         returns (uint256 shares)
     {
-        assetBalance[recipient] += msg.value;
-
+        _mint(recipient, msg.value);
         shares = msg.value;
     }
 }

--- a/contracts/contracts/proxies/InitializeGovernedUpgradeabilityProxy.sol
+++ b/contracts/contracts/proxies/InitializeGovernedUpgradeabilityProxy.sol
@@ -81,10 +81,11 @@ contract InitializeGovernedUpgradeabilityProxy is Governable {
      * It should include the signature and the parameters of the function to be called, as described in
      * https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#function-selector-and-argument-encoding.
      */
-    function upgradeToAndCall(
-        address newImplementation,
-        bytes calldata data
-    ) external payable onlyGovernor {
+    function upgradeToAndCall(address newImplementation, bytes calldata data)
+        external
+        payable
+        onlyGovernor
+    {
         _upgradeTo(newImplementation);
         (bool success, ) = newImplementation.delegatecall(data);
         require(success);

--- a/contracts/deploy/000_mock.js
+++ b/contracts/deploy/000_mock.js
@@ -1,6 +1,9 @@
 const { parseUnits } = require("ethers").utils;
 const { isMainnetOrFork } = require("../test/helpers");
 const { threeCRVPid } = require("../utils/constants");
+const { replaceContractAt } = require("../utils/deploy");
+
+const addresses = require("../utils/addresses");
 
 const {
   abi: FACTORY_ABI,
@@ -104,6 +107,11 @@ const deployMocks = async ({ getNamedAccounts, deployments }) => {
   const dai = await ethers.getContract("MockDAI");
   const usdc = await ethers.getContract("MockUSDC");
   const usdt = await ethers.getContract("MockUSDT");
+
+  // Replace WETH
+  const mockWETH = await ethers.getContract("MockWETH");
+  await replaceContractAt(addresses.mainnet.WETH, mockWETH);
+  const weth = await ethers.getContractAt("MockWETH", addresses.mainnet.WETH);
 
   // Deploy mock aTokens (Aave)
   // MockAave is the mock lendingPool
@@ -320,7 +328,6 @@ const deployMocks = async ({ getNamedAccounts, deployments }) => {
     },
   });
 
-  const weth = await ethers.getContract("MockWETH");
   await deploy("MockUniswapV3Router", {
     from: deployerAddr,
     contract: {

--- a/contracts/test/_fixture.js
+++ b/contracts/test/_fixture.js
@@ -6,6 +6,7 @@ const { formatUnits } = require("ethers/lib/utils");
 
 const addresses = require("../utils/addresses");
 const { setFraxOraclePrice } = require("../utils/frax");
+const { replaceContractAt } = require("../utils/deploy");
 const {
   balancer_rETH_WETH_PID,
   balancer_stETH_WETH_PID,
@@ -380,7 +381,7 @@ const defaultFixture = deployments.createFixture(async () => {
     dai = await ethers.getContract("MockDAI");
     tusd = await ethers.getContract("MockTUSD");
     usdc = await ethers.getContract("MockUSDC");
-    weth = await ethers.getContract("MockWETH");
+    weth = await ethers.getContractAt("MockWETH", addresses.mainnet.WETH);
     ogn = await ethers.getContract("MockOGN");
     LUSD = await ethers.getContract("MockLUSD");
     ogv = await ethers.getContract("MockOGV");
@@ -653,7 +654,7 @@ async function oethDefaultFixture() {
   const fixture = await defaultFixture();
 
   const { weth, reth, stETH, frxETH, sfrxETH } = fixture;
-  const { matt, josh, domen, daniel, franck, governor, oethVault } = fixture;
+  const { matt, josh, domen, daniel, franck, oethVault } = fixture;
 
   if (isFork) {
     for (const user of [matt, josh, domen, daniel, franck]) {
@@ -675,27 +676,15 @@ async function oethDefaultFixture() {
     );
     await mockedMinter.connect(franck).setAssetAddress(fixture.sfrxETH.address);
 
-    // Replace WETH contract with MockWETH
-    const mockWETH = await ethers.getContract("MockWETH");
-    await replaceContractAt(addresses.mainnet.WETH, mockWETH);
-    const stubbedWETH = await ethers.getContractAt(
-      "MockWETH",
-      addresses.mainnet.WETH
-    );
-    fixture.weth = stubbedWETH;
-
-    // And Fund it
-    _hardhatSetBalance(stubbedWETH.address, "999999999999999");
-
-    // And make sure vault knows about it
-    await oethVault.connect(governor).supportAsset(addresses.mainnet.WETH, 0);
+    // Fund WETH contract
+    _hardhatSetBalance(weth.address, "999999999999999");
 
     // Fund all with mockTokens
     await fundAccountsForOETHUnitTests();
 
     // Reset allowances
     for (const user of [matt, josh, domen, daniel, franck]) {
-      for (const asset of [stubbedWETH, reth, stETH, frxETH, sfrxETH]) {
+      for (const asset of [weth, reth, stETH, frxETH, sfrxETH]) {
         await resetAllowance(asset, user, oethVault.address);
       }
     }
@@ -2117,16 +2106,6 @@ async function fluxStrategyFixture() {
   return fixture;
 }
 
-async function replaceContractAt(targetAddress, mockContract) {
-  const signer = (await hre.ethers.getSigners())[0];
-  const mockCode = await signer.provider.getCode(mockContract.address);
-
-  await hre.network.provider.request({
-    method: "hardhat_setCode",
-    params: [targetAddress, mockCode],
-  });
-}
-
 /**
  * A fixture is a setup function that is run only the first time it's invoked. On subsequent invocations,
  * Hardhat will reset the state of the network to what it was at the point after the fixture was initially executed.
@@ -2200,7 +2179,6 @@ module.exports = {
   fraxETHStrategyFixture,
   oethMorphoAaveFixture,
   mintWETH,
-  replaceContractAt,
   oeth1InchSwapperFixture,
   oethCollateralSwapFixture,
   ousdCollateralSwapFixture,

--- a/contracts/test/helpers.js
+++ b/contracts/test/helpers.js
@@ -433,7 +433,7 @@ const getAssetAddresses = async (deployments) => {
       cUSDC: (await deployments.get("MockCUSDC")).address,
       cUSDT: (await deployments.get("MockCUSDT")).address,
       NonStandardToken: (await deployments.get("MockNonStandardToken")).address,
-      WETH: (await deployments.get("MockWETH")).address,
+      WETH: addresses.mainnet.WETH,
       COMP: (await deployments.get("MockCOMP")).address,
       ThreePool: (await deployments.get("MockCurvePool")).address,
       ThreePoolToken: (await deployments.get("Mock3CRV")).address,

--- a/contracts/test/strategies/fraxeth.fork-test.js
+++ b/contracts/test/strategies/fraxeth.fork-test.js
@@ -96,7 +96,8 @@ forkOnlyDescribe("ForkTest: FraxETH Strategy", function () {
           .withdraw(weth.address, weth.address, oethUnits("12"))
       ).to.be.revertedWith("Unexpected asset address");
     });
-    it("Should allow withdrawAll twice", async () => {
+    // TODO: Reenable this after FraxETH strategy has been upgraded
+    it.skip("Should allow withdrawAll twice", async () => {
       const { oethVault, fraxEthStrategy } = fixture;
       const fakeVaultSigner = await impersonateAndFundContract(
         oethVault.address

--- a/contracts/test/strategies/fraxeth.js
+++ b/contracts/test/strategies/fraxeth.js
@@ -1,6 +1,6 @@
 const { expect } = require("chai");
 
-const { oethUnits, units } = require("../helpers");
+const { oethUnits, units, ethUnits } = require("../helpers");
 
 const {
   createFixtureLoader,
@@ -57,9 +57,6 @@ describe("FraxETH Strategy", function () {
       const assets = [frxETH, weth, reth, stETH];
       const mintAmounts = ["10.2333", "20.45", "23.456", "15.3434"];
 
-      // Just assuming a 1:1 for all assets for simplicity of tests
-      await reth.connect(daniel).setExchangeRate(oethUnits("1"));
-
       // Rebase & Allocate
       await oethVault.connect(daniel).rebase();
       await oethVault.connect(daniel).allocate();
@@ -70,10 +67,6 @@ describe("FraxETH Strategy", function () {
           .connect(users[i])
           .mint(assets[i].address, oethUnits(mintAmounts[i]), "0");
       }
-
-      // Rebase & Allocate
-      await oethVault.connect(daniel).rebase();
-      await oethVault.connect(daniel).allocate();
 
       // Now try redeeming
       const supplyBeforeRedeem = await oeth.totalSupply();
@@ -107,8 +100,12 @@ describe("FraxETH Strategy", function () {
       // User should have got other assets
       let netGainedAssetValue = BigNumber.from(0);
       for (let i = 0; i < assets.length; i++) {
+        const redeemPrice = await oethVault.priceUnitRedeem(assets[i].address);
         netGainedAssetValue = netGainedAssetValue.add(
-          userAssetBalanceAfterRedeem[i].sub(userAssetBalanceBeforeRedeem[i])
+          userAssetBalanceAfterRedeem[i]
+            .sub(userAssetBalanceBeforeRedeem[i])
+            .mul(redeemPrice)
+            .div(ethUnits("1"))
         );
       }
       expect(netGainedAssetValue).to.approxEqualTolerance(

--- a/contracts/test/strategies/fraxeth.js
+++ b/contracts/test/strategies/fraxeth.js
@@ -39,8 +39,7 @@ describe("FraxETH Strategy", function () {
   });
 
   describe("Redeem", function () {
-    // TODO: Debug and fix this test
-    it.skip("Should allow redeem", async () => {
+    it("Should allow redeem", async () => {
       const {
         daniel,
         domen,

--- a/contracts/test/vault/oneinch-swapper.js
+++ b/contracts/test/vault/oneinch-swapper.js
@@ -635,8 +635,6 @@ describe("1Inch Swapper", () => {
         .connect(strategist)
         .mintTo(mock1InchSwapRouter.address, toAmount.mul(2));
 
-      await swapper1Inch.approveAssets([weth.address]);
-
       const tx = swapper1Inch
         .connect(strategist)
         .swap(weth.address, frxETH.address, fromAmount, toAmount, data);
@@ -689,8 +687,6 @@ describe("1Inch Swapper", () => {
       await frxETH
         .connect(strategist)
         .mintTo(swapper1Inch.address, toAmount.mul(2));
-
-      await swapper1Inch.approveAssets([weth.address]);
 
       const tx = swapper1Inch
         .connect(strategist)

--- a/contracts/utils/deploy.js
+++ b/contracts/utils/deploy.js
@@ -1248,6 +1248,16 @@ function deploymentWithGuardianGovernor(opts, fn) {
   return main;
 }
 
+async function replaceContractAt(targetAddress, mockContract) {
+  const signer = (await hre.ethers.getSigners())[0];
+  const mockCode = await signer.provider.getCode(mockContract.address);
+
+  await hre.network.provider.request({
+    method: "hardhat_setCode",
+    params: [targetAddress, mockCode],
+  });
+}
+
 module.exports = {
   log,
   sleep,
@@ -1261,4 +1271,5 @@ module.exports = {
   deploymentWithProposal,
   deploymentWithGovernanceProposal,
   deploymentWithGuardianGovernor,
+  replaceContractAt,
 };


### PR DESCRIPTION
- Only changes Mock contract to fix the unit tests
- Skips one fork tests added in #1838 (since the contract hasn't been upgraded on mainnet yet)
- Moves replacement of WETH strategy for unit tests to mock deployments instead of doing it in fixtures