### PR TITLE
Convex frxETH/WETH Strategy - N-03

### DIFF
--- a/contracts/contracts/strategies/BaseCurveStrategy.sol
+++ b/contracts/contracts/strategies/BaseCurveStrategy.sol
@@ -346,8 +346,9 @@ abstract contract BaseCurveStrategy is InitializableAbstractStrategy {
     function _approveAsset(address _asset) internal {
         IERC20 asset = IERC20(_asset);
         // Approve the Curve pool, eg 3Pool, to transfer an asset (required for adding liquidity)
-        asset.safeApprove(CURVE_POOL, 0);
-        asset.safeApprove(CURVE_POOL, type(uint256).max);
+        // Need to handle USDT so have to set to zero first
+        asset.approve(CURVE_POOL, 0);
+        asset.approve(CURVE_POOL, type(uint256).max);
     }
 
     function _approveBase() internal virtual;

--- a/contracts/contracts/strategies/BaseCurveStrategy.sol
+++ b/contracts/contracts/strategies/BaseCurveStrategy.sol
@@ -347,7 +347,10 @@ abstract contract BaseCurveStrategy is InitializableAbstractStrategy {
         IERC20 asset = IERC20(_asset);
         // Approve the Curve pool, eg 3Pool, to transfer an asset (required for adding liquidity)
         // Need to handle USDT so have to set to zero first
+
+        // slither-disable-next-line unused-return
         asset.approve(CURVE_POOL, 0);
+        // slither-disable-next-line unused-return
         asset.approve(CURVE_POOL, type(uint256).max);
     }
 

--- a/contracts/contracts/strategies/ConvexStrategy.sol
+++ b/contracts/contracts/strategies/ConvexStrategy.sol
@@ -163,6 +163,7 @@ contract ConvexStrategy is BaseCurveStrategy {
     function _approveBase() internal override {
         IERC20 curveLpToken = IERC20(CURVE_LP_TOKEN);
         // Approve the Convex deposit contract to transfer the Curve pool's LP token
+        // slither-disable-next-line unused-return
         curveLpToken.approve(cvxDepositor, type(uint256).max);
     }
 

--- a/contracts/contracts/strategies/ConvexStrategy.sol
+++ b/contracts/contracts/strategies/ConvexStrategy.sol
@@ -163,8 +163,7 @@ contract ConvexStrategy is BaseCurveStrategy {
     function _approveBase() internal override {
         IERC20 curveLpToken = IERC20(CURVE_LP_TOKEN);
         // Approve the Convex deposit contract to transfer the Curve pool's LP token
-        curveLpToken.safeApprove(cvxDepositor, 0);
-        curveLpToken.safeApprove(cvxDepositor, type(uint256).max);
+        curveLpToken.approve(cvxDepositor, type(uint256).max);
     }
 
     /**


### PR DESCRIPTION
Inside the `_approveAsset` function of `BaseCurveStrategy` , the function `safeApprove`
is used to first approve an amount of 0 and then approve the max uint256 value. This
bypasses the security mechanism behind `safeApprove` . Additionally, it is worth noting that
`safeApprove` is now deprecated and will not be supported in future OpenZeppelin contracts.

Consider avoiding this anti-pattern and using `safeIncreaseAllowance` instead.