### PR TITLE
Validator key decrypt

### DIFF
--- a/contracts/dev.env
+++ b/contracts/dev.env
@@ -48,11 +48,13 @@ P2P_HOLESKY_API_KEY=[SET API Key]
 # DEFENDER_API_KEY=
 # DEFENDER_API_SECRET=
 
-# needed to be able to either:
-#  - decode the private key we use to encrypt all of the validator private keys (AWS IAM user "validator_key_manager")
-#  - operate validators to upload encrypted validator keys to S3  (AWS IAM user "defender_action")
+# needed to be able to decode the private key we use to encrypt all of the validator private keys (AWS IAM user "validator_key_manager")
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
+
+# needed to be able to operate validators to upload encrypted validator keys to S3  (AWS IAM user "defender_action")
+AWS_ACCESS_S3_KEY_ID=
+AWS_SECRET_S3_ACCESS_KEY=
 
 VALIDATOR_KEYS_S3_BUCKET_NAME=[validator-keys-test | validator-keys]
 

--- a/contracts/tasks/tasks.js
+++ b/contracts/tasks/tasks.js
@@ -12,7 +12,6 @@ const {
   genECDHKey,
   decryptValidatorKey,
   decryptValidatorKeyWithMasterKey,
-  decryptValidatorKeyFromStorage,
 } = require("./crypto");
 const {
   encryptMasterPrivateKey,
@@ -1299,9 +1298,15 @@ subtask(
     undefined,
     types.string
   )
-  .addParam(
-    "message",
-    "Encrypted validator private key returned form P2P API",
+  .addOptionalParam(
+    "encryptedKey",
+    "Used if pubkey is not provided. The encrypted validator private key returned from P2P API in base64 format.",
+    undefined,
+    types.string
+  )
+  .addOptionalParam(
+    "pubkey",
+    "Public key of the validator whose private key is to be fetched in hex format. If not provided, the encryptedKey option must be used.",
     undefined,
     types.string
   )
@@ -1313,33 +1318,6 @@ subtask(
   )
   .setAction(decryptValidatorKey);
 task("decrypt").setAction(async (_, __, runSuper) => {
-  return runSuper();
-});
-
-subtask(
-  "decryptFromStorage",
-  "Decrypt an encrypted private key from S3 using a Elliptic-curve Diffie–Hellman (ECDH) key pair"
-)
-  .addOptionalParam(
-    "privatekey",
-    "Private key to decrypt the message with in hex format without the 0x prefix. If not provided, the encrypted private key in VALIDATOR_MASTER_ENCRYPTED_PRIVATE_KEY will be used.",
-    undefined,
-    types.string
-  )
-  .addParam(
-    "pubkey",
-    "Public key of the validator whose private key is to be fetched.",
-    undefined,
-    types.string
-  )
-  .addOptionalParam(
-    "displaypk",
-    "Display the private key in hex format in the console",
-    false,
-    types.boolean
-  )
-  .setAction(decryptValidatorKeyFromStorage);
-task("decryptFromStorage").setAction(async (_, __, runSuper) => {
   return runSuper();
 });
 

--- a/contracts/tasks/tasks.js
+++ b/contracts/tasks/tasks.js
@@ -12,6 +12,7 @@ const {
   genECDHKey,
   decryptValidatorKey,
   decryptValidatorKeyWithMasterKey,
+  decryptValidatorKeyFromStorage,
 } = require("./crypto");
 const {
   encryptMasterPrivateKey,
@@ -1312,6 +1313,33 @@ subtask(
   )
   .setAction(decryptValidatorKey);
 task("decrypt").setAction(async (_, __, runSuper) => {
+  return runSuper();
+});
+
+subtask(
+  "decryptFromStorage",
+  "Decrypt an encrypted private key from S3 using a Elliptic-curve Diffie–Hellman (ECDH) key pair"
+)
+  .addOptionalParam(
+    "privatekey",
+    "Private key to decrypt the message with in hex format without the 0x prefix. If not provided, the encrypted private key in VALIDATOR_MASTER_ENCRYPTED_PRIVATE_KEY will be used.",
+    undefined,
+    types.string
+  )
+  .addParam(
+    "pubkey",
+    "Public key of the validator whose private key is to be fetched.",
+    undefined,
+    types.string
+  )
+  .addOptionalParam(
+    "displaypk",
+    "Display the private key in hex format in the console",
+    false,
+    types.boolean
+  )
+  .setAction(decryptValidatorKeyFromStorage);
+task("decryptFromStorage").setAction(async (_, __, runSuper) => {
   return runSuper();
 });
 

--- a/contracts/tasks/validator.js
+++ b/contracts/tasks/validator.js
@@ -5,13 +5,9 @@ const { v4: uuidv4 } = require("uuid");
 const {
   KeyValueStoreClient,
 } = require("@openzeppelin/defender-kvstore-client");
-const {
-  PutObjectCommand,
-  GetObjectCommand,
-  S3Client,
-} = require("@aws-sdk/client-s3");
 
 const { getBlock } = require("./block");
+const { storePrivateKeyToS3 } = require("../utils/amazon");
 const addresses = require("../utils/addresses");
 const { resolveContract } = require("../utils/resolvers");
 const { getSigner } = require("../utils/signers");
@@ -698,71 +694,6 @@ const broadcastRegisterValidator = async (
   }
 };
 
-const getS3Context = async () => {
-  const apiKey = process.env.AWS_ACCESS_S3_KEY_ID;
-  const apiSecret = process.env.AWS_SECRET_S3_ACCESS_KEY;
-  const bucketName = process.env.VALIDATOR_KEYS_S3_BUCKET_NAME;
-
-  if (!apiKey || !apiSecret || !bucketName) {
-    throw new Error(
-      "AWS_ACCESS_S3_KEY_ID & AWS_SECRET_S3_ACCESS_KEY & VALIDATOR_KEYS_S3_BUCKET_NAME need to all be set."
-    );
-  }
-
-  return [
-    new S3Client({
-      region: "us-east-1",
-      credentials: {
-        accessKeyId: apiKey,
-        secretAccessKey: apiSecret,
-      },
-    }),
-    bucketName,
-  ];
-};
-
-const getPrivateKeyFromS3 = async (pubkey) => {
-  const [s3Client, bucketName] = await getS3Context();
-  log("Attempting to fetch encrypted private key from S3");
-  const fileName = `${pubkey}.json`;
-
-  const input = {
-    Bucket: bucketName,
-    Key: fileName,
-  };
-
-  const command = new GetObjectCommand(input);
-
-  try {
-    const response = await s3Client.send(command);
-    return await response.Body.transformToString();
-  } catch (err) {
-    log("Error fetching file from S3", err);
-    throw err;
-  }
-};
-
-const storePrivateKeyToS3 = async (pubkey, encryptedPrivateKey) => {
-  const [s3Client, bucketName] = await getS3Context();
-  log("Attempting to store encrypted private key to S3");
-
-  const fileName = `${pubkey}.json`;
-  const putCommand = new PutObjectCommand({
-    Bucket: bucketName,
-    Key: fileName,
-    Body: JSON.stringify({
-      encryptedPrivateKey,
-    }),
-  });
-
-  try {
-    await s3Client.send(putCommand);
-    log(`Private key stored under s3://${bucketName}/${fileName}`);
-  } catch (err) {
-    log("Error uploading file to S3", err);
-  }
-};
-
 const confirmValidatorRegistered = async (
   store,
   uuid,
@@ -1070,5 +1001,4 @@ module.exports = {
   fixAccounting,
   pauseStaking,
   snapStaking,
-  getPrivateKeyFromS3,
 };

--- a/contracts/utils/amazon.js
+++ b/contracts/utils/amazon.js
@@ -1,0 +1,78 @@
+require("dotenv").config();
+const {
+  PutObjectCommand,
+  GetObjectCommand,
+  S3Client,
+} = require("@aws-sdk/client-s3");
+
+const log = require("../utils/logger")("task:aws");
+
+const getS3Context = async () => {
+  const apiKey = process.env.AWS_ACCESS_S3_KEY_ID;
+  const apiSecret = process.env.AWS_SECRET_S3_ACCESS_KEY;
+  const bucketName = process.env.VALIDATOR_KEYS_S3_BUCKET_NAME;
+
+  if (!apiKey || !apiSecret || !bucketName) {
+    throw new Error(
+      "AWS_ACCESS_S3_KEY_ID & AWS_SECRET_S3_ACCESS_KEY & VALIDATOR_KEYS_S3_BUCKET_NAME need to all be set."
+    );
+  }
+
+  return [
+    new S3Client({
+      region: "us-east-1",
+      credentials: {
+        accessKeyId: apiKey,
+        secretAccessKey: apiSecret,
+      },
+    }),
+    bucketName,
+  ];
+};
+
+const getPrivateKeyFromS3 = async (pubkey) => {
+  const [s3Client, bucketName] = await getS3Context();
+  log("Attempting to fetch encrypted private key from S3");
+  const fileName = `${pubkey}.json`;
+
+  const input = {
+    Bucket: bucketName,
+    Key: fileName,
+  };
+
+  const command = new GetObjectCommand(input);
+
+  try {
+    const response = await s3Client.send(command);
+    return await response.Body.transformToString();
+  } catch (err) {
+    log("Error fetching file from S3", err);
+    throw err;
+  }
+};
+
+const storePrivateKeyToS3 = async (pubkey, encryptedPrivateKey) => {
+  const [s3Client, bucketName] = await getS3Context();
+  log("Attempting to store encrypted private key to S3");
+
+  const fileName = `${pubkey}.json`;
+  const putCommand = new PutObjectCommand({
+    Bucket: bucketName,
+    Key: fileName,
+    Body: JSON.stringify({
+      encryptedPrivateKey,
+    }),
+  });
+
+  try {
+    await s3Client.send(putCommand);
+    log(`Private key stored under s3://${bucketName}/${fileName}`);
+  } catch (err) {
+    log("Error uploading file to S3", err);
+  }
+};
+
+module.exports = {
+  getPrivateKeyFromS3,
+  storePrivateKeyToS3,
+};


### PR DESCRIPTION
Make it possible to decrypt a validator private key directly from S3 storage.

The following command using `VALIDATOR_KEYS_S3_BUCKET_NAME=validator-keys-test` should yield the following results
```
yarn hardhat decryptFromStorage --pubkey 0x8172ac384cade0b541c6b8fc486994e4d0a62fa0ed86bd3f8b6564106f2c223b7f274da673ff55e1c56d9b6428b06978 --displaypk true

Validator public key: 8172ac384cade0b541c6b8fc486994e4d0a62fa0ed86bd3f8b6564106f2c223b7f274da673ff55e1c56d9b6428b06978
Private validator key:  5a5f3f781842ee9097bf36895cb91f293950d1c5957fe9778d83afda91247322
```

Make sure to have the correct master encrypted validator private key configured