### PR TITLE
Discovery day: check for ".only" and prevent commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+RED='\033[0;31m'
+NC='\033[0m'
+GREEN='\033[0;32m'
+files=""
+# find all file ending with test.js that are not in node_modules
+for file in $(find . -type d -name node_modules -prune -o -name '*test.js' -print); do
+    # uncomment below to debug which files match
+    # echo "$file"
+		# search if any contain it.only or describe.only
+		match=$(grep -E "(describe|it)\.only[[:space:]]*\(" "$file")
+
+		# add together the files containing .only
+    if [[ -n "${match}" ]]; then
+    	files=${files}${file}'\n'
+    fi
+done
+if [[ -n "${files}" ]]; then
+	# fail pre-commit if
+	echo "${RED}Git pre-commit hook failed! Remove \".only\" from the following test file(s):${GREEN}"
+	echo ${files}
+	echo "${NC}"
+	exit 1
+fi

--- a/README.md
+++ b/README.md
@@ -221,3 +221,19 @@ Want to contribute to OUSD? Awesome!
 OUSD is an Open Source project and we welcome contributions of all sorts. There are many ways to help, from reporting issues, contributing to the code, and helping us improve our community.
 
 The best way to get involved is to join the Origin Protocol [discord server](https://discord.gg/jyxpUSe) and head over to the channel named ORIGIN DOLLAR & DEFI
+
+# Utils
+
+## Git pre-commit hooks (using Husky)
+
+### Setup
+```
+# install Husky
+npx install husky
+
+# from project root folder install Husky hooks
+npx husky install
+
+```
+
+If the script in .husky/pre-commit returns non 0 exit the pre-commit hook will fail. Currently the script prevents a commit if there is an ".only" in the test scripts. Use "git commit --no-verify" if you have the hook enabled and you'd like to skip pre-commit check.


### PR DESCRIPTION
This PR adds a husky enabled git pre-commit hook that scans all test (unit & fork) files for the presence of ".only" modifier that is used for local testing. If found the commit fails. This is an example of a failure: 

![Screenshot 2023-11-17 at 23 20 43](https://github.com/OriginProtocol/origin-dollar/assets/579910/ac9297e8-75b7-4372-a987-5bf5f1a66fe4)
