### PR TITLE
Reuse existing implementation for Second Native Staking Strategy

### DIFF
--- a/brownie/runlogs/2024_07_strategist.py
+++ b/brownie/runlogs/2024_07_strategist.py
@@ -94,3 +94,320 @@ def main():
     print("OETH supply change", "{:.6f}".format(supply_change / 10**18), supply_change)
     print("Vault Change", "{:.6f}".format(vault_change / 10**18), vault_change)
     print("-----")
+
+# -------------------------------------
+# Jul 9, 2024 - First deposit to Lido Withdrawal Strategy
+# -------------------------------------
+from world import *
+
+def main():
+  with TemporaryForkForReallocations() as txs:
+    # Before
+    txs.append(vault_oeth_core.rebase(std))
+    txs.append(oeth_vault_value_checker.takeSnapshot(std))
+    
+    # Deposit 1 stETH to Lido Withdrawal Strategy
+    txs.append(
+      vault_oeth_admin.depositToStrategy(
+        OETH_LIDO_WITHDRAWAL_STRAT, 
+        [STETH], 
+        [1 * 10**18],
+        std
+      )
+    )
+
+    # After
+    vault_change = vault_oeth_core.totalValue() - oeth_vault_value_checker.snapshots(STRATEGIST)[0]
+    supply_change = oeth.totalSupply() - oeth_vault_value_checker.snapshots(STRATEGIST)[1]
+    profit = vault_change - supply_change
+    txs.append(oeth_vault_value_checker.checkDelta(profit, (1 * 10**18), vault_change, (1 * 10**18), std))
+    print("-----")
+    print("Profit", "{:.6f}".format(profit / 10**18), profit)
+    print("OETH supply change", "{:.6f}".format(supply_change / 10**18), supply_change)
+    print("Vault Change", "{:.6f}".format(vault_change / 10**18), vault_change)
+    print("-----")
+
+# -------------------------------------
+# Jul 9, 2024 - Claim first withdrawal from Lido Withdrawal Strategy
+# -------------------------------------
+from world import *
+
+def main():
+  with TemporaryForkForReallocations() as txs:
+    # Before
+    txs.append(vault_oeth_core.rebase(std))
+    txs.append(oeth_vault_value_checker.takeSnapshot(std))
+    
+    # Claim the 1 ETH from the Lido Withdrawal Queue
+    txs.append(
+      lido_withdrawal_strat.claimWithdrawals(
+        [45153], # withdrawal NFT id
+        10**18 - 2,
+        std
+      )
+    )
+
+    # After
+    vault_change = vault_oeth_core.totalValue() - oeth_vault_value_checker.snapshots(STRATEGIST)[0]
+    supply_change = oeth.totalSupply() - oeth_vault_value_checker.snapshots(STRATEGIST)[1]
+    profit = vault_change - supply_change
+    txs.append(oeth_vault_value_checker.checkDelta(profit, (1 * 10**18), vault_change, (1 * 10**18), std))
+    print("-----")
+    print("Profit", "{:.6f}".format(profit / 10**18), profit)
+    print("OETH supply change", "{:.6f}".format(supply_change / 10**18), supply_change)
+    print("Vault Change", "{:.6f}".format(vault_change / 10**18), vault_change)
+    print("-----")
+
+
+# -------------------------------------
+# Jul 10, 2024 - deposit to Native Staking Strategy
+# -------------------------------------
+from world import *
+
+def main():
+  with TemporaryForkForReallocations() as txs:
+    # Before
+    txs.append(vault_oeth_core.rebase(std))
+    txs.append(oeth_vault_value_checker.takeSnapshot(std))
+    
+    # Deposit WETH to Native Staking Strategy
+    txs.append(
+      vault_oeth_admin.depositToStrategy(
+        OETH_NATIVE_STAKING_STRAT, 
+        [WETH], 
+        # 43 validators * 32 ETH = 1376 ETH
+        [1376 * 10**18],
+        std
+      )
+    )
+
+    # After
+    vault_change = vault_oeth_core.totalValue() - oeth_vault_value_checker.snapshots(STRATEGIST)[0]
+    supply_change = oeth.totalSupply() - oeth_vault_value_checker.snapshots(STRATEGIST)[1]
+    profit = vault_change - supply_change
+    txs.append(oeth_vault_value_checker.checkDelta(profit, (1 * 10**18), vault_change, (1 * 10**18), std))
+    print("-----")
+    print("Profit", "{:.6f}".format(profit / 10**18), profit)
+    print("OETH supply change", "{:.6f}".format(supply_change / 10**18), supply_change)
+    print("Vault Change", "{:.6f}".format(vault_change / 10**18), vault_change)
+    print("-----")
+
+# -------------------------------------
+# Jul 10, 2024 - Deposit 4992 stETH to Lido Withdrawal Strategy
+# -------------------------------------
+from world import *
+
+def main():
+  with TemporaryForkForReallocations() as txs:
+    # Before
+    txs.append(vault_oeth_core.rebase(std))
+    txs.append(oeth_vault_value_checker.takeSnapshot(std))
+
+    # Deposit 156 validators * 32 ETH = 4992 WETH
+    txs.append(
+      vault_oeth_admin.depositToStrategy(
+        OETH_LIDO_WITHDRAWAL_STRAT, 
+        [STETH], 
+        [4992 * 10 **18],
+        std
+      )
+    )
+
+    # After
+    vault_change = vault_oeth_core.totalValue() - oeth_vault_value_checker.snapshots(STRATEGIST)[0]
+    supply_change = oeth.totalSupply() - oeth_vault_value_checker.snapshots(STRATEGIST)[1]
+    profit = vault_change - supply_change
+    txs.append(oeth_vault_value_checker.checkDelta(profit, (1 * 10**18), vault_change, (1 * 10**18), std))
+    print("-----")
+    print("Profit", "{:.6f}".format(profit / 10**18), profit)
+    print("OETH supply change", "{:.6f}".format(supply_change / 10**18), supply_change)
+    print("Vault Change", "{:.6f}".format(vault_change / 10**18), vault_change)
+    print("-----")
+
+# -------------------------------------
+# Jul 10, 2024 - Claim second batch of withdrawals from Lido Withdrawal Strategy
+# -------------------------------------
+from world import *
+
+def main():
+  with TemporaryForkForReallocations() as txs:
+    # Before
+    txs.append(vault_oeth_core.rebase(std))
+    txs.append(oeth_vault_value_checker.takeSnapshot(std))
+    
+    # Claim the 5 withdrawal requests from the Lido Withdrawal Queue
+    txs.append(
+      lido_withdrawal_strat.claimWithdrawals(
+        [45270, 45271, 45272, 45273, 45274], # withdrawal NFT ids
+        4992 * 10**18,
+        std
+      )
+    )
+
+    # After
+    vault_change = vault_oeth_core.totalValue() - oeth_vault_value_checker.snapshots(STRATEGIST)[0]
+    supply_change = oeth.totalSupply() - oeth_vault_value_checker.snapshots(STRATEGIST)[1]
+    profit = vault_change - supply_change
+    txs.append(oeth_vault_value_checker.checkDelta(profit, (1 * 10**18), vault_change, (1 * 10**18), std))
+    print("-----")
+    print("Profit", "{:.6f}".format(profit / 10**18), profit)
+    print("OETH supply change", "{:.6f}".format(supply_change / 10**18), supply_change)
+    print("Vault Change", "{:.6f}".format(vault_change / 10**18), vault_change)
+    print("-----")
+
+# -------------------------------------
+# Jul 10, 2024 - Deposit all stETH to Lido Withdrawal Strategy
+# -------------------------------------
+from world import *
+
+def main():
+  with TemporaryForkForReallocations() as txs:
+    # Before
+    txs.append(vault_oeth_core.rebase(std))
+    txs.append(oeth_vault_value_checker.takeSnapshot(std))
+    
+    # Deposit 156 validators * 32 ETH = 4992 WETH
+    txs.append(
+      vault_oeth_admin.depositToStrategy(
+        OETH_LIDO_WITHDRAWAL_STRAT, 
+        [STETH], 
+        [4992 * 10 **18],
+        std
+      )
+    )
+
+    steth_remaining = steth.balanceOf(OETH_VAULT)
+
+    # deposit of the remaining stETH
+    txs.append(
+      vault_oeth_admin.depositToStrategy(
+        OETH_LIDO_WITHDRAWAL_STRAT, 
+        [STETH], 
+        [steth_remaining],
+        std
+      )
+    )
+
+    # After
+    vault_change = vault_oeth_core.totalValue() - oeth_vault_value_checker.snapshots(STRATEGIST)[0]
+    supply_change = oeth.totalSupply() - oeth_vault_value_checker.snapshots(STRATEGIST)[1]
+    profit = vault_change - supply_change
+    txs.append(oeth_vault_value_checker.checkDelta(profit, (1 * 10**18), vault_change, (1 * 10**18), std))
+    print("stETH remaining", "{:.6f}".format(steth_remaining / 10**18), steth_remaining)
+    print("-----")
+    print("Profit", "{:.6f}".format(profit / 10**18), profit)
+    print("OETH supply change", "{:.6f}".format(supply_change / 10**18), supply_change)
+    print("Vault Change", "{:.6f}".format(vault_change / 10**18), vault_change)
+    print("-----")
+
+# -------------------------------------
+# Jul 11, 2024 - Claim withdrawals from Lido Withdrawal Strategy
+# -------------------------------------
+from world import *
+
+def main():
+  with TemporaryForkForReallocations() as txs:
+    # Before
+    txs.append(vault_oeth_core.rebase(std))
+    txs.append(oeth_vault_value_checker.takeSnapshot(std))
+    
+    # Claim the withdrawal requests from the Lido Withdrawal Queue
+    expected_amount = (4992 + 7000) * 10**18 + 914635193689940225665 + 5
+    txs.append(
+      lido_withdrawal_strat.claimWithdrawals(
+        # withdrawal NFT IDs in tx 0x3d43421cc03b8c6580eba42e4e3f85b1e9b7c82d94c5d28a9f62777775ed2dc9
+        [45345, 45346, 45347, 45348, 45349, 45350, 45351, 45352, 45353, 45354, 45355, 45356, 45357],
+        expected_amount,
+        std
+      )
+    )
+
+    # Deposit WETH to Native Staking Strategy
+    txs.append(
+      vault_oeth_admin.depositToStrategy(
+        OETH_NATIVE_STAKING_STRAT, 
+        [WETH], 
+        # (500 max validators - 243 existing validators) * 32 = 8,224 ETH
+        [8224 * 10**18],
+        std
+      )
+    )
+
+    # After
+    vault_change = vault_oeth_core.totalValue() - oeth_vault_value_checker.snapshots(STRATEGIST)[0]
+    supply_change = oeth.totalSupply() - oeth_vault_value_checker.snapshots(STRATEGIST)[1]
+    profit = vault_change - supply_change
+    txs.append(oeth_vault_value_checker.checkDelta(profit, (1 * 10**18), vault_change, (1 * 10**18), std))
+    print("-----")
+    print("Expected amount", "{:.6f}".format(expected_amount / 10**18), expected_amount)
+    print("Profit", "{:.6f}".format(profit / 10**18), profit)
+    print("OETH supply change", "{:.6f}".format(supply_change / 10**18), supply_change)
+    print("Vault Change", "{:.6f}".format(vault_change / 10**18), vault_change)
+    print("-----")
+
+# -------------------------------------
+# Jul 12, 2024 - Deposit 96 WETH to Native Staking Strategy
+# -------------------------------------
+from world import *
+
+def main():
+  with TemporaryForkForReallocations() as txs:
+    # Before
+    txs.append(vault_oeth_core.rebase(std))
+    txs.append(oeth_vault_value_checker.takeSnapshot(std))
+
+    # Deposit WETH to Native Staking Strategy
+    txs.append(
+      vault_oeth_admin.depositToStrategy(
+        OETH_NATIVE_STAKING_STRAT, 
+        [WETH], 
+        # 3 existing validators * 32 = 96 ETH
+        [96 * 10**18],
+        std
+      )
+    )
+
+    # After
+    vault_change = vault_oeth_core.totalValue() - oeth_vault_value_checker.snapshots(STRATEGIST)[0]
+    supply_change = oeth.totalSupply() - oeth_vault_value_checker.snapshots(STRATEGIST)[1]
+    profit = vault_change - supply_change
+    txs.append(oeth_vault_value_checker.checkDelta(profit, (1 * 10**18), vault_change, (1 * 10**18), std))
+    print("-----")
+    print("Profit", "{:.6f}".format(profit / 10**18), profit)
+    print("OETH supply change", "{:.6f}".format(supply_change / 10**18), supply_change)
+    print("Vault Change", "{:.6f}".format(vault_change / 10**18), vault_change)
+    print("-----")
+
+
+# -------------------------------------
+# Jul 12, 2024 - Deposit 32 WETH to Native Staking Strategy
+# -------------------------------------
+from world import *
+
+def main():
+  with TemporaryForkForReallocations() as txs:
+    # Before
+    txs.append(vault_oeth_core.rebase(std))
+    txs.append(oeth_vault_value_checker.takeSnapshot(std))
+
+    # Deposit WETH to Native Staking Strategy
+    txs.append(
+      vault_oeth_admin.depositToStrategy(
+        OETH_NATIVE_STAKING_STRAT, 
+        [WETH], 
+        # 1 more validator
+        [32 * 10**18],
+        std
+      )
+    )
+
+    # After
+    vault_change = vault_oeth_core.totalValue() - oeth_vault_value_checker.snapshots(STRATEGIST)[0]
+    supply_change = oeth.totalSupply() - oeth_vault_value_checker.snapshots(STRATEGIST)[1]
+    profit = vault_change - supply_change
+    txs.append(oeth_vault_value_checker.checkDelta(profit, (1 * 10**18), vault_change, (1 * 10**18), std))
+    print("-----")
+    print("Profit", "{:.6f}".format(profit / 10**18), profit)
+    print("OETH supply change", "{:.6f}".format(supply_change / 10**18), supply_change)
+    print("Vault Change", "{:.6f}".format(vault_change / 10**18), vault_change)
+    print("-----")

--- a/contracts/contracts/proxies/Proxies.sol
+++ b/contracts/contracts/proxies/Proxies.sol
@@ -229,7 +229,7 @@ contract NativeStakingFeeAccumulatorProxy is
 }
 
 /**
- * @notice NativeStakingSSVStrategy2Proxy delegates calls to NativeStakingSSVStrategy2 implementation
+ * @notice NativeStakingSSVStrategy2Proxy delegates calls to NativeStakingSSVStrategy implementation
  */
 contract NativeStakingSSVStrategy2Proxy is
     InitializeGovernedUpgradeabilityProxy
@@ -238,7 +238,7 @@ contract NativeStakingSSVStrategy2Proxy is
 }
 
 /**
- * @notice NativeStakingFeeAccumulator2Proxy delegates calls to FeeAccumulator2 implementation
+ * @notice NativeStakingFeeAccumulator2Proxy delegates calls to FeeAccumulator implementation
  */
 contract NativeStakingFeeAccumulator2Proxy is
     InitializeGovernedUpgradeabilityProxy

--- a/contracts/contracts/strategies/NativeStaking/FeeAccumulator.sol
+++ b/contracts/contracts/strategies/NativeStaking/FeeAccumulator.sol
@@ -44,17 +44,3 @@ contract FeeAccumulator {
      */
     receive() external payable {}
 }
-
-/**
- * @title Second Fee Accumulator for Native Staking SSV Strategy
- * @notice Receives execution rewards which includes tx fees and
- * MEV rewards like tx priority and tx ordering.
- * It does NOT include swept ETH from beacon chain consensus rewards or full validator withdrawals.
- * @author Origin Protocol Inc
- */
-contract FeeAccumulator2 is FeeAccumulator {
-    /**
-     * @param _strategy Address of the Native Staking Strategy
-     */
-    constructor(address _strategy) FeeAccumulator(_strategy) {}
-}

--- a/contracts/contracts/strategies/NativeStaking/NativeStakingSSVStrategy.sol
+++ b/contracts/contracts/strategies/NativeStaking/NativeStakingSSVStrategy.sol
@@ -318,36 +318,3 @@ contract NativeStakingSSVStrategy is
         depositedWethAccountedFor -= deductAmount;
     }
 }
-
-/// @title Second Native Staking SSV Strategy
-/// @notice Strategy to deploy funds into DVT validators powered by the SSV Network
-/// @author Origin Protocol Inc
-contract NativeStakingSSVStrategy2 is NativeStakingSSVStrategy {
-    /// @param _baseConfig Base strategy config with platformAddress (ERC-4626 Vault contract), eg sfrxETH or sDAI,
-    /// and vaultAddress (OToken Vault contract), eg VaultProxy or OETHVaultProxy
-    /// @param _wethAddress Address of the Erc20 WETH Token contract
-    /// @param _ssvToken Address of the Erc20 SSV Token contract
-    /// @param _ssvNetwork Address of the SSV Network contract
-    /// @param _maxValidators Maximum number of validators that can be registered in the strategy
-    /// @param _feeAccumulator Address of the fee accumulator receiving execution layer validator rewards
-    /// @param _beaconChainDepositContract Address of the beacon chain deposit contract
-    constructor(
-        BaseStrategyConfig memory _baseConfig,
-        address _wethAddress,
-        address _ssvToken,
-        address _ssvNetwork,
-        uint256 _maxValidators,
-        address _feeAccumulator,
-        address _beaconChainDepositContract
-    )
-        NativeStakingSSVStrategy(
-            _baseConfig,
-            _wethAddress,
-            _ssvToken,
-            _ssvNetwork,
-            _maxValidators,
-            _feeAccumulator,
-            _beaconChainDepositContract
-        )
-    {}
-}

--- a/contracts/deploy/mainnet/102_2nd_native_ssv_staking.js
+++ b/contracts/deploy/mainnet/102_2nd_native_ssv_staking.js
@@ -52,17 +52,17 @@ module.exports = deploymentWithGovernanceProposal(
     );
 
     // 3. Deploy the new FeeAccumulator implementation
-    console.log(`About to deploy FeeAccumulator2 implementation`);
-    const dFeeAccumulator2 = await deployWithConfirmation("FeeAccumulator2", [
+    console.log(`About to deploy FeeAccumulator implementation`);
+    const dFeeAccumulator2 = await deployWithConfirmation("FeeAccumulator", [
       cNativeStakingStrategy2Proxy.address, // _collector
     ]);
     const cFeeAccumulator2 = await ethers.getContractAt(
-      "FeeAccumulator2",
+      "FeeAccumulator",
       dFeeAccumulator2.address
     );
 
     // 4. Init the Second FeeAccumulator proxy to point at the implementation, set the governor
-    console.log(`About to initialize FeeAccumulator2`);
+    console.log(`About to initialize FeeAccumulator`);
     const proxyInitFunction = "initialize(address,address,bytes)";
     await withConfirmation(
       cFeeAccumulator2Proxy.connect(sDeployer)[proxyInitFunction](
@@ -74,9 +74,9 @@ module.exports = deploymentWithGovernanceProposal(
     );
 
     // 5. Deploy the new Native Staking Strategy implementation
-    console.log(`About to deploy NativeStakingSSVStrategy2 implementation`);
+    console.log(`About to deploy NativeStakingSSVStrategy implementation`);
     const dNativeStakingStrategy2Impl = await deployWithConfirmation(
-      "NativeStakingSSVStrategy2",
+      "NativeStakingSSVStrategy",
       [
         [addresses.zero, cVaultProxy.address], //_baseConfig
         addresses.mainnet.WETH, // wethAddress
@@ -88,12 +88,12 @@ module.exports = deploymentWithGovernanceProposal(
       ]
     );
     const cNativeStakingStrategy2Impl = await ethers.getContractAt(
-      "NativeStakingSSVStrategy2",
+      "NativeStakingSSVStrategy",
       dNativeStakingStrategy2Impl.address
     );
 
     const cNativeStakingStrategy2 = await ethers.getContractAt(
-      "NativeStakingSSVStrategy2",
+      "NativeStakingSSVStrategy",
       cNativeStakingStrategy2Proxy.address
     );
 

--- a/contracts/test/behaviour/ssvStrategy.js
+++ b/contracts/test/behaviour/ssvStrategy.js
@@ -245,8 +245,16 @@ const shouldBehaveLikeAnSsvStrategy = (context) => {
       );
     };
 
-    beforeEach(async () => {
+    beforeEach(async function () {
       const { addresses, nativeStakingSSVStrategy } = await context();
+
+      // Skip these tests if the Native Staking Strategy is full
+      const activeValidators =
+        await nativeStakingSSVStrategy.activeDepositedValidators();
+      if (activeValidators.gte(500)) {
+        this.skip();
+        return;
+      }
 
       const stakingMonitorSigner = await impersonateAndFund(addresses.Guardian);
       await nativeStakingSSVStrategy

--- a/contracts/test/strategies/nativeSsvStaking.mainnet.fork-test.js
+++ b/contracts/test/strategies/nativeSsvStaking.mainnet.fork-test.js
@@ -57,11 +57,11 @@ describe("ForkTest: Second Native SSV Staking Strategy", function () {
     fixture = await loadFixture();
     nativeStakingSSVStrategy = await resolveContract(
       "NativeStakingSSVStrategy2Proxy",
-      "NativeStakingSSVStrategy2"
+      "NativeStakingSSVStrategy"
     );
     nativeStakingFeeAccumulator = await resolveContract(
       "NativeStakingFeeAccumulator2Proxy",
-      "FeeAccumulator2"
+      "FeeAccumulator"
     );
   });
 


### PR DESCRIPTION
### Changes
- Remove `FeeAccumulator2` and `NativeStakingStrategy2` contracts
- Deploy file uses existing contracts instead

### Impact
- Whenever we deploy a new implementation, the address of the previous (belonging to completely different Native staking strategy) will get replaced. However, this should be fine if we no longer have those address after the deployment has been verified and proposal executed (which is the case with the first strategy). We can always use the proxy to read the actual implementation address if we ever need them


## Code Change Checklist

To be completed before internal review begins:

- [ ]  The contract code is complete
- [ ]  Executable deployment file
- [ ]  Fork tests that test after the deployment file runs
- [ ]  Unit tests *if needed
- [ ]  The owner has done a [full checklist review](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) of the code + tests

Internal review:

- [ ] Two approvals by internal reviewers


## Deploy checklist

Two reviewers complete the following checklist:

```
- [ ] All deployed contracts are listed in the deploy PR's description
- [ ] Deployed contract's verified code (and all dependencies) match the code in master
- [ ] The transactions that interacted with the newly deployed contract match the deploy script.
- [ ] Governance proposal matches the deploy script
- [ ] Smoke tests pass after fork test execution of the governance proposal
```

