### PR TITLE
L-04 Inaccurate IBalancerVault Integration Enums

### DIFF
--- a/contracts/contracts/interfaces/balancer/IBalancerVault.sol
+++ b/contracts/contracts/interfaces/balancer/IBalancerVault.sol
@@ -4,25 +4,22 @@ pragma solidity ^0.8.0;
 import { IERC20 } from "../../utils/InitializableAbstractStrategy.sol";
 
 interface IBalancerVault {
-    enum WeightedPoolJoinKind {
+    enum MetaStablePoolJoinKind {
         INIT,
         EXACT_TOKENS_IN_FOR_BPT_OUT,
-        TOKEN_IN_FOR_EXACT_BPT_OUT,
-        ALL_TOKENS_IN_FOR_EXACT_BPT_OUT,
-        ADD_TOKEN
+        TOKEN_IN_FOR_EXACT_BPT_OUT
     }
 
-    enum WeightedPoolExitKind {
+    enum MetaStablePoolExitKind {
         EXACT_BPT_IN_FOR_ONE_TOKEN_OUT,
         EXACT_BPT_IN_FOR_TOKENS_OUT,
-        BPT_IN_FOR_EXACT_TOKENS_OUT,
-        REMOVE_TOKEN
+        BPT_IN_FOR_EXACT_TOKENS_OUT
     }
 
     enum ComposablePoolExitKind {
         EXACT_BPT_IN_FOR_ONE_TOKEN_OUT,
         BPT_IN_FOR_EXACT_TOKENS_OUT,
-        EXACT_BPT_IN_FOR_TOKENS_OUT
+        EXACT_BPT_IN_FOR_ALL_TOKENS_OUT
     }
 
     /**

--- a/contracts/contracts/mocks/MockEvilReentrantContract.sol
+++ b/contracts/contracts/mocks/MockEvilReentrantContract.sol
@@ -54,7 +54,7 @@ contract MockEvilReentrantContract {
         );
 
         bytes memory joinUserData = abi.encode(
-            IBalancerVault.WeightedPoolJoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT,
+            IBalancerVault.MetaStablePoolJoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT,
             amounts,
             minBPT
         );
@@ -73,7 +73,9 @@ contract MockEvilReentrantContract {
 
         // 2. Redeem as ETH
         bytes memory exitUserData = abi.encode(
-            IBalancerVault.WeightedPoolExitKind.EXACT_BPT_IN_FOR_ONE_TOKEN_OUT,
+            IBalancerVault
+                .MetaStablePoolExitKind
+                .EXACT_BPT_IN_FOR_ONE_TOKEN_OUT,
             bptTokenBalance,
             1
         );

--- a/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
@@ -19,7 +19,7 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
      * 
      * enum ExitKind { EXACT_BPT_IN_FOR_ONE_TOKEN_OUT, EXACT_BPT_IN_FOR_TOKENS_OUT, BPT_IN_FOR_EXACT_TOKENS_OUT }
 
-     * For Composable stable pools using IBalancerVault.WeightedPoolExitKind is not
+     * For Composable stable pools using IBalancerVault.MetaStablePoolExitKind is not
      * ok since the enum values are in different order as they are in MetaStable pools.
      * Value should be "1". From the pool code:
      * 
@@ -179,7 +179,7 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
          * [EXACT_TOKENS_IN_FOR_BPT_OUT, amountsIn, minimumBPT]
          */
         bytes memory userData = abi.encode(
-            IBalancerVault.WeightedPoolJoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT,
+            IBalancerVault.MetaStablePoolJoinKind.EXACT_TOKENS_IN_FOR_BPT_OUT,
             _getUserDataEncodedAmounts(amountsIn),
             minBPTwDeviation
         );

--- a/contracts/test/fixture/_hot-deploy.js
+++ b/contracts/test/fixture/_hot-deploy.js
@@ -35,7 +35,10 @@ async function hotDeployBalancerRethWETHStrategy(balancerREthFixture) {
         addresses.mainnet.balancerVault, // Address of the Balancer vault
         balancer_rETH_WETH_PID, // Pool ID of the Balancer pool
       ],
-      [2, 1], //BPT_IN_FOR_EXACT_TOKENS_OUT, EXACT_BPT_IN_FOR_TOKENS_OUT
+      [
+        2, // MetaStablePoolExitKind.BPT_IN_FOR_EXACT_TOKENS_OUT
+        1, // MetaStablePoolExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT
+      ],
       addresses.mainnet.rETH_WETH_AuraRewards, // Address of the Aura rewards contract
     ],
   });

--- a/contracts/utils/balancerStrategyDeployment.js
+++ b/contracts/utils/balancerStrategyDeployment.js
@@ -55,8 +55,8 @@ module.exports = ({
             poolId, // Pool ID of the Balancer pool
           ],
           [
-            2, // WeightedPoolExitKind.BPT_IN_FOR_EXACT_TOKENS_OUT
-            1, // WeightedPoolExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT
+            2, // MetaStablePoolExitKind.BPT_IN_FOR_EXACT_TOKENS_OUT
+            1, // MetaStablePoolExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT
           ],
           auraRewardsContractAddress,
         ],


### PR DESCRIPTION
**Audit notes:**
In `IBalancerVault.sol` , there are several enums which are inaccurate:
- The third value of the `IBalancerVault.ComposablePoolExitKind` enum is named
`EXACT_BPT_IN_FOR_TOKENS_OUT` . Consider changing it to
`EXACT_BPT_IN_FOR_ALL_TOKENS_OUT` in accordance with the the Balancer
documentation.
- The `IBalancerVault.WeightedPoolJoinKind` enum does not fully match any of
the `JoinKinds` from the Balancer documentation. While the actual value used is
correct, the above makes the code error-prone and unnecessarily confusing. Additionally,
it is named incorrectly as it is not the right pool type for the strategy.

Consider using the exact values detailed in the documentation. Additionally, consider adding
links to the documentation in inline comments for ease of validation.