### PR TITLE
Convex frxETH/WETH Strategy - OZ N-02

### DIFF
--- a/contracts/contracts/strategies/BaseCurveStrategy.sol
+++ b/contracts/contracts/strategies/BaseCurveStrategy.sol
@@ -81,7 +81,7 @@ abstract contract BaseCurveStrategy is InitializableAbstractStrategy {
     }
 
     /**
-     * @notice Deposit an vault asset into the Curve pool.
+     * @notice Deposit a vault asset into the Curve pool.
      * @dev This assumes the vault has already transferred the asset to this strategy contract.
      * @dev An invalid asset will fail in _getCoinIndex with "Unsupported asset".
      * @param _asset Address of asset to deposit
@@ -176,7 +176,7 @@ abstract contract BaseCurveStrategy is InitializableAbstractStrategy {
     function _lpWithdrawAll() internal virtual;
 
     /**
-     * @notice Withdraw an single asset from the Curve pool.
+     * @notice Withdraw a single asset from the Curve pool.
      * @dev An invalid asset will fail in _getCoinIndex with "Unsupported asset".
      * @param _recipient Address to receive withdrawn asset
      * @param _asset Address of asset to withdraw

--- a/contracts/contracts/strategies/curve/CurveThreeCoinLib.sol
+++ b/contracts/contracts/strategies/curve/CurveThreeCoinLib.sol
@@ -28,13 +28,13 @@ library CurveThreeCoinLib {
             _amounts.length == CURVE_POOL_ASSETS_COUNT,
             "Invalid number of amounts"
         );
-        uint256[CURVE_POOL_ASSETS_COUNT] memory amount = [
+        uint256[CURVE_POOL_ASSETS_COUNT] memory amounts = [
             _amounts[0],
             _amounts[1],
             _amounts[2]
         ];
 
-        ICurvePool(_pool).add_liquidity(amount, _min_mint_amount);
+        ICurvePool(_pool).add_liquidity(amounts, _min_mint_amount);
     }
 
     /**

--- a/contracts/contracts/strategies/curve/CurveTwoCoinLib.sol
+++ b/contracts/contracts/strategies/curve/CurveTwoCoinLib.sol
@@ -23,13 +23,13 @@ library CurveTwoCoinLib {
             _amounts.length == CURVE_POOL_ASSETS_COUNT,
             "Invalid number of amounts"
         );
-        uint256[CURVE_POOL_ASSETS_COUNT] memory amount = [
+        uint256[CURVE_POOL_ASSETS_COUNT] memory amounts = [
             _amounts[0],
             _amounts[1]
         ];
 
         // slither-disable-next-line unused-return
-        ICurveMetaPool(_pool).add_liquidity(amount, _min_mint_amount);
+        ICurveMetaPool(_pool).add_liquidity(amounts, _min_mint_amount);
     }
 
     /**


### PR DESCRIPTION
Several typographical errors were identified throughout the codebase:

- Line 85 in `BaseCurveStrategy` , "an vault" should be "a vault".
- Line 178 in `BaseCurveStrategy` , "an single asset" should be "a single asset".
- Line 24 in `CurveTwoCoinLib` , "amount" should be "amounts".

Consider addressing the above, as well as incorporating an automated spelling and grammar
checker into your CI pipeline to identify any other instances.