### PR TITLE
OZ - Native Staking - M-01 All Addresses Are Registered Validators by Default

### DIFF
--- a/contracts/contracts/strategies/NativeStaking/ValidatorRegistrator.sol
+++ b/contracts/contracts/strategies/NativeStaking/ValidatorRegistrator.sol
@@ -215,6 +215,11 @@ abstract contract ValidatorRegistrator is Governable, Pausable {
         uint256 amount,
         Cluster calldata cluster
     ) external onlyRegistrator whenNotPaused {
+        require(
+            validatorsStates[keccak256(publicKey)] ==
+                VALIDATOR_STATE.NON_REGISTERED,
+            "Validator already registered"
+        );
         ISSVNetwork(SSV_NETWORK_ADDRESS).registerValidator(
             publicKey,
             operatorIds,

--- a/contracts/contracts/strategies/NativeStaking/ValidatorRegistrator.sol
+++ b/contracts/contracts/strategies/NativeStaking/ValidatorRegistrator.sol
@@ -48,6 +48,7 @@ abstract contract ValidatorRegistrator is Governable, Pausable {
     uint256[47] private __gap;
 
     enum VALIDATOR_STATE {
+        NON_REGISTERED, // validator is not registered on the SSV network
         REGISTERED, // validator is registered on the SSV network
         STAKED, // validator has funds staked
         EXITING, // exit message has been posted and validator is in the process of exiting

--- a/contracts/contracts/strategies/NativeStaking/ValidatorRegistrator.sol
+++ b/contracts/contracts/strategies/NativeStaking/ValidatorRegistrator.sol
@@ -208,6 +208,7 @@ abstract contract ValidatorRegistrator is Governable, Pausable {
 
     /// @notice Registers a new validator in the SSV Cluster.
     /// Only the registrator can call this function.
+    // slither-disable-start reentrancy-no-eth
     function registerSsvValidator(
         bytes calldata publicKey,
         uint64[] calldata operatorIds,
@@ -230,6 +231,8 @@ abstract contract ValidatorRegistrator is Governable, Pausable {
         validatorsStates[keccak256(publicKey)] = VALIDATOR_STATE.REGISTERED;
         emit SSVValidatorRegistered(publicKey, operatorIds);
     }
+
+    // slither-disable-end reentrancy-no-eth
 
     /// @notice Exit a validator from the Beacon chain.
     /// The staked ETH will eventually swept to this native staking strategy.

--- a/contracts/deploy/holesky/010_upgrade_strategy.js
+++ b/contracts/deploy/holesky/010_upgrade_strategy.js
@@ -3,7 +3,6 @@ const { withConfirmation } = require("../../utils/deploy");
 const { resolveContract } = require("../../utils/resolvers");
 const addresses = require("../../utils/addresses");
 const { parseEther } = require("ethers/lib/utils");
-// const { impersonateAndFund } = require("../../utils/signers.js");
 
 const mainExport = async () => {
   console.log("Running 010 deployment on Holesky...");

--- a/contracts/deploy/holesky/011_upgrade_strategy.js
+++ b/contracts/deploy/holesky/011_upgrade_strategy.js
@@ -1,0 +1,18 @@
+const { upgradeNativeStakingSSVStrategy } = require("../deployActions");
+
+const mainExport = async () => {
+  console.log("Running 011 deployment on Holesky...");
+
+  console.log("Upgrading native staking strategy");
+  await upgradeNativeStakingSSVStrategy();
+
+  console.log("Running 011 deployment done");
+  return true;
+};
+
+mainExport.id = "011_upgrade_strategy";
+mainExport.tags = [];
+mainExport.dependencies = [];
+mainExport.skip = () => false;
+
+module.exports = mainExport;


### PR DESCRIPTION
# Contract Changes

* Adding `NON_REGISTERED` as the default value in the `VALIDATOR_STATE` enum.

# Issue

In Solidity, an enum variable is automatically set to its first enumerated value if it is initialized without specifying a particular value. In `ValidatorRegistrator.sol` , `REGISTERED` is the default value of the `VALIDATOR_STATE` enum, meaning that it is possible to stake with any address even if `registerSsvValidator` were not called. Since the address would not be
registered as a validator in the SSV Network, it would not perform validations correctly which could result in funds being lost due to slashing.
