### PR TITLE
L-02 Balancer Pool Recovery Mode Is Not Supported

### DIFF
--- a/contracts/contracts/interfaces/balancer/IBalancerPool.sol
+++ b/contracts/contracts/interfaces/balancer/IBalancerPool.sol
@@ -8,4 +8,6 @@ interface IBalancerPool {
         external
         view
         returns (IRateProvider[] memory providers);
+
+    function inRecoveryMode() external view returns (bool);
 }

--- a/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
@@ -8,12 +8,17 @@ pragma solidity ^0.8.0;
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { BaseAuraStrategy, BaseBalancerStrategy } from "./BaseAuraStrategy.sol";
 import { IBalancerVault } from "../../interfaces/balancer/IBalancerVault.sol";
+import { IBalancerPool } from "../../interfaces/balancer/IBalancerPool.sol";
 import { IERC20, InitializableAbstractStrategy } from "../../utils/InitializableAbstractStrategy.sol";
 import { StableMath } from "../../utils/StableMath.sol";
 
 contract BalancerMetaPoolStrategy is BaseAuraStrategy {
     using SafeERC20 for IERC20;
     using StableMath for uint256;
+
+    // Special ExitKind for all Balancer pools, used in Recovery Mode.
+    uint256 constant RECOVERY_MODE_EXIT_KIND = 255;
+
     /* For Meta stable pools the enum value should be "2" as it is defined 
      * in the IBalancerVault. From the Metastable pool codebase:
      * 
@@ -421,6 +426,18 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
      * Is only executable by the OToken's Vault or the Governor.
      */
     function withdrawAll() external override onlyVaultOrGovernor nonReentrant {
+        _withdrawAll(false);
+    }
+
+    function recoveryModeWithdrawAll()
+        external
+        onlyVaultOrGovernor
+        nonReentrant
+    {
+        _withdrawAll(true);
+    }
+
+    function _withdrawAll(bool isRecoveryModeWithdrawal) internal {
         // STEP 1 - Withdraw all Balancer Pool Tokens (BPT) from Aura to this strategy contract
 
         _lpWithdrawAll();
@@ -441,11 +458,26 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
          * It is ok to pass an empty minAmountsOut since tilting the pool in any direction
          * when doing a proportional exit can only be beneficial to the strategy. Since
          * it will receive more of the underlying tokens for the BPT traded in.
+         *
+         * Important when `isRecoveryModeWithdrawal` is true then a special recovery mode exit
+         * kind is used for a much simpler and more gas efficient exit of the pool.
          */
         bytes memory userData = abi.encode(
-            balancerExactBptInTokensOutIndex,
+            isRecoveryModeWithdrawal
+                ? RECOVERY_MODE_EXIT_KIND
+                : balancerExactBptInTokensOutIndex,
             BPTtoWithdraw
         );
+
+        if (isRecoveryModeWithdrawal) {
+            /* Older Balancer pools don't support this functionality (e.g. rETH/WETH). In that case the
+             * transaction will just fail as it should.
+             */
+            require(
+                IBalancerPool(platformAddress).inRecoveryMode(),
+                "Pool not in recovery mode"
+            );
+        }
 
         IBalancerVault.ExitPoolRequest memory request = IBalancerVault
             .ExitPoolRequest(poolAssets, minAmountsOut, userData, false);

--- a/contracts/test/fixture/_fixture.js
+++ b/contracts/test/fixture/_fixture.js
@@ -1022,6 +1022,19 @@ async function balancerFrxETHwstETHeETHFixture(
     josh
   );
 
+  /* balancer Gnosis safe authorized account
+   * Use this Dube query to get relevant transactions: 
+   - https://dune.com/queries/3184026
+   */
+  const authorizerAddress = "0xa29f61256e948f3fb707b4b3b138c5ccb9ef9888";
+  const recoveryModeSigner = await impersonateAndFund(authorizerAddress);
+
+  fixture.enableRecoveryMode = async () => {
+    await fixture.sfrxETHwstETHrEthBPT
+      .connect(recoveryModeSigner)
+      .enableRecoveryMode();
+  };
+
   await setERC20TokenBalance(josh.address, reth, "1000000", hre);
   await setERC20TokenBalance(josh.address, frxETH, "1000000", hre);
   await setERC20TokenBalance(josh.address, stETH, "1000000", hre);

--- a/contracts/test/strategies/balancerMetaStablePool.fork-test.js
+++ b/contracts/test/strategies/balancerMetaStablePool.fork-test.js
@@ -369,6 +369,16 @@ describe("ForkTest: Balancer MetaStablePool rETH/WETH Strategy", function () {
       expect(stEthBalanceDiff).to.be.gte(await units("15", reth), 1);
     });
 
+    it("Should fail withdrawing all of pool liquidity in recovery mode (pool doesn't support it)", async function () {
+      const { oethVault, balancerREthStrategy } = fixture;
+
+      const oethVaultSigner = await impersonateAndFund(oethVault.address);
+
+      await expect(
+        balancerREthStrategy.connect(oethVaultSigner).recoveryModeWithdrawAll()
+      ).to.be.reverted;
+    });
+
     it("Should be able to withdraw with higher withdrawal deviation", async function () {});
   });
 


### PR DESCRIPTION
Balancer pools may enter a recovery mode, allowing for a simplified exit code path in case the
usual exit path malfunctions. In order to be able to exit when this mode is enabled, userData
must be specifically encoded to signal the exit path type.

According to the recent Balancer post-mortem, the recovery mode is an important feature that
has already been used several times:
`It has saved us more than once, including during the present incident.`

Consider supporting this exit path via an additional withdrawal function.