### PR TITLE
Hot deploy & Balancer rate provider fix

### DIFF
--- a/contracts/contracts/mocks/BalancerComposablePoolTestStrategy.sol
+++ b/contracts/contracts/mocks/BalancerComposablePoolTestStrategy.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title OETH Balancer BalancerComposablePoolTest Strategy
+ * This one is required to expose internal functions to our test suite. In fixtures
+ * we replace the mainnet byte code with the one from this contract.
+ *
+ * @author Origin Protocol Inc
+ */
+import { BalancerComposablePoolStrategy } from "../strategies/balancer/BalancerComposablePoolStrategy.sol";
+
+contract BalancerComposablePoolTestStrategy is BalancerComposablePoolStrategy {
+    constructor(
+        BaseStrategyConfig memory _stratConfig,
+        BaseBalancerConfig memory _balancerConfig,
+        BaseMetaPoolConfig memory _metapoolConfig,
+        address _auraRewardPoolAddress
+    )
+        BalancerComposablePoolStrategy(
+            _stratConfig,
+            _balancerConfig,
+            _metapoolConfig,
+            _auraRewardPoolAddress
+        )
+    {}
+
+    function getRateProviderRate(address _asset)
+        external
+        view
+        returns (uint256)
+    {
+        return _getRateProviderRate(_asset);
+    }
+}

--- a/contracts/contracts/mocks/BalancerMetaPoolTestStrategy.sol
+++ b/contracts/contracts/mocks/BalancerMetaPoolTestStrategy.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title OETH Balancer BalancerMetaPoolTest Strategy
+ * This one is required to expose internal functions to our test suite. In fixtures
+ * we replace the mainnet byte code with the one from this contract.
+ *
+ * @author Origin Protocol Inc
+ */
+import { BalancerMetaPoolStrategy } from "../strategies/balancer/BalancerMetaPoolStrategy.sol";
+
+contract BalancerMetaPoolTestStrategy is BalancerMetaPoolStrategy {
+    constructor(
+        BaseStrategyConfig memory _stratConfig,
+        BaseBalancerConfig memory _balancerConfig,
+        BaseMetaPoolConfig memory _metapoolConfig,
+        address _auraRewardPoolAddress
+    )
+        BalancerMetaPoolStrategy(
+            _stratConfig,
+            _balancerConfig,
+            _metapoolConfig,
+            _auraRewardPoolAddress
+        )
+    {}
+
+    function getRateProviderRate(address _asset)
+        external
+        view
+        returns (uint256)
+    {
+        return _getRateProviderRate(_asset);
+    }
+}

--- a/contracts/test/fixture/_fixture.js
+++ b/contracts/test/fixture/_fixture.js
@@ -1652,7 +1652,10 @@ async function resetAllowance(
 }
 
 async function mintWETH(weth, recipient, amount = "100") {
-  await _hardhatSetBalance(recipient.address || recipient._address, (Number(amount) * 2).toString());
+  await _hardhatSetBalance(
+    recipient.address || recipient._address,
+    (Number(amount) * 2).toString()
+  );
   await weth.connect(recipient).deposit({
     value: parseEther(amount),
   });

--- a/contracts/test/fixture/_fixture.js
+++ b/contracts/test/fixture/_fixture.js
@@ -8,7 +8,10 @@ const addresses = require("../../utils/addresses");
 const { setFraxOraclePrice } = require("../../utils/frax");
 require("./_global-hooks");
 
-const { hotDeployBalancerRethWETHStrategy } = require("./_hot-deploy");
+const {
+  hotDeployBalancerRethWETHStrategy,
+  hotDeployBalancerFrxEethRethWstEThStrategy,
+} = require("./_hot-deploy");
 const { replaceContractAt } = require("../../utils/deploy");
 const {
   balancer_rETH_WETH_PID,
@@ -975,8 +978,8 @@ async function balancerFrxETHwstETHeETHFixture(
   const {
     oethVault,
     timelock,
-    frxEth,
-    stEth,
+    frxETH,
+    stETH,
     reth,
     balancerSfrxWstRETHStrategy,
     josh,
@@ -992,13 +995,13 @@ async function balancerFrxETHwstETHeETHFixture(
     await oethVault
       .connect(timelock)
       .setAssetDefaultStrategy(
-        stEth.address,
+        stETH.address,
         balancerSfrxWstRETHStrategy.address
       );
     await oethVault
       .connect(timelock)
       .setAssetDefaultStrategy(
-        frxEth.address,
+        frxETH.address,
         balancerSfrxWstRETHStrategy.address
       );
   }
@@ -1081,6 +1084,18 @@ async function balancerRethWETHExposeFunctionFixture() {
   await balancerREthStrategy.connect(josh).cachePoolAssets();
   // IMPORTANT also remove this one
   await balancerREthStrategy.connect(josh).cacheRateProviders();
+
+  return fixture;
+}
+
+/**
+ * Configure a Vault with the Balancer strategy for frxEth/Reth/wstEth pool and
+ * replace the byte code with the one that exposes internal functions
+ */
+async function balancerSfrxETHRETHWstETHExposeFunctionFixture() {
+  const fixture = await hotDeployBalancerFrxEethRethWstEThStrategy(
+    balancerFrxETHwstETHeETHFixture
+  );
 
   return fixture;
 }
@@ -2180,6 +2195,7 @@ module.exports = {
   oethCollateralSwapFixture,
   ousdCollateralSwapFixture,
   balancerRethWETHExposeFunctionFixture,
+  balancerSfrxETHRETHWstETHExposeFunctionFixture,
   fluxStrategyFixture,
   mineBlocks,
   nodeSnapshot,

--- a/contracts/test/fixture/_fixture.js
+++ b/contracts/test/fixture/_fixture.js
@@ -1652,7 +1652,7 @@ async function resetAllowance(
 }
 
 async function mintWETH(weth, recipient, amount = "100") {
-  await _hardhatSetBalance(recipient.address, (Number(amount) * 2).toString());
+  await _hardhatSetBalance(recipient.address || recipient._address, (Number(amount) * 2).toString());
   await weth.connect(recipient).deposit({
     value: parseEther(amount),
   });

--- a/contracts/test/fixture/_fixture.js
+++ b/contracts/test/fixture/_fixture.js
@@ -8,6 +8,7 @@ const addresses = require("../../utils/addresses");
 const { setFraxOraclePrice } = require("../../utils/frax");
 require("./_global-hooks");
 
+const { hotDeployBalancerRethWETHStrategy } = require("./_hot-deploy");
 const { replaceContractAt } = require("../../utils/deploy");
 const {
   balancer_rETH_WETH_PID,
@@ -1064,6 +1065,22 @@ async function balancerFrxETHwstETHeETHFixture(
     josh.getAddress(),
     60 // use 60% of the account balances
   );
+
+  return fixture;
+}
+
+/**
+ * Configure a Vault with the Balancer strategy for rETH/WETH pool and
+ * replace the byte code with the one that exposes internal functions
+ */
+async function balancerRethWETHExposeFunctionFixture() {
+  const fixture = await hotDeployBalancerRethWETHStrategy(balancerREthFixture);
+  const { balancerREthStrategy, josh } = fixture;
+
+  // IMPORTANT: remove once rETH/WETH is redeployed with the new code base
+  await balancerREthStrategy.connect(josh).cachePoolAssets();
+  // IMPORTANT also remove this one
+  await balancerREthStrategy.connect(josh).cacheRateProviders();
 
   return fixture;
 }
@@ -2162,6 +2179,7 @@ module.exports = {
   oeth1InchSwapperFixture,
   oethCollateralSwapFixture,
   ousdCollateralSwapFixture,
+  balancerRethWETHExposeFunctionFixture,
   fluxStrategyFixture,
   mineBlocks,
   nodeSnapshot,

--- a/contracts/test/fixture/_hot-deploy.js
+++ b/contracts/test/fixture/_hot-deploy.js
@@ -11,6 +11,13 @@ const {
 const { ethers } = hre;
 
 async function hotDeployBalancerRethWETHStrategy(balancerREthFixture) {
+  /* Because of the way hardhat fixture caching works it is vital that
+   * the fixtures are loaded before the hot-deployment of contracts. If the
+   * contracts are hot-deployed and fixture load happens afterwards the deployed
+   * contract is not visible in deployments.
+   */
+  const fixture = await balancerREthFixture();
+  const { balancerREthStrategy } = fixture;
   const { deploy } = deployments;
 
   // deploy this contract that exposes internal function
@@ -33,9 +40,6 @@ async function hotDeployBalancerRethWETHStrategy(balancerREthFixture) {
     ],
   });
 
-  const fixture = await balancerREthFixture();
-  const { balancerREthStrategy } = fixture;
-
   await replaceContractAt(
     balancerREthStrategy.address,
     await ethers.getContract("BalancerMetaPoolTestStrategy")
@@ -54,6 +58,13 @@ async function hotDeployBalancerRethWETHStrategy(balancerREthFixture) {
 async function hotDeployBalancerFrxEethRethWstEThStrategy(
   balancerFrxETHwstETHeETHFixture
 ) {
+  /* Because of the way hardhat fixture caching works it is vital that
+   * the fixtures are loaded before the hot-deployment of contracts. If the
+   * contracts are hot-deployed and fixture load happens afterwards the deployed
+   * contract is not visible in deployments.
+   */
+  const fixture = await balancerFrxETHwstETHeETHFixture();
+  const { balancerSfrxWstRETHStrategy } = fixture;
   const { deploy } = deployments;
 
   // deploy this contract that exposes internal function
@@ -81,9 +92,6 @@ async function hotDeployBalancerFrxEethRethWstEThStrategy(
       addresses.mainnet.wstETH_sfrxETH_rETH_AuraRewards, // Address of the Aura rewards contract
     ],
   });
-
-  const fixture = await balancerFrxETHwstETHeETHFixture();
-  const { balancerSfrxWstRETHStrategy } = fixture;
 
   await replaceContractAt(
     balancerSfrxWstRETHStrategy.address,

--- a/contracts/test/fixture/_hot-deploy.js
+++ b/contracts/test/fixture/_hot-deploy.js
@@ -34,7 +34,7 @@ async function hotDeployBalancerRethWETHStrategy(balancerREthFixture) {
   });
 
   const fixture = await balancerREthFixture();
-  const { balancerREthStrategy, josh } = fixture;
+  const { balancerREthStrategy } = fixture;
 
   await replaceContractAt(
     balancerREthStrategy.address,
@@ -83,7 +83,7 @@ async function hotDeployBalancerFrxEethRethWstEThStrategy(
   });
 
   const fixture = await balancerFrxETHwstETHeETHFixture();
-  const { balancerSfrxWstRETHStrategy, josh } = fixture;
+  const { balancerSfrxWstRETHStrategy } = fixture;
 
   await replaceContractAt(
     balancerSfrxWstRETHStrategy.address,

--- a/contracts/test/fixture/_hot-deploy.js
+++ b/contracts/test/fixture/_hot-deploy.js
@@ -1,0 +1,53 @@
+/* This file contains functions that hot deploy a contract or a set of contracts. Should/can be
+ * used for fork-contract development process where the standalone (separate terminal) node
+ * doesn't need to be restarted to pick up code and ABI changes.
+ */
+const { replaceContractAt } = require("../../utils/deploy");
+const addresses = require("../../utils/addresses");
+const { balancer_rETH_WETH_PID } = require("../../utils/constants");
+const { ethers } = hre;
+
+async function hotDeployBalancerRethWETHStrategy(balancerREthFixture) {
+  const { deploy } = deployments;
+
+  // deploy this contract that exposes internal function
+  await deploy("BalancerMetaPoolTestStrategy", {
+    from: addresses.mainnet.Timelock, // doesn't matter which address deploys it
+    contract: "BalancerMetaPoolTestStrategy",
+    args: [
+      [addresses.mainnet.rETH_WETH_BPT, addresses.mainnet.OETHVaultProxy],
+      [
+        addresses.mainnet.rETH,
+        addresses.mainnet.stETH,
+        addresses.mainnet.wstETH,
+        addresses.mainnet.frxETH,
+        addresses.mainnet.sfrxETH,
+        addresses.mainnet.balancerVault, // Address of the Balancer vault
+        balancer_rETH_WETH_PID, // Pool ID of the Balancer pool
+      ],
+      [2, 1], //BPT_IN_FOR_EXACT_TOKENS_OUT, EXACT_BPT_IN_FOR_TOKENS_OUT
+      addresses.mainnet.rETH_WETH_AuraRewards, // Address of the Aura rewards contract
+    ],
+  });
+
+  const fixture = await balancerREthFixture();
+  const { balancerREthStrategy, josh } = fixture;
+
+  await replaceContractAt(
+    balancerREthStrategy.address,
+    await ethers.getContract("BalancerMetaPoolTestStrategy")
+  );
+
+  // add additional contract functions present in the byte code while keeping
+  // the existing storage slots.
+  fixture.balancerREthStrategy = await ethers.getContractAt(
+    "BalancerMetaPoolTestStrategy",
+    balancerREthStrategy.address
+  );
+
+  return fixture;
+}
+
+module.exports = {
+  hotDeployBalancerRethWETHStrategy,
+};

--- a/contracts/test/fixture/_pool_tilt.js
+++ b/contracts/test/fixture/_pool_tilt.js
@@ -57,7 +57,7 @@ async function _fundAttackerOption({
   );
   const assetBalance = await asset.balanceOf(attackerAddress);
   const ethToFund = 1000000;
-  const sAttacker = await hre.ethers.provider.getSigner(address);
+  const sAttacker = await hre.ethers.provider.getSigner(attackerAddress);
 
   if (attackerEthBalance.lte(ousdUnits(`${ethToFund - 100}`))) {
     await impersonateAndFundContract(attackerAddress, `${ethToFund}`); // 1m ETH

--- a/contracts/test/fixture/_pools.js
+++ b/contracts/test/fixture/_pools.js
@@ -32,6 +32,7 @@ class BalancerPool extends Pool {
     const amountsIn = Array(
       this.assetAddressArray.length + assetIndexAdjustement
     ).fill(BigNumber.from("0"));
+    const attackerAddress = sAttacker.address || sAttacker._address
 
     amountsIn[(await this.getAssetIndex(asset)) + assetIndexAdjustement] =
       amount;
@@ -55,8 +56,8 @@ class BalancerPool extends Pool {
 
     await this.balancerVault.connect(sAttacker).joinPool(
       this.poolId,
-      sAttacker.address, // sender
-      sAttacker.address, // recipient
+      attackerAddress, // sender
+      attackerAddress, // recipient
       [
         //JoinPoolRequest
         this.assetAddressArray, // assets
@@ -73,6 +74,7 @@ class BalancerPool extends Pool {
   async untiltPool(sAttacker, attackingAsset) {
     // for composableStable pools do not encode the BPT token in the user data request
     const assetIndexAdjustement = this.poolType == "composableStable" ? -1 : 0;
+    const attackerAddress = sAttacker.address || sAttacker._address
 
     /* encode user data for pool joining
      *
@@ -87,7 +89,7 @@ class BalancerPool extends Pool {
       ["uint256", "uint256", "uint256"],
       [
         0,
-        await this.bptToken.balanceOf(sAttacker.address),
+        await this.bptToken.balanceOf(attackerAddress),
         BigNumber.from(
           (
             (await this.getAssetIndex(attackingAsset)) + assetIndexAdjustement
@@ -102,8 +104,8 @@ class BalancerPool extends Pool {
 
     await this.balancerVault.connect(sAttacker).exitPool(
       this.poolId,
-      sAttacker.address, // sender
-      sAttacker.address, // recipient
+      attackerAddress, // sender
+      attackerAddress, // recipient
       [
         //ExitPoolRequest
         this.assetAddressArray, // assets

--- a/contracts/test/fixture/_pools.js
+++ b/contracts/test/fixture/_pools.js
@@ -32,7 +32,7 @@ class BalancerPool extends Pool {
     const amountsIn = Array(
       this.assetAddressArray.length + assetIndexAdjustement
     ).fill(BigNumber.from("0"));
-    const attackerAddress = sAttacker.address || sAttacker._address
+    const attackerAddress = sAttacker.address || sAttacker._address;
 
     amountsIn[(await this.getAssetIndex(asset)) + assetIndexAdjustement] =
       amount;
@@ -74,7 +74,7 @@ class BalancerPool extends Pool {
   async untiltPool(sAttacker, attackingAsset) {
     // for composableStable pools do not encode the BPT token in the user data request
     const assetIndexAdjustement = this.poolType == "composableStable" ? -1 : 0;
-    const attackerAddress = sAttacker.address || sAttacker._address
+    const attackerAddress = sAttacker.address || sAttacker._address;
 
     /* encode user data for pool joining
      *

--- a/contracts/test/strategies/BalancerComposableStablePool.fork-test.js
+++ b/contracts/test/strategies/BalancerComposableStablePool.fork-test.js
@@ -10,6 +10,7 @@ const {
   impersonateAndFundContract,
   createFixtureLoader,
   mineBlocks,
+  balancerSfrxETHRETHWstETHExposeFunctionFixture,
 } = require("../fixture/_fixture");
 
 const { tiltPool, unTiltPool } = require("../fixture/_pool_tilt");
@@ -1146,6 +1147,47 @@ forkOnlyDescribe(
           expect(unitDiff / 1e18).to.be.gte(parseFloat(maxDiff));
         });
       }
+    });
+
+    describe("return correct rate provider rates", function () {
+      beforeEach(async () => {
+        fixture = await balancerSfrxETHRETHWstETHExposeFunctionFixture();
+      });
+
+      it("should throw an exception for an unsupported asset", async function () {
+        const { balancerSfrxWstRETHStrategy } = fixture;
+
+        await expect(
+          balancerSfrxWstRETHStrategy.getRateProviderRate(addresses.mainnet.DAI)
+        ).to.be.revertedWith("Asset unsupported");
+      });
+
+      it("should return a valid rate for rEth", async function () {
+        const { balancerSfrxWstRETHStrategy } = fixture;
+
+        const rate = await balancerSfrxWstRETHStrategy.getRateProviderRate(
+          addresses.mainnet.rETH
+        );
+        expect(rate).to.be.gte(await oethUnits("1.01"));
+      });
+
+      it("should return a valid rate for wstETH", async function () {
+        const { balancerSfrxWstRETHStrategy } = fixture;
+
+        const rate = await balancerSfrxWstRETHStrategy.getRateProviderRate(
+          addresses.mainnet.wstETH
+        );
+        expect(rate).to.be.gte(await oethUnits("1"));
+      });
+
+      it("should return a valid rate for sfrxETH", async function () {
+        const { balancerSfrxWstRETHStrategy } = fixture;
+
+        const rate = await balancerSfrxWstRETHStrategy.getRateProviderRate(
+          addresses.mainnet.sfrxETH
+        );
+        expect(rate).to.be.gte(await oethUnits("1"));
+      });
     });
   }
 );

--- a/contracts/test/strategies/balancerMetaStablePool.fork-test.js
+++ b/contracts/test/strategies/balancerMetaStablePool.fork-test.js
@@ -8,6 +8,7 @@ const { units, oethUnits, forkOnlyDescribe, isCI } = require("../helpers");
 const {
   balancerREthFixture,
   balancerWstEthFixture,
+  balancerRethWETHExposeFunctionFixture,
   impersonateAndFundContract,
   createFixtureLoader,
   mineBlocks,
@@ -1141,6 +1142,38 @@ forkOnlyDescribe(
           expect(unitDiff / 1e18).to.be.gte(parseFloat(maxDiff));
         });
       }
+    });
+
+    describe("return correct rate provider rates", function () {
+      beforeEach(async () => {
+        fixture = await balancerRethWETHExposeFunctionFixture();
+      });
+
+      it("should throw an exception for an unsupported asset", async function () {
+        const { balancerREthStrategy } = fixture;
+
+        await expect(
+          balancerREthStrategy.getRateProviderRate(addresses.mainnet.DAI)
+        ).to.be.revertedWith("Asset unsupported");
+      });
+
+      it("should return a fixed rate for WETH", async function () {
+        const { balancerREthStrategy } = fixture;
+
+        const rate = await balancerREthStrategy.getRateProviderRate(
+          addresses.mainnet.WETH
+        );
+        expect(rate).to.equal(await oethUnits("1"));
+      });
+
+      it("should return a valid rate for rEth", async function () {
+        const { balancerREthStrategy } = fixture;
+
+        const rate = await balancerREthStrategy.getRateProviderRate(
+          addresses.mainnet.rETH
+        );
+        expect(rate).to.be.gte(await oethUnits("1.01"));
+      });
     });
   }
 );

--- a/contracts/test/strategies/balancerMetaStablePool.fork-test.js
+++ b/contracts/test/strategies/balancerMetaStablePool.fork-test.js
@@ -1145,6 +1145,7 @@ forkOnlyDescribe(
     });
 
     describe("return correct rate provider rates", function () {
+      let fixture;
       beforeEach(async () => {
         fixture = await balancerRethWETHExposeFunctionFixture();
       });


### PR DESCRIPTION
This PR: 
- fixes the issue where an exception wouldn't be thrown when a rate provider for unsupported asset is queried
- makes fetching rate provider rates more gas efficient
- hot deploys a contract change in the fixture rather than deploy file for a more efficient forked environment development