### PR TITLE
N-05 Missing Docstrings

### DIFF
--- a/contracts/contracts/strategies/balancer/BalancerComposablePoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerComposablePoolStrategy.sol
@@ -38,7 +38,8 @@ contract BalancerComposablePoolStrategy is BalancerMetaPoolStrategy {
         bptTokenPoolPosition = _bptTokenPoolPosition;
     }
 
-    /* enum Value that represents exit encoding where for max BPT given
+    /*
+     * @dev Value that represents exit encoding where for max BPT given
      * request exactly specifies the amount of underlying assets
      * to be returned.
      */
@@ -56,7 +57,8 @@ contract BalancerComposablePoolStrategy is BalancerMetaPoolStrategy {
             );
     }
 
-    /* enum Value that represents exit encoding where BPT tokens are supplied for
+    /*
+     * @dev Value that represents exit encoding where BPT tokens are supplied for
      * proportional exit is required when calling a withdrawAll.
      */
     function _exactBptInTokensOutIndex()

--- a/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol
@@ -17,7 +17,7 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
     using SafeERC20 for IERC20;
     using StableMath for uint256;
 
-    // Special ExitKind for all Balancer pools, used in Recovery Mode.
+    /// @dev Special ExitKind for all Balancer pools, used in Recovery Mode.
     uint256 constant RECOVERY_MODE_EXIT_KIND = 255;
 
     int256[50] private ___reserved;
@@ -32,7 +32,8 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
         BaseAuraStrategy(_auraRewardPoolAddress)
     {}
 
-    /* enum Value that represents exit encoding where for max BPT given
+    /*
+     * @dev enum Value that represents exit encoding where for max BPT given
      * request exactly specifies the amount of underlying assets
      * to be returned.
      */
@@ -50,7 +51,8 @@ contract BalancerMetaPoolStrategy is BaseAuraStrategy {
             );
     }
 
-    /* enum Value that represents exit encoding where BPT tokens are supplied for
+    /*
+     * @dev enum Value that represents exit encoding where BPT tokens are supplied for
      * proportional exit is required when calling a withdrawAll.
      */
     function _exactBptInTokensOutIndex()

--- a/contracts/contracts/strategies/balancer/BaseBalancerStrategy.sol
+++ b/contracts/contracts/strategies/balancer/BaseBalancerStrategy.sol
@@ -21,11 +21,11 @@ abstract contract BaseBalancerStrategy is InitializableAbstractStrategy {
     using StableMath for uint256;
 
     /*
-     * When redeeming sfrxETH for frxETH there is usually a 1 WEI rounding
+     * @dev When redeeming sfrxETH for frxETH there is usually a 1 WEI rounding
      * error. To mitigate this issue we overshoot by 1 WEI when redeeming.
      */
     uint256 public constant FRX_ETH_REDEEM_CORRECTION = 1;
-    // A constant representing a rate provider with a fixed 1e18 rate
+    /// @dev A constant representing a rate provider with a fixed 1e18 rate
     address public constant FIXED_RATE_PROVIDER =
         0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
@@ -40,16 +40,17 @@ abstract contract BaseBalancerStrategy is InitializableAbstractStrategy {
     /// @notice Balancer pool identifier
     bytes32 public immutable balancerPoolId;
 
-    // Max withdrawal deviation denominated in 1e18 (1e18 == 100%)
+    /// @notice Max withdrawal deviation denominated in 1e18 (1e18 == 100%)
     uint256 public maxWithdrawalDeviation;
-    // Max deposit deviation denominated in 1e18 (1e18 == 100%)
+    /// @notice Max deposit deviation denominated in 1e18 (1e18 == 100%)
     uint256 public maxDepositDeviation;
-    // Cache of asset => rateProvider
+    /// @dev Cache of asset => rateProvider
     mapping(address => address) public assetToRateProviderCache;
 
-    // all the pool assets as returned by the balancerVault.getPoolTokens() function
+    /// @dev all the pool assets as returned by the balancerVault.getPoolTokens() function
     address[] public poolAssets;
-    /* A mapping of pool asset address to asset index. With Balancer the
+
+    /* @dev A mapping of pool asset address to asset index. With Balancer the
      * configured order of the pool assets is important and never changes.
      * For those reasons these assets are cached as they greatly simplify the
      * code and make it more gas efficient.


### PR DESCRIPTION

**Audit notes:**
Several parts of the [codebase](https://github.com/OriginProtocol/origin-dollar/tree/f0cb237347faa7c650787498e127aba7e0c0488a) either have no documentation, or the documentation is not in NatSpec format:

In the [BalancerMetaPoolStrategy contract](https://github.com/OriginProtocol/origin-dollar/blob/f0cb237347faa7c650787498e127aba7e0c0488a/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol), lines [28](https://github.com/OriginProtocol/origin-dollar/blob/f0cb237347faa7c650787498e127aba7e0c0488a/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol#L28) and [34](https://github.com/OriginProtocol/origin-dollar/blob/f0cb237347faa7c650787498e127aba7e0c0488a/contracts/contracts/strategies/balancer/BalancerMetaPoolStrategy.sol#L34)
In the [BaseBalancerStrategy contract](https://github.com/OriginProtocol/origin-dollar/blob/f0cb237347faa7c650787498e127aba7e0c0488a/contracts/contracts/strategies/balancer/BaseBalancerStrategy.sol), lines [27](https://github.com/OriginProtocol/origin-dollar/blob/f0cb237347faa7c650787498e127aba7e0c0488a/contracts/contracts/strategies/balancer/BaseBalancerStrategy.sol#L27), [29](https://github.com/OriginProtocol/origin-dollar/blob/f0cb237347faa7c650787498e127aba7e0c0488a/contracts/contracts/strategies/balancer/BaseBalancerStrategy.sol#L29), [44](https://github.com/OriginProtocol/origin-dollar/blob/f0cb237347faa7c650787498e127aba7e0c0488a/contracts/contracts/strategies/balancer/BaseBalancerStrategy.sol#L44), [46](https://github.com/OriginProtocol/origin-dollar/blob/f0cb237347faa7c650787498e127aba7e0c0488a/contracts/contracts/strategies/balancer/BaseBalancerStrategy.sol#L46), [48](https://github.com/OriginProtocol/origin-dollar/blob/f0cb237347faa7c650787498e127aba7e0c0488a/contracts/contracts/strategies/balancer/BaseBalancerStrategy.sol#L48), [51](https://github.com/OriginProtocol/origin-dollar/blob/f0cb237347faa7c650787498e127aba7e0c0488a/contracts/contracts/strategies/balancer/BaseBalancerStrategy.sol#L51), and [57](https://github.com/OriginProtocol/origin-dollar/blob/f0cb237347faa7c650787498e127aba7e0c0488a/contracts/contracts/strategies/balancer/BaseBalancerStrategy.sol#L57)
Consider ensuring that all the above instances of code have the proper documentation written in NatSpec format. This would ensure that tools like Etherscan can accurately render these comments.