### PR TITLE
Husky pre-commit to run linter

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 cd contracts
-yarn run lint
+yarn run lint:js

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,25 +1,4 @@
 #!/bin/sh
 
-RED='\033[0;31m'
-NC='\033[0m'
-GREEN='\033[0;32m'
-files=""
-# find all file ending with test.js that are not in node_modules
-for file in $(find . -type d -name node_modules -prune -o -name '*test.js' -print); do
-    # uncomment below to debug which files match
-    # echo "$file"
-		# search if any contain it.only or describe.only
-		match=$(grep -E "(describe|it)\.only[[:space:]]*\(" "$file")
-
-		# add together the files containing .only
-    if [[ -n "${match}" ]]; then
-    	files=${files}${file}'\n'
-    fi
-done
-if [[ -n "${files}" ]]; then
-	# fail pre-commit if
-	echo "${RED}Git pre-commit hook failed! Remove \".only\" from the following test file(s):${GREEN}"
-	echo ${files}
-	echo "${NC}"
-	exit 1
-fi
+cd contracts
+yarn run lint

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # Origin DeFi's OTokens: Origin Dollar (OUSD) and Origin Ether (OETH)
- 
+
 For more details about the product, checkout [our docs](https://docs.oeth.com).
 
 ---
 
-| Branch    | CI/CD Status                                                                                                                                                                                                      |
-| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `master`  | [![Origin DeFi](https://github.com/OriginProtocol/origin-dollar/actions/workflows/defi.yml/badge.svg)](https://github.com/OriginProtocol/origin-dollar/actions/workflows/defi.yml)                                       |
-
+| Branch   | CI/CD Status                                                                                                                                                                       |
+| -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `master` | [![Origin DeFi](https://github.com/OriginProtocol/origin-dollar/actions/workflows/defi.yml/badge.svg)](https://github.com/OriginProtocol/origin-dollar/actions/workflows/defi.yml) |
 
 ## Requirements
 
@@ -96,7 +95,7 @@ Head over to [contracts/fork-test.md](contracts/fork-test.md)
 
 Want to contribute to OUSD? Awesome!
 
-OUSD is an Open Source project and we welcome contributions of all sorts. There are many ways to help, from reporting issues, contributing to the code, and helping us improve our community.
+OUSD is an Open Source project and we welcome contributions of all sorts. There are many ways to help, from reporting issues, contributing code, and helping us improve our community.
 
 The best way to get involved is to join the Origin Protocol [discord server](https://discord.gg/jyxpUSe) and head over to the channel named ORIGIN DOLLAR & DEFI
 
@@ -104,14 +103,6 @@ The best way to get involved is to join the Origin Protocol [discord server](htt
 
 ## Git pre-commit hooks (using Husky)
 
-### Setup
-```
-# install Husky
-npx install husky
+[husky](https://typicode.github.io/husky/) is a development dependency in the root project folder. To install, run `yarn` in the project root folder.
 
-# from project root folder install Husky hooks
-npx husky install
-
-```
-
-If the script in .husky/pre-commit returns non 0 exit the pre-commit hook will fail. Currently the script prevents a commit if there is an ".only" in the test scripts. Use "git commit --no-verify" if you have the hook enabled and you'd like to skip pre-commit check.
+If the [.husky/pre-commit](.husky/pre-commit) script returns non-zero, the pre-commit hook will fail. Currently, the script prevents a commit if there is a ".only" in the test scripts. Use `git commit --no-verify` if you have the hook enabled and you'd like to skip pre-commit check.

--- a/README.md
+++ b/README.md
@@ -105,4 +105,4 @@ The best way to get involved is to join the Origin Protocol [discord server](htt
 
 [husky](https://typicode.github.io/husky/) is a development dependency in the root project folder. To install, run `yarn` in the project root folder.
 
-If the [.husky/pre-commit](.husky/pre-commit) script returns non-zero, the pre-commit hook will fail. Currently, the script prevents a commit if there is a ".only" in the test scripts. Use `git commit --no-verify` if you have the hook enabled and you'd like to skip pre-commit check.
+If the [.husky/pre-commit](.husky/pre-commit) script returns non-zero, the pre-commit hook will fail. Currently, the script runs the contracts linter. Use `git commit --no-verify` if you have the hook enabled and you'd like to skip the pre-commit check.

--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
   "scripts": {
     "build": "(cd contracts && NODE_ENV=development yarn install && yarn run deploy)",
     "start": "(cd contracts && yarn run node)",
-    "test": "exit 0"
+    "test": "exit 0",
+    "prepare": "husky"
   },
   "engines": {
     "node": "20"
   },
   "devDependencies": {
-    "danger": "^11.2.8"
+    "danger": "^11.2.8",
+    "husky": "^9.0.11"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -521,6 +521,11 @@ https-proxy-agent@^5.0.1:
     agent-base "6"
     debug "4"
 
+husky@^9.0.11:
+  version "9.0.11"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-9.0.11.tgz#fc91df4c756050de41b3e478b2158b87c1e79af9"
+  integrity sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==
+
 hyperlinker@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hyperlinker/-/hyperlinker-1.0.0.tgz#23dc9e38a206b208ee49bc2d6c8ef47027df0c0e"


### PR DESCRIPTION
# Changes

- Add Husky as a dependency at the project root
- Change the Husky pre-commit to run the contracts linter
- Upate Husky install docs

This does slow down the commit as it needs to run the linter
