### PR TITLE
Fix tests on master and .only linter

### DIFF
--- a/contracts/.eslintrc.js
+++ b/contracts/.eslintrc.js
@@ -18,5 +18,8 @@ module.exports = {
     getNamedAccounts: "readable",
     hre: "readable",
   },
-  rules: {},
+  plugins: ["no-only-tests"],
+  rules: {
+    "no-only-tests/no-only-tests": "error",
+  },
 };

--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -1,14 +1,11 @@
 const ethers = require("ethers");
 const { task } = require("hardhat/config");
 const {
-  isFork,
   isArbitrumFork,
   isHoleskyFork,
   isHolesky,
   isForkTest,
-  isArbForkTest,
   isHoleskyForkTest,
-  providerUrl,
   arbitrumProviderUrl,
   holeskyProviderUrl,
   adjustTheForkBlockNumber,

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -57,6 +57,7 @@
     "debug": "^4.3.4",
     "dotenv": "^10.0.0",
     "eslint": "^7.32.0",
+    "eslint-plugin-no-only-tests": "^3.1.0",
     "ethereum-waffle": "^4.0.10",
     "ethers": "^5.4.6",
     "hardhat": "^2.14.1",

--- a/contracts/test/strategies/oeth-metapool.fork-test.js
+++ b/contracts/test/strategies/oeth-metapool.fork-test.js
@@ -94,7 +94,7 @@ describe("ForkTest: OETH AMO Curve Metapool Strategy", function () {
       );
       await oethVault.connect(josh).rebase();
 
-      await expect(wethDiff).to.be.gte(parseUnits("0.2"));
+      await expect(wethDiff).to.be.gte(parseUnits("0.1"));
     });
     it("Only Governor can approve all tokens", async () => {
       const {

--- a/contracts/test/vault/oeth-vault.fork-test.js
+++ b/contracts/test/vault/oeth-vault.fork-test.js
@@ -256,7 +256,7 @@ describe("ForkTest: OETH Vault", function () {
   });
 
   describe("operations", () => {
-    it.only("should rebase", async function () {
+    it("should rebase", async function () {
       const { oethVault } = fixture;
 
       const tx = await oethVault.rebase();

--- a/contracts/yarn.lock
+++ b/contracts/yarn.lock
@@ -2810,6 +2810,11 @@ escodegen@1.8.x:
   optionalDependencies:
     source-map "~0.2.0"
 
+eslint-plugin-no-only-tests@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-3.1.0.tgz#f38e4935c6c6c4842bf158b64aaa20c366fe171b"
+  integrity sha512-Lf4YW/bL6Un1R6A76pRZyE1dl1vr31G/ev8UzIc/geCgFWyrKil8hVjYqWVKGB/UIGmb6Slzs9T0wNezdSVegw==
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"


### PR DESCRIPTION
Changes

* Removed .only from AMO fork tests
* Adds linter check for .only in tests
* Fixed fork test harvesting CRV as price has dropped relative to ETH