### PR TITLE
OZ - Native Staking - N-07 Lack of Indexed Event Parameters

### DIFF
--- a/contracts/contracts/strategies/NativeStaking/ValidatorRegistrator.sol
+++ b/contracts/contracts/strategies/NativeStaking/ValidatorRegistrator.sol
@@ -54,8 +54,8 @@ abstract contract ValidatorRegistrator is Governable, Pausable {
         EXIT_COMPLETE // validator has funds withdrawn to the EigenPod and is removed from the SSV
     }
 
-    event RegistratorChanged(address newAddress);
-    event StakingMonitorChanged(address newAddress);
+    event RegistratorChanged(address indexed newAddress);
+    event StakingMonitorChanged(address indexed newAddress);
     event ETHStaked(bytes pubkey, uint256 amount, bytes withdrawal_credentials);
     event SSVValidatorRegistered(bytes pubkey, uint64[] operatorIds);
     event SSVValidatorExitInitiated(bytes pubkey, uint64[] operatorIds);

--- a/contracts/test/behaviour/ssvStrategy.js
+++ b/contracts/test/behaviour/ssvStrategy.js
@@ -199,7 +199,11 @@ const shouldBehaveLikeAnSsvStrategy = (context) => {
         );
       await expect(regTx)
         .to.emit(nativeStakingSSVStrategy, "SSVValidatorRegistered")
-        .withArgs(testValidator.publicKey, testValidator.operatorIds);
+        .withArgs(
+          keccak256(testValidator.publicKey),
+          testValidator.publicKey,
+          testValidator.operatorIds
+        );
 
       expect(
         await nativeStakingSSVStrategy.validatorsStates(
@@ -221,7 +225,8 @@ const shouldBehaveLikeAnSsvStrategy = (context) => {
       await expect(stakeTx)
         .to.emit(nativeStakingSSVStrategy, "ETHStaked")
         .withNamedArgs({
-          pubkey: testValidator.publicKey,
+          pubKeyHash: keccak256(testValidator.publicKey),
+          pubKey: testValidator.publicKey,
           amount: oethUnits("32"),
         });
 
@@ -397,7 +402,11 @@ const shouldBehaveLikeAnSsvStrategy = (context) => {
 
       await expect(exitTx)
         .to.emit(nativeStakingSSVStrategy, "SSVValidatorExitInitiated")
-        .withArgs(testValidator.publicKey, testValidator.operatorIds);
+        .withArgs(
+          keccak256(testValidator.publicKey),
+          testValidator.publicKey,
+          testValidator.operatorIds
+        );
 
       const removeTx = await nativeStakingSSVStrategy
         .connect(validatorRegistrator)
@@ -409,7 +418,11 @@ const shouldBehaveLikeAnSsvStrategy = (context) => {
 
       await expect(removeTx)
         .to.emit(nativeStakingSSVStrategy, "SSVValidatorExitCompleted")
-        .withArgs(testValidator.publicKey, testValidator.operatorIds);
+        .withArgs(
+          keccak256(testValidator.publicKey),
+          testValidator.publicKey,
+          testValidator.operatorIds
+        );
     });
   });
 


### PR DESCRIPTION
# Contract changes

* Indexed the `RegistratorChanged` and `StakingMonitorChanged` events in the `ValidatorRegistrator` contract.

# Issue

Throughout the codebase, several events do not have indexed parameters.

To improve the ability of off-chain services to search and filter for specific events, consider [indexing event parameters](https://docs.soliditylang.org/en/latest/contracts.html#events).

# Comment

Although `bytes` types can be indexed, the Waffle framework used for testing does not support it. Ideally, the `pubkey` parameters would be indexed so events for a specific validator can be filtered. But this breaks Waffle's event matchers.