### PR TITLE
Convex frxETH/WETH Strategy - N-05

### DIFF
--- a/contracts/contracts/strategies/ConvexStrategy.sol
+++ b/contracts/contracts/strategies/ConvexStrategy.sol
@@ -54,7 +54,6 @@ contract ConvexStrategy is BaseCurveStrategy {
 
     struct ConvexConfig {
         address cvxDepositor;
-        address cvxRewardStaker;
         uint256 cvxDepositorPoolId;
     }
 
@@ -67,8 +66,12 @@ contract ConvexStrategy is BaseCurveStrategy {
         BaseCurveStrategy(_curveConfig)
     {
         cvxDepositor = _convexConfig.cvxDepositor;
-        cvxRewardStaker = _convexConfig.cvxRewardStaker;
         cvxDepositorPoolId = _convexConfig.cvxDepositorPoolId;
+
+        // Get the Convex Rewards contract for the Convex pool
+        (, , , cvxRewardStaker, , ) = IConvexDeposits(
+            _convexConfig.cvxDepositor
+        ).poolInfo(_convexConfig.cvxDepositorPoolId);
     }
 
     /**

--- a/contracts/contracts/strategies/IConvexDeposits.sol
+++ b/contracts/contracts/strategies/IConvexDeposits.sol
@@ -13,4 +13,16 @@ interface IConvexDeposits {
         bool _lock,
         address _stakeAddress
     ) external;
+
+    function poolInfo(uint256 _pid)
+        external
+        view
+        returns (
+            address lptoken,
+            address token,
+            address gauge,
+            address crvRewards,
+            address stash,
+            bool shutdown
+        );
 }

--- a/contracts/deploy/001_core.js
+++ b/contracts/deploy/001_core.js
@@ -192,12 +192,6 @@ const deployConvexStrategy = async () => {
   const cVaultProxy = await ethers.getContract("VaultProxy");
   const mockBooster = await ethers.getContract("MockBooster");
   await mockBooster.setPool(threeCRVPid, assetAddresses.ThreePoolToken);
-  // Get the convex rewards pool created in the previous setPool call
-  const poolInfo = await mockBooster.poolInfo(threeCRVPid);
-  const mockRewardPool = await ethers.getContractAt(
-    "MockRewardPool",
-    poolInfo.crvRewards
-  );
 
   await deployWithConfirmation("ConvexStrategyProxy", [], null, true);
   const cConvexStrategyProxy = await ethers.getContract("ConvexStrategyProxy");
@@ -218,7 +212,6 @@ const deployConvexStrategy = async () => {
       ],
       [
         mockBooster.address, // _cvxDepositorAddress,
-        mockRewardPool.address, // _cvxRewardStakerAddress,
         threeCRVPid, // _cvxDepositorPTokenId
       ],
     ],
@@ -271,12 +264,6 @@ const deployConvexFrxEthWethStrategy = async () => {
     frxEthWethPoolLpPID,
     assetAddresses.CurveFrxEthWethPool
   );
-  // Get the convex rewards pool created in the previous setPool call
-  const poolInfo = await mockBooster.poolInfo(frxEthWethPoolLpPID);
-  const mockRewardPool = await ethers.getContractAt(
-    "MockRewardPool",
-    poolInfo.crvRewards
-  );
 
   await deployWithConfirmation("ConvexFrxEthWethStrategyProxy", [], null, true);
   const cConvexFrxEthWethStrategyProxy = await ethers.getContract(
@@ -301,7 +288,6 @@ const deployConvexFrxEthWethStrategy = async () => {
       ],
       [
         mockBooster.address, // _cvxDepositorAddress,
-        mockRewardPool.address, // _cvxRewardStakerAddress,
         frxEthWethPoolLpPID, // _cvxDepositorPTokenId
       ],
     ],

--- a/contracts/deploy/078_convex_frax_strategy.js
+++ b/contracts/deploy/078_convex_frax_strategy.js
@@ -56,11 +56,7 @@ module.exports = deploymentWithGovernanceProposal(
           addresses.mainnet.CurveFrxEthWethPool, // Curve pool
           addresses.mainnet.CurveFrxEthWethPool, // Curve LP token
         ],
-        [
-          addresses.mainnet.CVXBooster,
-          addresses.mainnet.ConvexFrxEthWethRewardsPool,
-          frxEthWethPoolLpPID,
-        ],
+        [addresses.mainnet.CVXBooster, frxEthWethPoolLpPID],
       ],
       null,
       true, // assertUpgradeIsSafe does not support libraries so need to skip it


### PR DESCRIPTION
The `cvxRewardStaker` state variable of the `ConvexStrategy` contract is provided as a
constructor argument. Alternatively, its value can be retrieved from the `crvRewards` member
of the Convex `poolInfo` , where poolInfo can be retrieved through
`ConvexBooster.poolInfo(poolId)` . In our case, `cvxDepositor` is the address of the
`ConvexBooster` , whereas `cvxDepositorPoolId` is the `poolId`.

Consider removing the `cvxRewardStaker` constructor argument and retrieving its value from
the Convex `Booster` on-chain state. This would make the deployment more encapsulated and
less error-prone.