### PR TITLE
OZ - Native Staking - N-06 Unnecessary Conditional

### DIFF
--- a/contracts/contracts/strategies/NativeStaking/ValidatorAccountant.sol
+++ b/contracts/contracts/strategies/NativeStaking/ValidatorAccountant.sol
@@ -71,7 +71,6 @@ abstract contract ValidatorAccountant is ValidatorRegistrator {
     ) external onlyGovernor {
         require(
             _fuseIntervalStart < _fuseIntervalEnd &&
-                _fuseIntervalStart < 32 ether &&
                 _fuseIntervalEnd < 32 ether &&
                 _fuseIntervalEnd - _fuseIntervalStart >= 4 ether,
             "incorrect fuse interval"


### PR DESCRIPTION
# Contract changes

* Removed the redundant condition in the fuse interval check in `ValidatorAccountant.setFuseInterval`

# Issue

The [require](https://github.com/OriginProtocol/origin-dollar/blob/21d55698f5157ef0af835a1653bb6aa9f5e7944b/contracts/contracts/strategies/NativeStaking/ValidatorAccountant.sol#L71-L77) statement in [_doAccounting](https://github.com/OriginProtocol/origin-dollar/blob/21d55698f5157ef0af835a1653bb6aa9f5e7944b/contracts/contracts/strategies/NativeStaking/ValidatorAccountant.sol#L109) checks that both `_fuseIntervalStart` and `_fuseIntervalEnd` are less than 32 ether and that `_fuseIntervalStart < _fuseIntervalEnd`. However, the `_fuseIntervalStart < 32 ether` condition is redundant as this condition is already ensured by the two other checks which ensure that `_fuseIntervalEnd` is already less than 32 ether and the start of the interval is less than the end.