### PR TITLE
enable rebaseOptIn by the governor

### DIFF
--- a/contracts/contracts/token/OUSD.sol
+++ b/contracts/contracts/token/OUSD.sol
@@ -30,8 +30,8 @@ contract OUSD is Initializable, InitializableERC20Detailed, Governable {
         uint256 rebasingCredits,
         uint256 rebasingCreditsPerToken
     );
-    event RebaseOptIn(address account);
-    event RebaseOptOut(address account);
+    event AccountRebasingEnabled(address account);
+    event AccountRebasingDisabled(address account);
 
     enum RebaseOptions {
         NotSet,
@@ -471,6 +471,7 @@ contract OUSD is Initializable, InitializableERC20Detailed, Governable {
      */
     function _ensureRebasingMigration(address _account) internal {
         if (nonRebasingCreditsPerToken[_account] == 0) {
+            emit AccountRebasingDisabled(_account);
             if (_creditBalances[_account] == 0) {
                 // Since there is no existing balance, we can directly set to
                 // high resolution, and do not have to do any other bookkeeping
@@ -497,7 +498,11 @@ contract OUSD is Initializable, InitializableERC20Detailed, Governable {
      * to upside and downside.
      * @param _account Address of the account.
      */
-    function governanceRebaseOptIn(address _account) public nonReentrant onlyGovernor {
+    function governanceRebaseOptIn(address _account)
+        public
+        nonReentrant
+        onlyGovernor
+    {
         _rebaseOptIn(_account);
     }
 
@@ -531,7 +536,7 @@ contract OUSD is Initializable, InitializableERC20Detailed, Governable {
 
         // Delete any fixed credits per token
         delete nonRebasingCreditsPerToken[_account];
-        emit RebaseOptIn(_account);
+        emit AccountRebasingEnabled(_account);
     }
 
     /**
@@ -551,7 +556,7 @@ contract OUSD is Initializable, InitializableERC20Detailed, Governable {
 
         // Mark explicitly opted out of rebasing
         rebaseState[msg.sender] = RebaseOptions.OptOut;
-        emit RebaseOptOut(msg.sender);
+        emit AccountRebasingDisabled(msg.sender);
     }
 
     /**

--- a/contracts/deploy/082_upgrade_oeth.js
+++ b/contracts/deploy/082_upgrade_oeth.js
@@ -1,0 +1,44 @@
+const { deploymentWithGovernanceProposal } = require("../utils/deploy");
+
+module.exports = deploymentWithGovernanceProposal(
+  {
+    deployName: "082_upgrade_oeth",
+    forceDeploy: false,
+    reduceQueueTime: true,
+    deployerIsProposer: true
+  },
+  async ({ ethers, deployWithConfirmation }) => {
+    const cOETHProxy = await ethers.getContract("OETHProxy");
+    const eigenLayerStrategyContract = "0xa4c637e0f704745d182e4d38cab7e7485321d059";
+
+    // Deploy new version of OETH contract
+    const dOETHImpl = await deployWithConfirmation(
+      "OETH",
+      []
+    );
+
+    const cOETH = await ethers.getContractAt(
+      "OETH",
+      cOETHProxy.address
+    );
+
+    // Governance Actions
+    // ----------------
+    return {
+      name: "Upgrade the OETH AMO strategy with peg keeping functions.",
+      actions: [
+        // Upgrade the OETH token proxy contract to the new implementation
+        {
+          contract: cOETHProxy,
+          signature: "upgradeTo(address)",
+          args: [dOETHImpl.address],
+        },
+        {
+          contract: cOETH,
+          signature: "governanceRebaseOptIn(address)",
+          args: [eigenLayerStrategyContract],
+        },
+      ],
+    };
+  }
+);

--- a/contracts/deploy/082_upgrade_oeth.js
+++ b/contracts/deploy/082_upgrade_oeth.js
@@ -5,22 +5,17 @@ module.exports = deploymentWithGovernanceProposal(
     deployName: "082_upgrade_oeth",
     forceDeploy: false,
     reduceQueueTime: true,
-    deployerIsProposer: true
+    deployerIsProposer: true,
   },
   async ({ ethers, deployWithConfirmation }) => {
     const cOETHProxy = await ethers.getContract("OETHProxy");
-    const eigenLayerStrategyContract = "0xa4c637e0f704745d182e4d38cab7e7485321d059";
+    const eigenLayerStrategyContract =
+      "0xa4c637e0f704745d182e4d38cab7e7485321d059";
 
     // Deploy new version of OETH contract
-    const dOETHImpl = await deployWithConfirmation(
-      "OETH",
-      []
-    );
+    const dOETHImpl = await deployWithConfirmation("OETH", []);
 
-    const cOETH = await ethers.getContractAt(
-      "OETH",
-      cOETHProxy.address
-    );
+    const cOETH = await ethers.getContractAt("OETH", cOETHProxy.address);
 
     // Governance Actions
     // ----------------

--- a/contracts/node.sh
+++ b/contracts/node.sh
@@ -61,7 +61,6 @@ main()
         printf "\n"
         echo "🟢 Node initialized"
 
-        FORK=true npm run copy-interface-artifacts
         FORK=true npx hardhat fund --amount 100000 --network localhost --accountsfromenv true &
         
         # wait for subprocesses to finish

--- a/contracts/test/token/oeth.fork-test.js
+++ b/contracts/test/token/oeth.fork-test.js
@@ -1,9 +1,7 @@
 const { expect } = require("chai");
 
 const { loadDefaultFixture } = require("./../_fixture");
-const {
-  isCI,
-} = require("./../helpers");
+const { isCI } = require("./../helpers");
 
 /**
  * Regarding hardcoded addresses:
@@ -34,7 +32,8 @@ describe("ForkTest: OETH", function () {
     // These tests use a transaction to call a view function so the gas usage can be reported.
     it("Should get total value", async () => {
       const { oeth } = fixture;
-      const eigenLayerStrategyContract = "0xa4c637e0f704745d182e4d38cab7e7485321d059";
+      const eigenLayerStrategyContract =
+        "0xa4c637e0f704745d182e4d38cab7e7485321d059";
       // 2 equals OptIn
       expect(await oeth.rebaseState(eigenLayerStrategyContract)).to.be.equal(2);
     });

--- a/contracts/test/token/oeth.fork-test.js
+++ b/contracts/test/token/oeth.fork-test.js
@@ -1,0 +1,42 @@
+const { expect } = require("chai");
+
+const { loadDefaultFixture } = require("./../_fixture");
+const {
+  isCI,
+} = require("./../helpers");
+
+/**
+ * Regarding hardcoded addresses:
+ * The addresses are hardcoded in the test files (instead of
+ * using them from addresses.js) intentionally. While importing and
+ * using the variables from that file increases readability, it may
+ * result in it being a single point of failure. Anyone can update
+ * the addresses.js file and it may go unnoticed.
+ *
+ * Points against this: The on-chain data would still be correct,
+ * making the tests to fail in case only addresses.js is updated.
+ *
+ * Still open to discussion.
+ */
+
+describe("ForkTest: OETH", function () {
+  this.timeout(0);
+
+  // Retry up to 3 times on CI
+  this.retries(isCI ? 3 : 0);
+
+  let fixture;
+  beforeEach(async () => {
+    fixture = await loadDefaultFixture();
+  });
+
+  describe("verify state", () => {
+    // These tests use a transaction to call a view function so the gas usage can be reported.
+    it("Should get total value", async () => {
+      const { oeth } = fixture;
+      const eigenLayerStrategyContract = "0xa4c637e0f704745d182e4d38cab7e7485321d059";
+      // 2 equals OptIn
+      expect(await oeth.rebaseState(eigenLayerStrategyContract)).to.be.equal(2);
+    });
+  });
+});

--- a/contracts/test/token/ousd.js
+++ b/contracts/test/token/ousd.js
@@ -430,8 +430,8 @@ describe("Token", function () {
 
     const rebaseTx = await mockNonRebasing.rebaseOptIn();
     await expect(rebaseTx)
-        .to.emit(ousd, "RebaseOptIn")
-        .withArgs(mockNonRebasing.address);
+      .to.emit(ousd, "AccountRebasingEnabled")
+      .withArgs(mockNonRebasing.address);
 
     await expect(mockNonRebasing).has.an.approxBalanceOf("99.50", ousd);
     expect(await ousd.totalSupply()).to.equal(totalSupplyBefore);
@@ -477,8 +477,8 @@ describe("Token", function () {
 
     const rebaseTx = await ousd.connect(matt).rebaseOptOut();
     await expect(rebaseTx)
-        .to.emit(ousd, "RebaseOptOut")
-        .withArgs(matt.address);
+      .to.emit(ousd, "AccountRebasingDisabled")
+      .withArgs(matt.address);
 
     // Received 100 from the rebase, the 200 simulated yield was split between
     // Matt and Josh
@@ -682,7 +682,15 @@ describe("Token", function () {
       vault.address,
       daiUnits("100")
     );
-    await mockNonRebasing.mintOusd(vault.address, dai.address, daiUnits("50"));
+    const tx = await mockNonRebasing.mintOusd(
+      vault.address,
+      dai.address,
+      daiUnits("50")
+    );
+    await expect(tx)
+      .to.emit(ousd, "AccountRebasingDisabled")
+      .withArgs(mockNonRebasing.address);
+
     await expect(await ousd.totalSupply()).to.equal(
       totalSupplyBefore.add(ousdUnits("50"))
     );

--- a/contracts/test/token/ousd.js
+++ b/contracts/test/token/ousd.js
@@ -427,7 +427,12 @@ describe("Token", function () {
 
     const totalSupplyBefore = await ousd.totalSupply();
     await expect(mockNonRebasing).has.an.approxBalanceOf("99.50", ousd);
-    await mockNonRebasing.rebaseOptIn();
+
+    const rebaseTx = await mockNonRebasing.rebaseOptIn();
+    await expect(rebaseTx)
+        .to.emit(ousd, "RebaseOptIn")
+        .withArgs(mockNonRebasing.address);
+
     await expect(mockNonRebasing).has.an.approxBalanceOf("99.50", ousd);
     expect(await ousd.totalSupply()).to.equal(totalSupplyBefore);
 
@@ -470,7 +475,11 @@ describe("Token", function () {
     const initialrebasingCreditsPerTokenHighres =
       await ousd.rebasingCreditsPerTokenHighres();
 
-    await ousd.connect(matt).rebaseOptOut();
+    const rebaseTx = await ousd.connect(matt).rebaseOptOut();
+    await expect(rebaseTx)
+        .to.emit(ousd, "RebaseOptOut")
+        .withArgs(matt.address);
+
     // Received 100 from the rebase, the 200 simulated yield was split between
     // Matt and Josh
     await expect(matt).has.an.approxBalanceOf("200.00", ousd);


### PR DESCRIPTION
- enable the governor to toggle rebaseOptIn on
- add events to rebase opt in/out
- remove copy artefacts that is no longer needed
- enable rebasing for [eigenLayer contract](https://etherscan.io/address/0xa4c637e0f704745d182e4d38cab7e7485321d059)