### PR TITLE
N-02 ERC-20 Approval Issues

### DIFF
--- a/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
@@ -553,6 +553,13 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
      */
     function _approveAsset(address _asset) internal {
         IERC20 asset = IERC20(_asset);
+        /* Double approve is not required with the assets supported by the
+         * strategies today. This is defensive, future proof programming
+         * in case we ever utilize this asset for OUSD supporting non completely
+         * ERC20 compliant tokens (e.g. USDT)
+         */
+        // slither-disable-next-line unused-return
+        asset.approve(address(balancerVault), 0);
         // slither-disable-next-line unused-return
         asset.approve(address(balancerVault), type(uint256).max);
     }

--- a/contracts/contracts/strategies/balancer/BaseBalancerStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BaseBalancerStrategy.sol
@@ -516,8 +516,6 @@ abstract contract BaseBalancerStrategy is InitializableAbstractStrategy {
 
         // Balancer vault for BPT token (required for removing liquidity)
         // slither-disable-next-line unused-return
-        pToken.approve(address(balancerVault), 0);
-        // slither-disable-next-line unused-return
         pToken.approve(address(balancerVault), type(uint256).max);
     }
 


### PR DESCRIPTION
**Audit notes:**
- A single approval is used to grant the approval for an asset token. However, an asset
token like USDT can be non-compliant and may revert if the approval is not reset before
this approval call. This may block repeated execution of safeApproveAllTokens .
Although the LST tokens used in the current strategy do not have this issue, if the code
is extended to also use Balancer strategies for other assets (e.g., for the tokens backing
OUSD), this may become an issue. Consider documenting this possibility or renaming
the function to _approveERC20CompliantAsset . Alternatively, consider following the
double approval pattern.
- A double approval is used for the BPT. However, this is unnecessary as the BPTs are
ERC-20-compliant tokens. Consider only doing one approve in this case.