### PR TITLE
L-01 Duplicate Strategy Assets Can Be Passed to _withdraw

### DIFF
--- a/contracts/contracts/mocks/BalancerMetaPoolTestStrategy.sol
+++ b/contracts/contracts/mocks/BalancerMetaPoolTestStrategy.sol
@@ -32,4 +32,15 @@ contract BalancerMetaPoolTestStrategy is BalancerMetaPoolStrategy {
     {
         return _getRateProviderRate(_asset);
     }
+
+    /**
+     * @notice This exposes the function that is currently not implemented
+     * just to future proof the usage of _deposit.
+     */
+    function deposit(
+        address[] calldata _strategyAssets,
+        uint256[] calldata _strategyAmounts
+    ) external override onlyVault nonReentrant {
+        _deposit(_strategyAssets, _strategyAmounts);
+    }
 }

--- a/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
@@ -310,8 +310,8 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
             if (poolAssetAmount > 0) {
                 strategyAssetsToPoolAssetsAmounts[i] = poolAssetAmount;
 
-                /* This check is triggered when the _withdrawal is unexpectedly
-                 * called with a duplicate asset in the _strategyAssets array
+                /* This check is triggered when the _withdrawal is called with
+                 * a duplicate asset in the _strategyAssets array
                  */
                 require(
                     poolAssetsAmountsOut[poolAssetIndex[poolAsset]] == 0,

--- a/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
@@ -158,8 +158,8 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
                     strategyAmount
                 );
 
-                /* This check is triggered when the _deposit is unexpectedly
-                 * called with a duplicate asset in the _strategyAssets array
+                /* This check is triggered when the _deposit is called with
+                 * a duplicate asset in the _strategyAssets array
                  */
                 require(
                     amountsIn[assetIndex] == 0,

--- a/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
@@ -158,6 +158,9 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
                     strategyAmount
                 );
 
+                /* This check is triggered when the _deposit is unexpectedly
+                 * called with a duplicate asset in the _strategyAssets array
+                 */
                 require(
                     amountsIn[assetIndex] == 0,
                     "No duplicate deposit assets"

--- a/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
@@ -83,6 +83,7 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
      */
     function deposit(address[] calldata, uint256[] calldata)
         external
+        virtual
         onlyVault
         nonReentrant
     {
@@ -155,6 +156,11 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
                 (, strategyAssetAmountsToPoolAssetAmounts[i]) = _wrapPoolAsset(
                     strategyAsset,
                     strategyAmount
+                );
+
+                require(
+                    amountsIn[assetIndex] == 0,
+                    "No duplicate deposit assets"
                 );
 
                 amountsIn[assetIndex] = strategyAssetAmountsToPoolAssetAmounts[
@@ -299,6 +305,14 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
 
             if (poolAssetAmount > 0) {
                 strategyAssetsToPoolAssetsAmounts[i] = poolAssetAmount;
+
+                /* This check is triggered when the _withdrawal is unexpectedly
+                 * called with a duplicate asset in the _strategyAssets array
+                 */
+                require(
+                    poolAssetsAmountsOut[poolAssetIndex[poolAsset]] == 0,
+                    "No duplicate withdrawal assets"
+                );
 
                 /* Because of the potential Balancer rounding error mentioned below
                  * the contract might receive 1-2 WEI smaller amount than required


### PR DESCRIPTION
This PR adds a check so withdrawal with duplicate assets can not be called. Currently, the deposit with duplicate assets can not be called (contract API doesn't support it) but a future proof check is still added (with a test) to validate duplicate asset deposit calls can also not be made. 

**Audit comments:**
The array arguments passed to `_withdraw` are not validated to ensure that they contain
unique assets. If, in a future extension, it becomes possible to pass duplicates (either due to
user or strategist input), the following impacts may occur:
- The calculated expected BPT from _getBPTExpected may be double-counted.
- Duplicate transfers may be executed, transferring too many tokens to the recipient.

Consider enforcing that poolAssetsAmountsOut[..] is 0 before setting its value.