### PR TITLE
M-01 DoS of Strategy Removal Due to Underflow

### DIFF
--- a/contracts/test/fixture/_fixture.js
+++ b/contracts/test/fixture/_fixture.js
@@ -1935,7 +1935,7 @@ async function fluxStrategyFixture() {
 /**
  * A fixture is a setup function that is run only the first time it's invoked. On subsequent invocations,
  * Hardhat will reset the state of the network to what it was at the point after the fixture was initially executed.
- * The returned `loadFixture` function is typically inlcuded in the beforeEach().
+ * The returned `loadFixture` function is typically included in the beforeEach().
  * @example
  *   const loadFixture = createFixtureLoader(convexOETHMetaVaultFixture);
  *   beforeEach(async () => {

--- a/contracts/test/strategies/BalancerComposableStablePool.fork-test.js
+++ b/contracts/test/strategies/BalancerComposableStablePool.fork-test.js
@@ -436,6 +436,97 @@ describe("ForkTest: Balancer ComposableStablePool sfrxETH/wstETH/rETH Strategy",
       expect(rethBalanceDiff).to.be.gte(await units("15", reth), 1);
       expect(frxEthBalanceDiff).to.be.gte(await units("15", frxETH), 1);
     });
+
+    it("Should be able to withdraw all of pool's liquidity twice", async function () {
+      const { oethVault, balancerSfrxWstRETHStrategy } = fixture;
+
+      const oethVaultSigner = await impersonateAndFund(oethVault.address);
+
+      await balancerSfrxWstRETHStrategy.connect(oethVaultSigner).withdrawAll();
+      await balancerSfrxWstRETHStrategy.connect(oethVaultSigner).withdrawAll();
+    });
+
+    for (const assetAmount of ["2", "3", "4"]) {
+      const shareAmount = `${parseInt(assetAmount) - 1}`;
+      it(`Should be able to withdraw all when if malicious actor would somehow manage to give ${shareAmount}wei of sfrxETH to the strategy`, async function () {
+        const {
+          oethVault,
+          josh,
+          frxETH,
+          sfrxETH,
+          balancerSfrxWstRETHStrategy,
+        } = fixture;
+        const strategySigner = await impersonateAndFund(
+          balancerSfrxWstRETHStrategy.address
+        );
+
+        const oethVaultSigner = await impersonateAndFund(oethVault.address);
+        // empty the strategy
+        await balancerSfrxWstRETHStrategy
+          .connect(oethVaultSigner)
+          .withdrawAll();
+
+        // send some frxETH dust
+        await frxETH
+          .connect(josh)
+          .transfer(balancerSfrxWstRETHStrategy.address, assetAmount);
+
+        await frxETH
+          .connect(strategySigner)
+          .approve(sfrxETH.address, assetAmount);
+
+        // this will mint `shareAmount` of wei of the sfrxETH "share" token to the strategy
+        await sfrxETH.connect(strategySigner).deposit(
+          assetAmount, // assets
+          balancerSfrxWstRETHStrategy.address // receiver
+        );
+
+        await balancerSfrxWstRETHStrategy
+          .connect(oethVaultSigner)
+          .withdrawAll();
+      });
+    }
+
+    for (const bptTokens of ["1", "2", "3", "4", "5"]) {
+      it(`Should be able to withdraw all when balance of BPT tokens is ${bptTokens} wei`, async function () {
+        const {
+          oethVault,
+          josh,
+          sfrxETHwstETHrEthAuraPool,
+          sfrxETHwstETHrEthBPT,
+          balancerSfrxWstRETHStrategy,
+        } = fixture;
+        const strategySigner = await impersonateAndFund(
+          balancerSfrxWstRETHStrategy.address
+        );
+
+        // lift `bptTokens` wei of BPT from the reward pool
+        await sfrxETHwstETHrEthAuraPool.connect(strategySigner).withdraw(
+          bptTokens, // assets amount
+          balancerSfrxWstRETHStrategy.address, // receiver
+          balancerSfrxWstRETHStrategy.address // owner
+        );
+
+        // tuck `bptTokens` WEI of BPT token away
+        await sfrxETHwstETHrEthBPT
+          .connect(strategySigner)
+          .transfer(josh.address, bptTokens);
+
+        const oethVaultSigner = await impersonateAndFund(oethVault.address);
+        await balancerSfrxWstRETHStrategy
+          .connect(oethVaultSigner)
+          .withdrawAll();
+
+        // give `bptTokens` WEI of BPT back to the strategy
+        await sfrxETHwstETHrEthBPT
+          .connect(josh)
+          .transfer(balancerSfrxWstRETHStrategy.address, bptTokens);
+
+        await balancerSfrxWstRETHStrategy
+          .connect(oethVaultSigner)
+          .withdrawAll();
+      });
+    }
   });
 
   describe("Large withdraw", function () {


### PR DESCRIPTION
In emergencies, certain `VaultAdmin` actions relying on `withdrawAll` may be blocked by
an attacker. This can happen in the following cases:
- The strategy does not have any investment.
- The strategy lacks BPT due to an earlier withdrawal performed without removing the
strategy as well.

The check condition and subtraction in the `withdrawAll` function are inconsistent.
Consequently, an amount of `1` wei passes the check but triggers an arithmetic underflow.

This underflow can be maliciously triggered if the Balancer exit returns 0 wei of sfrxETH when
the strategy does not hold any BPT. The required 0 BPT balance may arise from a lack of
allocation or a previous withdrawal.

Thus, an attacker could trigger an underflow by transferring to the strategy either 1 wei of
sfrxETH, a minimal BPT amount (e.g., 4 wei) or a suitable amount of AURA LP tokens.

This would block all functions that depend on `withdrawAll` not reverting. Namely
`removeStrategy` , withdrawFromStrategy and importantly,
`withdrawAllFromStrategies`.

As part of damage mitigation during an attack, the protocol team can transfer more sfrxETH to
the strategy and call `removeStrategy` . However, during emergencies, the time to identify
and resolve this issue could delay addressing the initial emergency, possibly causing severe
consequences.

Consider aligning the checked and subtracted amounts. Additionally, consider using try-
catch in `withdrawAllFromStrategies` , so that one strategy's withdrawal reverting does not revert the entire transaction.

