### PR TITLE
Shorten Dripper Duration

### DIFF
--- a/contracts/deploy/083_dripper_seven_day.js
+++ b/contracts/deploy/083_dripper_seven_day.js
@@ -12,12 +12,10 @@ module.exports = deploymentWithGovernanceProposal(
   async ({ deployWithConfirmation, ethers }) => {
     // Current contracts
     const cOETHDripperProxy = await ethers.getContract("OETHDripperProxy");
-    const cOETHDripper = await ethers.getContract(
+    const cOETHDripper = await ethers.getContractAt(
       "OETHDripper",
       cOETHDripperProxy.address
     );
-
-    // cOETHDripper.collectAndRebase();
 
     // Governance Actions
     // ----------------

--- a/contracts/deploy/083_dripper_seven_day.js
+++ b/contracts/deploy/083_dripper_seven_day.js
@@ -9,7 +9,7 @@ module.exports = deploymentWithGovernanceProposal(
     // reduceQueueTime: true, // just to solve the issue of later active proposals failing
     //proposalId: ""
   },
-  async ({ deployWithConfirmation, ethers }) => {
+  async ({ ethers }) => {
     // Current contracts
     const cOETHDripperProxy = await ethers.getContract("OETHDripperProxy");
     const cOETHDripper = await ethers.getContractAt(

--- a/contracts/deploy/083_dripper_seven_day.js
+++ b/contracts/deploy/083_dripper_seven_day.js
@@ -1,0 +1,47 @@
+const { deploymentWithGovernanceProposal } = require("../utils/deploy");
+
+module.exports = deploymentWithGovernanceProposal(
+  {
+    deployName: "083_dripper_seven_day",
+    forceDeploy: false,
+    // forceSkip: true,
+    // onlyOnFork: true, // this is only executed in forked environment
+    // reduceQueueTime: true, // just to solve the issue of later active proposals failing
+    //proposalId: ""
+  },
+  async ({ deployWithConfirmation, ethers }) => {
+    // Current contracts
+    const cOETHDripperProxy = await ethers.getContract("OETHDripperProxy");
+    const cOETHDripper = await ethers.getContract(
+      "OETHDripper",
+      cOETHDripperProxy.address
+    );
+
+    // cOETHDripper.collectAndRebase();
+
+    // Governance Actions
+    // ----------------
+    return {
+      name: "Shorten OETH Dripper Time\n\
+      \n\
+      Change the OETH dripper time down to 7 days.\n\
+      \n\
+      The OETH dripper's duration was set to a long 14 days last month to avoid dripping out all AURA and BAL token rewards too quickly.\
+      Now that some time has passed, we can reduce the duration to a more normal size. \
+      In the short term this will result in increase of funds flowing from the dripper to OETH.\
+      ",
+      actions: [
+        {
+          contract: cOETHDripper,
+          signature: "setDripDuration(uint256)",
+          args: [7 * 24 * 60 * 60],
+        },
+        {
+          contract: cOETHDripper,
+          signature: "collectAndRebase()",
+          args: [],
+        },
+      ],
+    };
+  }
+);


### PR DESCRIPTION
Change the OETH dripper time down to 7 days.

The OETH dripper's duration was set to a long 14 days last month to avoid dripping out all AURA and BAL token rewards too quickly. Now that some time has passed, we can reduce the duration to a more normal size. In the short term this will result in increase of funds flowing from the dripper to OETH.