### PR TITLE
L-03 Abstraction of Pool Exit Kinds Is Error-Prone

### DIFF
--- a/contracts/contracts/mocks/BalancerComposablePoolTestStrategy.sol
+++ b/contracts/contracts/mocks/BalancerComposablePoolTestStrategy.sol
@@ -14,13 +14,11 @@ contract BalancerComposablePoolTestStrategy is BalancerComposablePoolStrategy {
     constructor(
         BaseStrategyConfig memory _stratConfig,
         BaseBalancerConfig memory _balancerConfig,
-        BaseMetaPoolConfig memory _metapoolConfig,
         address _auraRewardPoolAddress
     )
         BalancerComposablePoolStrategy(
             _stratConfig,
             _balancerConfig,
-            _metapoolConfig,
             _auraRewardPoolAddress
         )
     {}

--- a/contracts/contracts/mocks/BalancerMetaPoolTestStrategy.sol
+++ b/contracts/contracts/mocks/BalancerMetaPoolTestStrategy.sol
@@ -14,13 +14,11 @@ contract BalancerMetaPoolTestStrategy is BalancerMetaPoolStrategy {
     constructor(
         BaseStrategyConfig memory _stratConfig,
         BaseBalancerConfig memory _balancerConfig,
-        BaseMetaPoolConfig memory _metapoolConfig,
         address _auraRewardPoolAddress
     )
         BalancerMetaPoolStrategy(
             _stratConfig,
             _balancerConfig,
-            _metapoolConfig,
             _auraRewardPoolAddress
         )
     {}

--- a/contracts/contracts/strategies/balancer/BalancerComposablePoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerComposablePoolStrategy.sol
@@ -27,8 +27,8 @@ contract BalancerComposablePoolStrategy is BalancerMetaPoolStrategy {
         )
     {}
 
-    /* enum Value that represents exit encoding where for BPT given
-     * request exactly specifies the minimum amount of underlying assets
+    /* enum Value that represents exit encoding where for max BPT given
+     * request exactly specifies the amount of underlying assets
      * to be returned.
      */
     function _btpInExactTokensOutIndex()
@@ -45,8 +45,8 @@ contract BalancerComposablePoolStrategy is BalancerMetaPoolStrategy {
             );
     }
 
-    /* User encoding where BPT tokens are supplied for proportional exit is required when
-     * calling a withdrawAll
+    /* enum Value that represents exit encoding where BPT tokens are supplied for
+     * proportional exit is required when calling a withdrawAll.
      */
     function _exactBptInTokensOutIndex()
         internal

--- a/contracts/contracts/strategies/balancer/BalancerComposablePoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerComposablePoolStrategy.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.0;
  */
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { BalancerMetaPoolStrategy } from "./BalancerMetaPoolStrategy.sol";
+import { IBalancerVault } from "../../interfaces/balancer/IBalancerVault.sol";
 import { IERC20 } from "../../utils/InitializableAbstractStrategy.sol";
 import { StableMath } from "../../utils/StableMath.sol";
 
@@ -17,16 +18,49 @@ contract BalancerComposablePoolStrategy is BalancerMetaPoolStrategy {
     constructor(
         BaseStrategyConfig memory _stratConfig,
         BaseBalancerConfig memory _balancerConfig,
-        BaseMetaPoolConfig memory _metapoolConfig,
         address _auraRewardPoolAddress
     )
         BalancerMetaPoolStrategy(
             _stratConfig,
             _balancerConfig,
-            _metapoolConfig,
             _auraRewardPoolAddress
         )
     {}
+
+    /* enum Value that represents exit encoding where for BPT given
+     * request exactly specifies the minimum amount of underlying assets
+     * to be returned.
+     */
+    function _btpInExactTokensOutIndex()
+        internal
+        pure
+        override
+        returns (uint256)
+    {
+        return
+            uint256(
+                IBalancerVault
+                    .MetaStablePoolExitKind
+                    .BPT_IN_FOR_EXACT_TOKENS_OUT
+            );
+    }
+
+    /* User encoding where BPT tokens are supplied for proportional exit is required when
+     * calling a withdrawAll
+     */
+    function _exactBptInTokensOutIndex()
+        internal
+        pure
+        override
+        returns (uint256)
+    {
+        return
+            uint256(
+                IBalancerVault
+                    .ComposablePoolExitKind
+                    .EXACT_BPT_IN_FOR_ALL_TOKENS_OUT
+            );
+    }
 
     function _assetConfigVerification(address[] calldata _assets)
         internal

--- a/contracts/contracts/strategies/balancer/BalancerComposablePoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerComposablePoolStrategy.sol
@@ -40,7 +40,7 @@ contract BalancerComposablePoolStrategy is BalancerMetaPoolStrategy {
         return
             uint256(
                 IBalancerVault
-                    .MetaStablePoolExitKind
+                    .ComposablePoolExitKind
                     .BPT_IN_FOR_EXACT_TOKENS_OUT
             );
     }

--- a/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
@@ -340,7 +340,7 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
 
         // STEP 4 - Withdraw the balancer pool assets from the pool
 
-        /* 
+        /*
          * User sends an estimated but unknown (computed at run time) quantity of BPT,
          * and receives precise quantities of specified tokens.
          *

--- a/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
@@ -27,8 +27,8 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
         BaseAuraStrategy(_auraRewardPoolAddress)
     {}
 
-    /* enum Value that represents exit encoding where for BPT given
-     * request exactly specifies the minimum amount of underlying assets
+    /* enum Value that represents exit encoding where for max BPT given
+     * request exactly specifies the amount of underlying assets
      * to be returned.
      */
     function _btpInExactTokensOutIndex()

--- a/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
@@ -45,9 +45,8 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
             );
     }
 
-    /* User encoding where BPT tokens are supplied for proportional exit is required when
-     * calling a withdrawAll. For MetaStablePools that enum value is called EXACT_BPT_IN_FOR_TOKENS_OUT -
-     * value "1" and for ComposableStablePools it is called EXACT_BPT_IN_FOR_ALL_TOKENS_OUT value "2".
+    /* enum Value that represents exit encoding where BPT tokens are supplied for
+     * proportional exit is required when calling a withdrawAll.
      */
     function _exactBptInTokensOutIndex()
         internal
@@ -341,12 +340,12 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
 
         // STEP 4 - Withdraw the balancer pool assets from the pool
 
-        /* Custom asset exit: BPT_IN_FOR_EXACT_TOKENS_OUT:
+        /* 
          * User sends an estimated but unknown (computed at run time) quantity of BPT,
          * and receives precise quantities of specified tokens.
          *
          * ['uint256', 'uint256[]', 'uint256']
-         * [BPT_IN_FOR_EXACT_TOKENS_OUT, amountsOut, maxBPTAmountIn]
+         * [USER_ENCODING_ENUM, amountsOut, maxBPTAmountIn]
          */
         bytes memory userData = abi.encode(
             _btpInExactTokensOutIndex(),
@@ -432,12 +431,12 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
         uint256[] memory minAmountsOut = new uint256[](poolAssets.length);
 
         // STEP 2 - Withdraw the Balancer pool assets from the pool
-        /* Proportional exit: EXACT_BPT_IN_FOR_TOKENS_OUT:
+        /* Proportional exit:
          * User sends a precise quantity of BPT, and receives an estimated but unknown
          * (computed at run time) quantity of a single token
          *
          * ['uint256', 'uint256']
-         * [EXACT_BPT_IN_FOR_TOKENS_OUT, bptAmountIn]
+         * [USER_ENCODING_ENUM, bptAmountIn]
          *
          * It is ok to pass an empty minAmountsOut since tilting the pool in any direction
          * when doing a proportional exit can only be beneficial to the strategy. Since

--- a/contracts/deploy/078_balancer_sfrxETH_wstETH_rETH.js
+++ b/contracts/deploy/078_balancer_sfrxETH_wstETH_rETH.js
@@ -51,10 +51,6 @@ module.exports = deploymentWithGovernanceProposal(
           addresses.mainnet.balancerVault, // Address of the Balancer vault
           balancer_wstETH_sfrxETH_rETH_PID, // Pool ID of the Balancer pool
         ],
-        [
-          1, // ComposablePoolExitKind.BPT_IN_FOR_EXACT_TOKENS_OUT
-          2, // ComposablePoolExitKind.EXACT_BPT_IN_FOR_(ALL_)TOKENS_OUT
-        ],
         addresses.mainnet.wstETH_sfrxETH_rETH_AuraRewards, // Address of the Aura rewards contract
       ]);
     const cOETHBalancerComposablePoolStrategy = await ethers.getContractAt(

--- a/contracts/test/fixture/_hot-deploy.js
+++ b/contracts/test/fixture/_hot-deploy.js
@@ -35,10 +35,6 @@ async function hotDeployBalancerRethWETHStrategy(balancerREthFixture) {
         addresses.mainnet.balancerVault, // Address of the Balancer vault
         balancer_rETH_WETH_PID, // Pool ID of the Balancer pool
       ],
-      [
-        2, // MetaStablePoolExitKind.BPT_IN_FOR_EXACT_TOKENS_OUT
-        1, // MetaStablePoolExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT
-      ],
       addresses.mainnet.rETH_WETH_AuraRewards, // Address of the Aura rewards contract
     ],
   });
@@ -87,10 +83,6 @@ async function hotDeployBalancerFrxEethRethWstEThStrategy(
         addresses.mainnet.sfrxETH,
         addresses.mainnet.balancerVault, // Address of the Balancer vault
         balancer_wstETH_sfrxETH_rETH_PID, // Pool ID of the Balancer pool
-      ],
-      [
-        1, // ComposablePoolExitKind.BPT_IN_FOR_EXACT_TOKENS_OUT
-        2, // ComposablePoolExitKind.EXACT_BPT_IN_FOR_(ALL_)TOKENS_OUT
       ],
       addresses.mainnet.wstETH_sfrxETH_rETH_AuraRewards, // Address of the Aura rewards contract
     ],

--- a/contracts/utils/balancerStrategyDeployment.js
+++ b/contracts/utils/balancerStrategyDeployment.js
@@ -54,10 +54,6 @@ module.exports = ({
             addresses.mainnet.balancerVault, // Address of the Balancer vault
             poolId, // Pool ID of the Balancer pool
           ],
-          [
-            2, // MetaStablePoolExitKind.BPT_IN_FOR_EXACT_TOKENS_OUT
-            1, // MetaStablePoolExitKind.EXACT_BPT_IN_FOR_TOKENS_OUT
-          ],
           auraRewardsContractAddress,
         ],
         null,


### PR DESCRIPTION
**Audit notes:**
The use of different enum indices, namely `balancerBptInExactTokensOutIndex` and
`balancerExactBptInTokensOutIndex` , to be passed to Balancer for different pool types
is achieved by passing constructor input arguments and storing immutable variables.

However, this approach is error-prone. It reduces readability and makes it difficult for off-chain
tooling and governance to correctly test and pass the arguments during deployment, and verify
the result. As such, any mistake in setting these values could have severe consequences.

Consider creating and overriding internal functions in each class. This will not increase the gas
usage but will ensure that the correct value is always used for each concrete contract. A
simplified example is shown below:

```python
contract A {
    function _someValue() internal pure virtual returns(uint) { return 1; }
}

contract B is A {
    function _someValue() internal pure override returns(uint) { return 2; }
}
```