### PR TITLE
Add 30 minute time delay between request and claim from the OETH Withdrawal Queue.

### DIFF
--- a/contracts/contracts/vault/OETHVaultAdmin.sol
+++ b/contracts/contracts/vault/OETHVaultAdmin.sol
@@ -96,8 +96,8 @@ contract OETHVaultAdmin is VaultAdmin {
         uint256 _minToAssetAmount,
         bytes calldata _data
     ) internal override returns (uint256 toAssetAmount) {
-        require(_fromAsset != weth, "swap from WETH not supported");
-        require(_toAsset == weth, "only swap to WETH");
+        require(_fromAsset != weth, "Swap from WETH not supported");
+        require(_toAsset == weth, "Only swap to WETH");
         toAssetAmount = super._swapCollateral(
             _fromAsset,
             _toAsset,

--- a/contracts/contracts/vault/OETHVaultCore.sol
+++ b/contracts/contracts/vault/OETHVaultCore.sol
@@ -255,11 +255,11 @@ contract OETHVaultCore is VaultCore {
         WithdrawalQueueMetadata memory queue = withdrawalQueueMetadata;
         WithdrawalRequest memory request = withdrawalRequests[requestId];
 
-        require(request.claimed == false, "already claimed");
-        require(request.withdrawer == msg.sender, "not requester");
+        require(request.claimed == false, "Already claimed");
+        require(request.withdrawer == msg.sender, "Not requester");
         require(
             request.timestamp + CLAIM_DELAY <= block.timestamp,
-            "claim delay not met"
+            "Claim delay not met"
         );
 
         // Try and get more liquidity in the withdrawal queue if there is not enough
@@ -273,7 +273,7 @@ contract OETHVaultCore is VaultCore {
             // If there still isn't enough liquidity in the queue to claim, revert
             require(
                 request.queued <= queue.claimable + addedClaimable,
-                "queue pending liquidity"
+                "Queue pending liquidity"
             );
         }
 

--- a/contracts/contracts/vault/OETHVaultCore.sol
+++ b/contracts/contracts/vault/OETHVaultCore.sol
@@ -191,6 +191,7 @@ contract OETHVaultCore is VaultCore {
         withdrawalRequests[requestId] = WithdrawalRequest({
             withdrawer: msg.sender,
             claimed: false,
+            timestamp: uint40(block.timestamp),
             amount: uint128(_amount),
             queued: uint128(queued)
         });
@@ -255,6 +256,10 @@ contract OETHVaultCore is VaultCore {
 
         require(request.claimed == false, "already claimed");
         require(request.withdrawer == msg.sender, "not requester");
+        require(
+            request.timestamp + CLAIM_DELAY <= block.timestamp,
+            "claim delay not met"
+        );
 
         // Try and get more liquidity in the withdrawal queue if there is not enough
         if (request.queued > queue.claimable) {

--- a/contracts/contracts/vault/OETHVaultCore.sol
+++ b/contracts/contracts/vault/OETHVaultCore.sol
@@ -17,6 +17,7 @@ contract OETHVaultCore is VaultCore {
     using SafeERC20 for IERC20;
     using StableMath for uint256;
 
+    uint256 constant CLAIM_DELAY = 30 minutes;
     address public immutable weth;
     uint256 public wethAssetIndex;
 

--- a/contracts/contracts/vault/VaultStorage.sol
+++ b/contracts/contracts/vault/VaultStorage.sol
@@ -221,8 +221,6 @@ contract VaultStorage is Initializable, Governable {
     /// @notice Mapping of withdrawal request indices to the user withdrawal request data
     mapping(uint256 => WithdrawalRequest) public withdrawalRequests;
 
-    uint256 constant CLAIM_DELAY = 30 minutes;
-
     // For future use
     uint256[46] private __gap;
 

--- a/contracts/contracts/vault/VaultStorage.sol
+++ b/contracts/contracts/vault/VaultStorage.sol
@@ -210,6 +210,7 @@ contract VaultStorage is Initializable, Governable {
     struct WithdrawalRequest {
         address withdrawer;
         bool claimed;
+        uint40 timestamp; // timestamp of the withdrawal request
         // Amount of oTokens to redeem. eg OETH
         uint128 amount;
         // cumulative total of all withdrawal requests including this one.
@@ -219,6 +220,8 @@ contract VaultStorage is Initializable, Governable {
 
     /// @notice Mapping of withdrawal request indices to the user withdrawal request data
     mapping(uint256 => WithdrawalRequest) public withdrawalRequests;
+
+    uint256 constant CLAIM_DELAY = 30 minutes;
 
     // For future use
     uint256[46] private __gap;

--- a/contracts/contracts/vault/VaultStorage.sol
+++ b/contracts/contracts/vault/VaultStorage.sol
@@ -231,7 +231,7 @@ contract VaultStorage is Initializable, Governable {
     function setAdminImpl(address newImpl) external onlyGovernor {
         require(
             Address.isContract(newImpl),
-            "New implementation is not a contract"
+            "new implementation is not a contract"
         );
         bytes32 position = adminImplPosition;
         // solhint-disable-next-line no-inline-assembly

--- a/contracts/contracts/vault/VaultStorage.sol
+++ b/contracts/contracts/vault/VaultStorage.sol
@@ -231,7 +231,7 @@ contract VaultStorage is Initializable, Governable {
     function setAdminImpl(address newImpl) external onlyGovernor {
         require(
             Address.isContract(newImpl),
-            "new implementation is not a contract"
+            "New implementation is not a contract"
         );
         bytes32 position = adminImplPosition;
         // solhint-disable-next-line no-inline-assembly


### PR DESCRIPTION
## Changes

* Add a 30 minute delay between requesting a withdrawal and claiming a withdrawal from the OETH Vault.

## Code Change Checklist

To be completed before internal review begins:

- [ ]  The contract code is complete
- [ ]  Executable deployment file
- [ ]  Fork tests that test after the deployment file runs
- [ ]  Unit tests *if needed
- [ ]  The owner has done a [full checklist review](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) of the code + tests

Internal review:

- [ ] Two approvals by internal reviewers
