### PR TITLE
Convex frxETH/WETH Strategy - OZ L-03

### DIFF
--- a/contracts/contracts/strategies/ConvexStrategy.sol
+++ b/contracts/contracts/strategies/ConvexStrategy.sol
@@ -131,7 +131,8 @@ contract ConvexStrategy is BaseCurveStrategy {
      * the Harvester collects more rewards and swaps them for a vault asset.
      */
     function _lpWithdrawAll() internal override {
-        // Unstake all the Convex LP token and withdraw all the Curve LP tokens from the Convex pool to this strategy contract.
+        // Unstake all the Convex LP token and withdraw all the Curve LP tokens
+        // from the Convex pool to this strategy contract.
         IRewardStaking(cvxRewardStaker).withdrawAndUnwrap(
             IRewardStaking(cvxRewardStaker).balanceOf(address(this)),
             false // do not claim Convex token rewards

--- a/contracts/contracts/strategies/ConvexStrategy.sol
+++ b/contracts/contracts/strategies/ConvexStrategy.sol
@@ -98,7 +98,15 @@ contract ConvexStrategy is BaseCurveStrategy {
         );
     }
 
+    /**
+     * @dev Unstake a required amount of Convex LP token and withdraw the Curve LP tokens from the Convex pool.
+     * This assumes 1 Convex LP token equals 1 Curve LP token.
+     * Do not collect Convex token rewards (CRV and CVX) as that's done via the Harvester.
+     * Collecting token rewards now just adds extra gas as they will sit in the strategy until
+     * the Harvester collects more rewards and swaps them for a vault asset.
+     */
     function _lpWithdraw(uint256 requiredLpTokens) internal override {
+        // Get the actual amount of Convex LP tokens staked.
         uint256 actualLpTokens = IRewardStaking(cvxRewardStaker).balanceOf(
             address(this)
         );
@@ -109,18 +117,24 @@ contract ConvexStrategy is BaseCurveStrategy {
             "Insufficient Curve LP balance"
         );
 
-        // withdraw and unwrap with claim takes back the lpTokens and also collects the rewards to this
+        // Unstake the Convex LP token and withdraw the Curve LP tokens from the Convex pool to this strategy contract.
         IRewardStaking(cvxRewardStaker).withdrawAndUnwrap(
             requiredLpTokens,
-            true // stake
+            false // do not claim Convex token rewards
         );
     }
 
+    /**
+     * @dev Unstake all the Convex LP tokens and withdraw all the Curve LP tokens from the Convex pool.
+     * Do not collect Convex token rewards (CRV and CVX) as that's done via the Harvester.
+     * Collecting token rewards now just adds extra gas as they will sit in the strategy until
+     * the Harvester collects more rewards and swaps them for a vault asset.
+     */
     function _lpWithdrawAll() internal override {
-        // withdraw and unwrap with claim takes back the lpTokens and also collects the rewards to this
+        // Unstake all the Convex LP token and withdraw all the Curve LP tokens from the Convex pool to this strategy contract.
         IRewardStaking(cvxRewardStaker).withdrawAndUnwrap(
             IRewardStaking(cvxRewardStaker).balanceOf(address(this)),
-            true // stake
+            false // do not claim Convex token rewards
         );
     }
 


### PR DESCRIPTION
* The `ConvexStrategy` contract is designed for investing both stablecoins and pegged
assets in the appropriate Curve + Convex pools. However, line 6 of the contract only
mentions stablecoins and the Curve 3Pool.
* The NatSpec of the `_getAsset` function refers to `_coinIndex` as the "Curve pool
index", whereas it is actually the index of the coin inside the tokens array of the Curve
pool.
* In both `_lpWithdraw` and `_lpWithdrawAll` functions of the `ConvexStrategy`
contract, the true flag used when calling the `withdrawAndUnwrap` function is documented as "stake". In actuality, this flag is used to determine whether the caller
intends to claim rewards in addition to withdrawing from Convex.

Consider addressing the above in order to increase code readability.
