### PR TITLE
Another allocate refactor

### DIFF
--- a/contracts/contracts/vault/VaultCore.sol
+++ b/contracts/contracts/vault/VaultCore.sol
@@ -284,7 +284,7 @@ contract VaultCore is VaultInitializer {
     /**
      * @notice Allocate unallocated funds on Vault to strategies.
      **/
-    function allocate() external whenNotCapitalPaused nonReentrant {
+    function allocate() external virtual whenNotCapitalPaused nonReentrant {
         _allocate();
     }
 


### PR DESCRIPTION
## Contract Changes

* Override `allocate` on OETH Vault so `_addWithdrawalQueueLiquidity` is not called twice on large mints.
* OEH Vault `_allocate` exits early if no default WETH strategy

## Code Change Checklist

To be completed before internal review begins:

- [ ]  The contract code is complete
- [ ]  Executable deployment file
- [ ]  Fork tests that test after the deployment file runs
- [ ]  Unit tests *if needed
- [ ]  The owner has done a [full checklist review](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) of the code + tests

Internal review:

- [ ] Two approvals by internal reviewers
