### PR TITLE
Convex frxETH/WETH Strategy - OZ N-04

### DIFF
--- a/contracts/contracts/strategies/BaseCurveStrategy.sol
+++ b/contracts/contracts/strategies/BaseCurveStrategy.sol
@@ -21,7 +21,10 @@ abstract contract BaseCurveStrategy is InitializableAbstractStrategy {
     uint256 public constant MAX_SLIPPAGE = 1e16; // 1%, same as the Curve UI
     /// @notice number of assets in the Curve pool. eg 3 for the 3Pool
     uint256 public immutable CURVE_POOL_ASSETS_COUNT;
+    /// @notice Address of the Curve pool contract
     address public immutable CURVE_POOL;
+    /// @notice Address of the Curve pool's liquidity provider (LP) token.
+    /// This can be different to the Curve pool. For exmaple, 3Pool's 3Crv LP token.
     address public immutable CURVE_LP_TOKEN;
 
     // Only supporting up to 3 coins for now.


### PR DESCRIPTION
OZ comment:
Usually, liquidity pool smart contracts contain both the swapping and LP token implementation
at the same address. This is the case for Curve as well; the pool address and the LP token
address are the same, making `CURVE_POOL` and `CURVE_LP_TOKEN` equal.

Consider removing one of the variables to decrease the effort of initializing the smart contracts
and increase code readability.

Origin response:
Some of the older Curve pools had separate LP tokens from the Curve pool contract. The best example is the 3Pool which has a separate 3Crv token for the pool's LP token.
OUSD has a Convex 3Pool strategy hence the reason `CURVE_POOL` and `CURVE_LP_TOKEN` are split.