### PR TITLE
M-02 Incorrect Assumption That Pool’s BPT Is the First Token in Balancer Pool

### DIFF
--- a/contracts/contracts/mocks/BalancerComposablePoolTestStrategy.sol
+++ b/contracts/contracts/mocks/BalancerComposablePoolTestStrategy.sol
@@ -15,13 +15,15 @@ contract BalancerComposablePoolTestStrategy is BalancerComposablePoolStrategy {
         BaseStrategyConfig memory _stratConfig,
         BaseBalancerConfig memory _balancerConfig,
         BaseMetaPoolConfig memory _metapoolConfig,
-        address _auraRewardPoolAddress
+        address _auraRewardPoolAddress,
+        uint256 _bptTokenPoolPosition
     )
         BalancerComposablePoolStrategy(
             _stratConfig,
             _balancerConfig,
             _metapoolConfig,
-            _auraRewardPoolAddress
+            _auraRewardPoolAddress,
+            _bptTokenPoolPosition
         )
     {}
 
@@ -31,5 +33,29 @@ contract BalancerComposablePoolTestStrategy is BalancerComposablePoolStrategy {
         returns (uint256)
     {
         return _getRateProviderRate(_asset);
+    }
+
+    function assetConfigVerification(address[] calldata _assets)
+        external
+        view
+        returns (uint256)   
+    {
+        _assetConfigVerification(_assets);
+    }
+
+    function getUserDataEncodedAmounts(uint256[] memory _amounts)
+        external
+        view
+        returns (uint256[] memory amounts)
+    {
+        return _getUserDataEncodedAmounts(_amounts);
+    }
+
+    function getUserDataEncodedAssets(address[] memory _assets)
+        external
+        view
+        returns (address[] memory assets)
+    {
+        return _getUserDataEncodedAssets(_assets);
     }
 }

--- a/contracts/contracts/mocks/BalancerComposablePoolTestStrategy.sol
+++ b/contracts/contracts/mocks/BalancerComposablePoolTestStrategy.sol
@@ -38,7 +38,7 @@ contract BalancerComposablePoolTestStrategy is BalancerComposablePoolStrategy {
     function assetConfigVerification(address[] calldata _assets)
         external
         view
-        returns (uint256)   
+        returns (uint256)
     {
         _assetConfigVerification(_assets);
     }

--- a/contracts/contracts/strategies/balancer/BalancerComposablePoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerComposablePoolStrategy.sol
@@ -74,14 +74,12 @@ contract BalancerComposablePoolStrategy is BalancerMetaPoolStrategy {
         override
         returns (uint256[] memory amounts)
     {
-        // first asset in the Composable stable pool is the BPT token.
-        // skip over that entry and shift all other assets for 1 position
-        // to the left
+        // remove the position in the array that represents the BPT
+        // token
         amounts = new uint256[](_amounts.length - 1);
         for (uint256 i = 0; i < _amounts.length - 1; ++i) {
             amounts[i] = _amounts[i >= bptTokenPoolPosition ? i + 1 : i];
         }
-        // TODO verify this works with various pools
     }
 
     function _getUserDataEncodedAssets(address[] memory _assets)
@@ -91,13 +89,11 @@ contract BalancerComposablePoolStrategy is BalancerMetaPoolStrategy {
         override
         returns (address[] memory assets)
     {
-        // first asset in the Composable stable pool is the BPT token.
-        // skip over that entry and shift all other assets for 1 position
-        // to the left
+        // remove the position in the array that represents the BPT
+        // token
         assets = new address[](_assets.length - 1);
         for (uint256 i = 0; i < _assets.length - 1; ++i) {
             assets[i] = _assets[i >= bptTokenPoolPosition ? i + 1 : i];
         }
-        // TODO verify this works with various pools
     }
 }

--- a/contracts/contracts/strategies/balancer/BalancerComposablePoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerComposablePoolStrategy.sol
@@ -14,11 +14,15 @@ contract BalancerComposablePoolStrategy is BalancerMetaPoolStrategy {
     using SafeERC20 for IERC20;
     using StableMath for uint256;
 
+    // position of BPT token in the Balancer's pool
+    uint256 public immutable bptTokenPoolPosition;
+
     constructor(
         BaseStrategyConfig memory _stratConfig,
         BaseBalancerConfig memory _balancerConfig,
         BaseMetaPoolConfig memory _metapoolConfig,
-        address _auraRewardPoolAddress
+        address _auraRewardPoolAddress,
+        uint256 _bptTokenPoolPosition
     )
         BalancerMetaPoolStrategy(
             _stratConfig,
@@ -26,7 +30,9 @@ contract BalancerComposablePoolStrategy is BalancerMetaPoolStrategy {
             _metapoolConfig,
             _auraRewardPoolAddress
         )
-    {}
+    {
+        bptTokenPoolPosition = _bptTokenPoolPosition;
+    }
 
     function _assetConfigVerification(address[] calldata _assets)
         internal
@@ -40,7 +46,9 @@ contract BalancerComposablePoolStrategy is BalancerMetaPoolStrategy {
         );
         for (uint256 i = 0; i < _assets.length; ++i) {
             require(
-                _assets[i] == _fromPoolAsset(poolAssets[i + 1]),
+                _assets[i] == _fromPoolAsset(poolAssets[
+                    i >= bptTokenPoolPosition ? i + 1 : i
+                ]),
                 "Pool assets mismatch"
             );
         }
@@ -58,8 +66,9 @@ contract BalancerComposablePoolStrategy is BalancerMetaPoolStrategy {
         // to the left
         amounts = new uint256[](_amounts.length - 1);
         for (uint256 i = 0; i < _amounts.length - 1; ++i) {
-            amounts[i] = _amounts[i + 1];
+            amounts[i] = _amounts[i >= bptTokenPoolPosition ? i + 1 : i];
         }
+        // TODO verify this works with various pools
     }
 
     function _getUserDataEncodedAssets(address[] memory _assets)
@@ -74,7 +83,8 @@ contract BalancerComposablePoolStrategy is BalancerMetaPoolStrategy {
         // to the left
         assets = new address[](_assets.length - 1);
         for (uint256 i = 0; i < _assets.length - 1; ++i) {
-            assets[i] = _assets[i + 1];
+            assets[i] = _assets[i >= bptTokenPoolPosition ? i + 1 : i];
         }
+        // TODO verify this works with various pools
     }
 }

--- a/contracts/contracts/strategies/balancer/BalancerComposablePoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerComposablePoolStrategy.sol
@@ -14,7 +14,12 @@ contract BalancerComposablePoolStrategy is BalancerMetaPoolStrategy {
     using SafeERC20 for IERC20;
     using StableMath for uint256;
 
-    // position of BPT token in the Balancer's pool
+    /* @notice position of BPT token in the Balancer's pool
+     *
+     * @dev this could be a storage variable that gets set by reading Balancer's pool
+     * tokens and comparing it to platformAddress. Seems more convenient, but we rather
+     * go for gas savings of an immutable variable.
+     */
     uint256 public immutable bptTokenPoolPosition;
 
     constructor(
@@ -44,11 +49,19 @@ contract BalancerComposablePoolStrategy is BalancerMetaPoolStrategy {
             poolAssets.length - 1 == _assets.length,
             "Pool assets length mismatch"
         );
+
+        require(
+            // BPT position should be correctly configured
+            poolAssets[bptTokenPoolPosition] == platformAddress,
+            "BPT token position incorrect"
+        );
+
         for (uint256 i = 0; i < _assets.length; ++i) {
             require(
-                _assets[i] == _fromPoolAsset(poolAssets[
-                    i >= bptTokenPoolPosition ? i + 1 : i
-                ]),
+                _assets[i] ==
+                    _fromPoolAsset(
+                        poolAssets[i >= bptTokenPoolPosition ? i + 1 : i]
+                    ),
                 "Pool assets mismatch"
             );
         }

--- a/contracts/deploy/076_balancer_sfrxETH_wstETH_rETH.js
+++ b/contracts/deploy/076_balancer_sfrxETH_wstETH_rETH.js
@@ -56,6 +56,7 @@ module.exports = deploymentWithGovernanceProposal(
           2, // ComposablePoolExitKind.EXACT_BPT_IN_FOR_(ALL_)TOKENS_OUT
         ],
         addresses.mainnet.wstETH_sfrxETH_rETH_AuraRewards, // Address of the Aura rewards contract
+        0, // position of BPT token within the sfrxETH-rETH-wstETH Balancer pool
       ]);
     const cOETHBalancerComposablePoolStrategy = await ethers.getContractAt(
       "BalancerComposablePoolStrategy",

--- a/contracts/test/fixture/_custom-deploys.js
+++ b/contracts/test/fixture/_custom-deploys.js
@@ -5,12 +5,10 @@ const { ethers } = hre;
 const deployBalancerFrxEethRethWstEThStrategyMissConfigured = async () => {
   const { deploy } = deployments;
   const platformAddress = addresses.mainnet.wstETH_sfrxETH_rETH_BPT;
-  const { deployerAddr } = await getNamedAccounts();
-  const sDeployer = await ethers.provider.getSigner(deployerAddr);
+  const sTimelock = await ethers.provider.getSigner(addresses.mainnet.Timelock);
 
-  // deploy this contract that exposes internal function
   await deploy("BalancerComposablePoolStrategy", {
-    from: addresses.mainnet.Timelock, // doesn't matter which address deploys it
+    from: addresses.mainnet.Timelock,
     contract: "BalancerComposablePoolStrategy",
     args: [
       [
@@ -38,7 +36,7 @@ const deployBalancerFrxEethRethWstEThStrategyMissConfigured = async () => {
   const strategy = await ethers.getContract("BalancerComposablePoolStrategy");
   // prettier-ignore
   await strategy
-    .connect(sDeployer)["initialize(address[],address[],address[])"](
+    .connect(sTimelock)["initialize(address[],address[],address[])"](
       [addresses.mainnet.BAL, addresses.mainnet.AURA],
       [
         addresses.mainnet.stETH,

--- a/contracts/test/fixture/_custom-deploys.js
+++ b/contracts/test/fixture/_custom-deploys.js
@@ -1,0 +1,56 @@
+const addresses = require("../../utils/addresses");
+const { balancer_wstETH_sfrxETH_rETH_PID } = require("../../utils/constants");
+const { ethers } = hre;
+
+const deployBalancerFrxEethRethWstEThStrategyMissConfigured = async () => {
+  const { deploy } = deployments;
+  const platformAddress = addresses.mainnet.wstETH_sfrxETH_rETH_BPT;
+  const { deployerAddr } = await getNamedAccounts();
+  const sDeployer = await ethers.provider.getSigner(deployerAddr);
+
+  // deploy this contract that exposes internal function
+  await deploy("BalancerComposablePoolStrategy", {
+    from: addresses.mainnet.Timelock, // doesn't matter which address deploys it
+    contract: "BalancerComposablePoolStrategy",
+    args: [
+      [
+        addresses.mainnet.wstETH_sfrxETH_rETH_BPT,
+        addresses.mainnet.OETHVaultProxy,
+      ],
+      [
+        addresses.mainnet.rETH,
+        addresses.mainnet.stETH,
+        addresses.mainnet.wstETH,
+        addresses.mainnet.frxETH,
+        addresses.mainnet.sfrxETH,
+        addresses.mainnet.balancerVault, // Address of the Balancer vault
+        balancer_wstETH_sfrxETH_rETH_PID, // Pool ID of the Balancer pool
+      ],
+      [
+        1, // ComposablePoolExitKind.BPT_IN_FOR_EXACT_TOKENS_OUT
+        2, // ComposablePoolExitKind.EXACT_BPT_IN_FOR_(ALL_)TOKENS_OUT
+      ],
+      addresses.mainnet.wstETH_sfrxETH_rETH_AuraRewards, // Address of the Aura rewards contract
+      1, // this is configured incorrectly -> the actual BPT position is at position 0
+    ],
+  });
+
+  const strategy = await ethers.getContract("BalancerComposablePoolStrategy");
+  // prettier-ignore
+  await strategy
+    .connect(sDeployer)["initialize(address[],address[],address[])"](
+      [addresses.mainnet.BAL, addresses.mainnet.AURA],
+      [
+        addresses.mainnet.stETH,
+        addresses.mainnet.frxETH,
+        addresses.mainnet.rETH,
+      ],
+      [platformAddress, platformAddress, platformAddress]
+    );
+
+  return strategy;
+};
+
+module.exports = {
+  deployBalancerFrxEethRethWstEThStrategyMissConfigured,
+};

--- a/contracts/test/fixture/_fixture.js
+++ b/contracts/test/fixture/_fixture.js
@@ -10,6 +10,9 @@ require("./_global-hooks");
 //const { setChainlinkOraclePrice } = require("../utils/oracle");
 
 const {
+  deployBalancerFrxEethRethWstEThStrategyMissConfigured,
+} = require("./_custom-deploys");
+const {
   hotDeployBalancerRethWETHStrategy,
   hotDeployBalancerFrxEethRethWstEThStrategy,
 } = require("./_hot-deploy");
@@ -1051,6 +1054,13 @@ async function balancerRethWETHExposeFunctionFixture() {
 }
 
 /**
+ * Deploy the Balancer Composable Stable pool with incorrect configuration
+ */
+async function balancerSfrxETHRETHWstETHMissConfiguredStrategy() {
+  return await deployBalancerFrxEethRethWstEThStrategyMissConfigured();
+}
+
+/**
  * Configure a Vault with the Balancer strategy for frxEth/Reth/wstEth pool and
  * replace the byte code with the one that exposes internal functions
  */
@@ -2004,6 +2014,7 @@ module.exports = {
   ousdCollateralSwapFixture,
   balancerRethWETHExposeFunctionFixture,
   balancerSfrxETHRETHWstETHExposeFunctionFixture,
+  balancerSfrxETHRETHWstETHMissConfiguredStrategy,
   fluxStrategyFixture,
   nodeSnapshot,
   nodeRevert,

--- a/contracts/test/fixture/_hot-deploy.js
+++ b/contracts/test/fixture/_hot-deploy.js
@@ -90,6 +90,7 @@ async function hotDeployBalancerFrxEethRethWstEThStrategy(
         2, // ComposablePoolExitKind.EXACT_BPT_IN_FOR_(ALL_)TOKENS_OUT
       ],
       addresses.mainnet.wstETH_sfrxETH_rETH_AuraRewards, // Address of the Aura rewards contract
+      0, // position of BPT token within the sfrxETH-rETH-wstETH Balancer pool
     ],
   });
 

--- a/contracts/test/strategies/BalancerComposableStablePool.fork-test.js
+++ b/contracts/test/strategies/BalancerComposableStablePool.fork-test.js
@@ -321,7 +321,9 @@ describe("ForkTest: Balancer ComposableStablePool sfrxETH/wstETH/rETH Strategy",
         balancerSfrxETHRETHWstETHMissConfiguredStrategy
       );
 
-      await expect(loadBalancerFrxWstrETHFixture()).to.be.reverted;
+      await expect(loadBalancerFrxWstrETHFixture()).to.be.revertedWith(
+        "BPT token position incorrect"
+      );
     });
   });
 

--- a/contracts/test/strategies/BalancerComposableStablePool.fork-test.js
+++ b/contracts/test/strategies/BalancerComposableStablePool.fork-test.js
@@ -22,7 +22,8 @@ const log = require("../../utils/logger")(
 );
 
 const loadBalancerFrxWstrETHFixture = createFixtureLoader(
-  balancerFrxETHwstETHeETHFixture,
+  //balancerFrxETHwstETHeETHFixture,
+  balancerSfrxETHRETHWstETHExposeFunctionFixture,
   {
     defaultStrategy: false,
   }
@@ -357,7 +358,7 @@ describe("ForkTest: Balancer ComposableStablePool sfrxETH/wstETH/rETH Strategy",
     ];
 
     for (const [rethAmount, stethAmount, frxethAmount] of withdrawalTestCases) {
-      it(`Should be able to withdraw ${rethAmount} RETH, ${stethAmount} stETH and ${frxethAmount} frxETH from the strategy`, async function () {
+      it.only(`Should be able to withdraw ${rethAmount} RETH, ${stethAmount} stETH and ${frxethAmount} frxETH from the strategy`, async function () {
         const { reth, stETH, frxETH, balancerSfrxWstRETHStrategy, oethVault } =
           fixture;
 

--- a/contracts/test/strategies/BalancerComposableStablePool.fork-test.js
+++ b/contracts/test/strategies/BalancerComposableStablePool.fork-test.js
@@ -11,6 +11,7 @@ const {
   balancerFrxETHwstETHeETHFixture,
   createFixtureLoader,
   balancerSfrxETHRETHWstETHExposeFunctionFixture,
+  balancerSfrxETHRETHWstETHMissConfiguredStrategy,
 } = require("../fixture/_fixture");
 
 const { tiltPool, unTiltPool } = require("../fixture/_pool_tilt");
@@ -22,8 +23,7 @@ const log = require("../../utils/logger")(
 );
 
 const loadBalancerFrxWstrETHFixture = createFixtureLoader(
-  //balancerFrxETHwstETHeETHFixture,
-  balancerSfrxETHRETHWstETHExposeFunctionFixture,
+  balancerFrxETHwstETHeETHFixture,
   {
     defaultStrategy: false,
   }
@@ -315,6 +315,16 @@ describe("ForkTest: Balancer ComposableStablePool sfrxETH/wstETH/rETH Strategy",
     });
   });
 
+  describe("Incorrect deployment configuration", function () {
+    it.only("Should fail when _bptTokenPoolPosition is miss-configured", async function () {
+      const loadBalancerFrxWstrETHFixture = createFixtureLoader(
+        balancerSfrxETHRETHWstETHMissConfiguredStrategy
+      );
+
+      await expect(loadBalancerFrxWstrETHFixture()).to.be.reverted;
+    });
+  });
+
   describe("Withdraw", function () {
     beforeEach(async () => {
       fixture = await loadBalancerFrxWstrETHFixture();
@@ -358,7 +368,7 @@ describe("ForkTest: Balancer ComposableStablePool sfrxETH/wstETH/rETH Strategy",
     ];
 
     for (const [rethAmount, stethAmount, frxethAmount] of withdrawalTestCases) {
-      it.only(`Should be able to withdraw ${rethAmount} RETH, ${stethAmount} stETH and ${frxethAmount} frxETH from the strategy`, async function () {
+      it(`Should be able to withdraw ${rethAmount} RETH, ${stethAmount} stETH and ${frxethAmount} frxETH from the strategy`, async function () {
         const { reth, stETH, frxETH, balancerSfrxWstRETHStrategy, oethVault } =
           fixture;
 

--- a/contracts/test/strategies/BalancerComposableStablePool.fork-test.js
+++ b/contracts/test/strategies/BalancerComposableStablePool.fork-test.js
@@ -316,7 +316,7 @@ describe("ForkTest: Balancer ComposableStablePool sfrxETH/wstETH/rETH Strategy",
   });
 
   describe("Incorrect deployment configuration", function () {
-    it.only("Should fail when _bptTokenPoolPosition is miss-configured", async function () {
+    it("Should fail when _bptTokenPoolPosition is miss-configured", async function () {
       const loadBalancerFrxWstrETHFixture = createFixtureLoader(
         balancerSfrxETHRETHWstETHMissConfiguredStrategy
       );


### PR DESCRIPTION
This pull request adds a gas efficient `_bptTokenPoolPosition` immutable parameter to the Composable Stable Pool Strategy that specifies the position of the BPT token in the list of tokens returned from the strategy. That parameter is used for required filtering of token lists. 

**Audit comment:**
`balancerVault.getPoolTokens()` is used to query the tokens supported by the Balancer
pool. The returned array includes the pool's BPT, which is used to track liquidity provisioning.

The `BalancerComposableStrategyContract` assumes that the BPT is at the first
position in the returned array. This assumption is made during `strategy initialization` and when
depositing/withdrawing assets by shifting the array parameters such that they exclude the
BPT.

While this assumption holds for the `wstETH-rETH-sfrxETH` pool, it does so only by
coincidence. The Balancer code does not enforce the BPT to be the first in the array. Instead, it
sorts the tokens by their contract address. Here is an example of a pool where the BPT comes
second in the queried array.

As such, trying to integrate with such a pool will fail during initialization. However, this
initialization check is crucial since the implementation relies on this assumption. Using the
current implementation with a pool that has BPT in another spot will cause unexpected
behavior and potential loss of value because of the faulty results of
_getUserDataEncodedAmounts and _getUserDataEncodedAssets .

Consider explicitly documenting this assumption in case only the pools where this assumption
holds will be used. Alternatively, if other pools are planned to be used, modify the
implementation to remove this assumption from the codebase.