### PR TITLE
Run log OUSD default for USDT from Morpho Aave V2 to Aave

### DIFF
--- a/brownie/runlogs/2024_07_strategist.py
+++ b/brownie/runlogs/2024_07_strategist.py
@@ -576,3 +576,30 @@ def main():
     print("OETH supply change", "{:.6f}".format(supply_change / 10**18), supply_change)
     print("Vault Change", "{:.6f}".format(vault_change / 10**18), vault_change)
     print("-----")
+
+
+
+# --------------------------------
+# Jul 30, 2024 - Change the USDT default strategy from Morpho Aave V2 as Aave V2
+# 
+
+from world import *
+
+with TemporaryFork():
+    txs = []
+    # Before
+    txs.append(vault_core.rebase(std))
+    txs.append(vault_value_checker.takeSnapshot(std))
+    
+    txs.append(vault_admin.setAssetDefaultStrategy(USDT, AAVE_STRAT, {'from':STRATEGIST}))
+
+    # After
+    vault_change = vault_core.totalValue() - vault_value_checker.snapshots(STRATEGIST)[0]
+    supply_change = ousd.totalSupply() - vault_value_checker.snapshots(STRATEGIST)[1]
+    profit = vault_change - supply_change
+    txs.append(vault_value_checker.checkDelta(profit, (1 * 10**18), vault_change, (1 * 10**18), std))
+    print("-----")
+    print("Profit", "{:.6f}".format(profit / 10**18), profit)
+    print("OUSD supply change", "{:.6f}".format(supply_change / 10**18), supply_change)
+    print("Vault Change", "{:.6f}".format(vault_change / 10**18), vault_change)
+    print("-----")

--- a/contracts/test/_fixture.js
+++ b/contracts/test/_fixture.js
@@ -1500,24 +1500,18 @@ async function morphoAaveFixture() {
   const { timelock } = fixture;
 
   if (isFork) {
+    // The supply of DAI and USDT has been paused for Morpho Aave V2 so no default strategy
     await fixture.vault
       .connect(timelock)
-      .setAssetDefaultStrategy(
-        fixture.usdt.address,
-        fixture.morphoAaveStrategy.address
-      );
+      .setAssetDefaultStrategy(fixture.dai.address, addresses.zero);
+    await fixture.vault
+      .connect(timelock)
+      .setAssetDefaultStrategy(fixture.usdt.address, addresses.zero);
 
     await fixture.vault
       .connect(timelock)
       .setAssetDefaultStrategy(
         fixture.usdc.address,
-        fixture.morphoAaveStrategy.address
-      );
-
-    await fixture.vault
-      .connect(timelock)
-      .setAssetDefaultStrategy(
-        fixture.dai.address,
         fixture.morphoAaveStrategy.address
       );
   } else {

--- a/contracts/test/_fixture.js
+++ b/contracts/test/_fixture.js
@@ -1492,6 +1492,30 @@ async function morphoCompoundFixture() {
 }
 
 /**
+ * Configure a Vault with only the Aave strategy for USDT.
+ */
+async function aaveFixture() {
+  const fixture = await defaultFixture();
+
+  const { timelock } = fixture;
+
+  if (isFork) {
+    await fixture.vault
+      .connect(timelock)
+      .setAssetDefaultStrategy(
+        fixture.usdt.address,
+        fixture.aaveStrategy.address
+      );
+  } else {
+    throw new Error(
+      "Aave strategy supported for USDT in forked test environment"
+    );
+  }
+
+  return fixture;
+}
+
+/**
  * Configure a Vault with only the Morpho strategy.
  */
 async function morphoAaveFixture() {
@@ -2467,6 +2491,7 @@ module.exports = {
   convexLUSDMetaVaultFixture,
   makerDsrFixture,
   morphoCompoundFixture,
+  aaveFixture,
   morphoAaveFixture,
   aaveVaultFixture,
   hackedVaultFixture,

--- a/contracts/test/strategies/aave.mainnet.fork-test.js
+++ b/contracts/test/strategies/aave.mainnet.fork-test.js
@@ -1,0 +1,187 @@
+const { expect } = require("chai");
+
+const {
+  units,
+  ousdUnits,
+  advanceBlocks,
+  advanceTime,
+  isCI,
+} = require("../helpers");
+const { createFixtureLoader, aaveFixture } = require("../_fixture");
+const { impersonateAndFund } = require("../../utils/signers");
+
+describe("ForkTest: Aave Strategy", function () {
+  this.timeout(0);
+
+  // Retry up to 3 times on CI
+  this.retries(isCI ? 3 : 0);
+
+  let fixture;
+  const loadFixture = createFixtureLoader(aaveFixture);
+  beforeEach(async () => {
+    fixture = await loadFixture();
+  });
+
+  describe("Mint", function () {
+    it("Should deploy USDT in Aave", async function () {
+      const { josh, usdt } = fixture;
+      await mintTest(fixture, josh, usdt, "200000");
+    });
+  });
+
+  describe("Redeem", function () {
+    it("Should redeem from Aave", async () => {
+      const { vault, ousd, usdt, anna } = fixture;
+
+      await vault.connect(anna).rebase();
+
+      const supplyBeforeMint = await ousd.totalSupply();
+
+      const amount = "30100";
+
+      // Mint with USDT
+      await vault
+        .connect(anna)
+        .mint(usdt.address, await units(amount, usdt), 0);
+
+      const currentSupply = await ousd.totalSupply();
+      const supplyAdded = currentSupply.sub(supplyBeforeMint);
+      expect(supplyAdded).to.approxEqualTolerance(ousdUnits("30000"), 1);
+
+      const currentBalance = await ousd.connect(anna).balanceOf(anna.address);
+
+      // Now try to redeem 30k
+      await vault.connect(anna).redeem(ousdUnits("30000"), 0);
+
+      // User balance should be down by 30k
+      const newBalance = await ousd.connect(anna).balanceOf(anna.address);
+      expect(newBalance).to.approxEqualTolerance(
+        currentBalance.sub(ousdUnits("30000")),
+        1
+      );
+
+      const newSupply = await ousd.totalSupply();
+      const supplyDiff = currentSupply.sub(newSupply);
+
+      expect(supplyDiff).to.approxEqualTolerance(ousdUnits("30000"), 1);
+    });
+  });
+
+  describe("Withdraw", function () {
+    it("Should be able to withdraw USDT from strategy", async function () {
+      const { franck, usdt } = fixture;
+      await withdrawTest(fixture, franck, usdt, "5000");
+    });
+
+    it("Should be able to withdrawAll from strategy", async function () {
+      const { matt, usdc, vault, usdt, aaveStrategy } = fixture;
+      const vaultSigner = await impersonateAndFund(vault.address);
+      const amount = "110000";
+
+      const usdcUnits = await units(amount, usdc);
+      const usdtUnits = await units(amount, usdt);
+
+      await vault.connect(matt).mint(usdt.address, usdtUnits, 0);
+      await vault.connect(matt).mint(usdc.address, usdcUnits, 0);
+
+      await vault.connect(matt).rebase();
+      await vault.connect(matt).allocate();
+
+      const vaultUsdtBefore = await usdt.balanceOf(vault.address);
+      const vaultUsdcBefore = await usdc.balanceOf(vault.address);
+
+      const stratBalUsdc = await aaveStrategy.checkBalance(usdc.address);
+      const stratBalUsdt = await aaveStrategy.checkBalance(usdt.address);
+
+      await aaveStrategy.connect(vaultSigner).withdrawAll();
+
+      const vaultUsdtDiff =
+        (await usdt.balanceOf(vault.address)) - vaultUsdtBefore;
+      const vaultUsdcDiff =
+        (await usdc.balanceOf(vault.address)) - vaultUsdcBefore;
+
+      expect(vaultUsdcDiff).to.approxEqualTolerance(stratBalUsdc, 1);
+      expect(vaultUsdtDiff).to.approxEqualTolerance(stratBalUsdt, 1);
+
+      expect(await aaveStrategy.checkBalance(usdc.address)).to.equal("0");
+      expect(await aaveStrategy.checkBalance(usdt.address)).to.equal("0");
+    });
+  });
+
+  // set it as a last test that executes because we advance time and theat
+  // messes with recency of oracle prices
+  describe("Supply Revenue", function () {
+    it("Should get supply interest", async function () {
+      const { anna, usdt, aaveStrategy } = fixture;
+      await mintTest(fixture, anna, usdt, "110000");
+
+      const currentBalance = await aaveStrategy.checkBalance(usdt.address);
+
+      await advanceTime(60 * 60 * 24 * 365);
+      await advanceBlocks(10000);
+
+      const balanceAfter1Y = await aaveStrategy.checkBalance(usdt.address);
+
+      const diff = balanceAfter1Y.sub(currentBalance);
+      expect(diff).to.be.gt(0);
+    });
+  });
+});
+
+async function mintTest(fixture, user, asset, amount = "30000") {
+  const { vault, ousd, aaveStrategy } = fixture;
+
+  await vault.connect(user).rebase();
+  await vault.connect(user).allocate();
+
+  const unitAmount = await units(amount, asset);
+
+  const currentSupply = await ousd.totalSupply();
+  const currentBalance = await ousd.connect(user).balanceOf(user.address);
+  const currentStrategyBalance = await aaveStrategy.checkBalance(asset.address);
+
+  // Mint OUSD w/ asset
+  await vault.connect(user).mint(asset.address, unitAmount, 0);
+  await vault.connect(user).allocate();
+
+  const newBalance = await ousd.connect(user).balanceOf(user.address);
+  const newSupply = await ousd.totalSupply();
+  const newStrategyBalance = await aaveStrategy.checkBalance(asset.address);
+
+  const balanceDiff = newBalance.sub(currentBalance);
+  // Ensure user has correct balance (w/ 1% slippage tolerance)
+  expect(balanceDiff).to.approxEqualTolerance(ousdUnits(amount), 1);
+
+  // Supply checks
+  const supplyDiff = newSupply.sub(currentSupply);
+  const ousdUnitAmount = ousdUnits(amount);
+
+  expect(supplyDiff).to.approxEqualTolerance(ousdUnitAmount, 1);
+
+  const liquidityDiff = newStrategyBalance.sub(currentStrategyBalance);
+
+  // Should have liquidity in Aave
+  expect(liquidityDiff).to.approxEqualTolerance(await units(amount, asset), 1);
+}
+
+async function withdrawTest(fixture, user, asset, amount) {
+  const { vault, aaveStrategy } = fixture;
+  if (amount) {
+    await mintTest(fixture, user, asset, amount);
+  }
+
+  const assetUnits = amount
+    ? await units(amount, asset)
+    : await aaveStrategy.checkBalance(asset.address);
+  const vaultAssetBalBefore = await asset.balanceOf(vault.address);
+  const vaultSigner = await impersonateAndFund(vault.address);
+
+  await aaveStrategy
+    .connect(vaultSigner)
+    .withdraw(vault.address, asset.address, assetUnits);
+  const vaultAssetBalDiff = (await asset.balanceOf(vault.address)).sub(
+    vaultAssetBalBefore
+  );
+
+  expect(vaultAssetBalDiff).to.approxEqualTolerance(assetUnits, 1);
+}

--- a/contracts/test/strategies/morpho-aave.mainnet.fork-test.js
+++ b/contracts/test/strategies/morpho-aave.mainnet.fork-test.js
@@ -28,12 +28,12 @@ describe("ForkTest: Morpho Aave Strategy", function () {
       await mintTest(fixture, matt, usdc, "110000");
     });
 
-    it("Should deploy USDT in Morpho Aave", async function () {
+    it.skip("Should deploy USDT in Morpho Aave", async function () {
       const { josh, usdt } = fixture;
       await mintTest(fixture, josh, usdt, "200000");
     });
 
-    it("Should deploy DAI in Morpho Aave", async function () {
+    it.skip("Should deploy DAI in Morpho Aave", async function () {
       const { anna, dai } = fixture;
       await mintTest(fixture, anna, dai, "110000");
     });
@@ -82,12 +82,12 @@ describe("ForkTest: Morpho Aave Strategy", function () {
   describe("Withdraw", function () {
     it("Should be able to withdraw from DAI strategy", async function () {
       const { domen, dai } = fixture;
-      await withdrawTest(fixture, domen, dai, "28000");
+      await withdrawTest(fixture, domen, dai, undefined);
     });
 
     it("Should be able to withdraw from USDT strategy", async function () {
       const { franck, usdt } = fixture;
-      await withdrawTest(fixture, franck, usdt, "33000");
+      await withdrawTest(fixture, franck, usdt, undefined);
     });
 
     it("Should be able to withdraw from USDC strategy", async function () {
@@ -134,15 +134,19 @@ describe("ForkTest: Morpho Aave Strategy", function () {
   // messes with recency of oracle prices
   describe("Supply Revenue", function () {
     it("Should get supply interest", async function () {
-      const { anna, dai, morphoAaveStrategy } = fixture;
-      await mintTest(fixture, anna, dai, "110000");
+      const { anna, usdc, morphoAaveStrategy } = fixture;
+      await mintTest(fixture, anna, usdc, "110000");
 
-      const currentBalance = await morphoAaveStrategy.checkBalance(dai.address);
+      const currentBalance = await morphoAaveStrategy.checkBalance(
+        usdc.address
+      );
 
       await advanceTime(60 * 60 * 24 * 365);
       await advanceBlocks(10000);
 
-      const balanceAfter1Y = await morphoAaveStrategy.checkBalance(dai.address);
+      const balanceAfter1Y = await morphoAaveStrategy.checkBalance(
+        usdc.address
+      );
 
       const diff = balanceAfter1Y.sub(currentBalance);
       expect(diff).to.be.gt(0);
@@ -191,11 +195,15 @@ async function mintTest(fixture, user, asset, amount = "30000") {
   );
 }
 
-async function withdrawTest(fixture, user, asset, amount = "25000") {
+async function withdrawTest(fixture, user, asset, amount) {
   const { vault, morphoAaveStrategy } = fixture;
-  await mintTest(fixture, user, asset, amount);
+  if (amount) {
+    await mintTest(fixture, user, asset, amount);
+  }
 
-  const assetUnits = await units(amount, asset);
+  const assetUnits = amount
+    ? await units(amount, asset)
+    : await morphoAaveStrategy.checkBalance(asset.address);
   const vaultAssetBalBefore = await asset.balanceOf(vault.address);
   const vaultSigner = await impersonateAndFund(vault.address);
 

--- a/contracts/test/vault/vault.mainnet.fork-test.js
+++ b/contracts/test/vault/vault.mainnet.fork-test.js
@@ -183,7 +183,7 @@ describe("ForkTest: Vault", function () {
     });
 
     it("should withdraw from and deposit to strategy", async () => {
-      const { vault, josh, usdc, dai, morphoAaveStrategy } = fixture;
+      const { vault, josh, usdc, dai, aaveStrategy } = fixture;
       await vault.connect(josh).mint(usdc.address, usdcUnits("90"), 0);
       await vault.connect(josh).mint(dai.address, daiUnits("50"), 0);
       const strategistSigner = await impersonateAndFund(
@@ -198,12 +198,12 @@ describe("ForkTest: Vault", function () {
         async () => {
           [daiStratDiff, usdcStratDiff] = await differenceInStrategyBalance(
             [dai.address, usdc.address],
-            [morphoAaveStrategy, morphoAaveStrategy],
+            [aaveStrategy, aaveStrategy],
             async () => {
               await vault
                 .connect(strategistSigner)
                 .depositToStrategy(
-                  morphoAaveStrategy.address,
+                  aaveStrategy.address,
                   [dai.address, usdc.address],
                   [daiUnits("50"), usdcUnits("90")]
                 );
@@ -224,12 +224,12 @@ describe("ForkTest: Vault", function () {
         async () => {
           [daiStratDiff, usdcStratDiff] = await differenceInStrategyBalance(
             [dai.address, usdc.address],
-            [morphoAaveStrategy, morphoAaveStrategy],
+            [aaveStrategy, aaveStrategy],
             async () => {
               await vault
                 .connect(strategistSigner)
                 .withdrawFromStrategy(
-                  morphoAaveStrategy.address,
+                  aaveStrategy.address,
                   [dai.address, usdc.address],
                   [daiUnits("50"), usdcUnits("90")]
                 );


### PR DESCRIPTION
## Changes

* The DAI and USDT markets for Morpho Aave V2 Optimizer have been paused for supply. This run log changes the USDT default strategy from Morpho Aave to Aave. 
* DAI currently defaults to the DRS strategy so there is no need to change it.
* The USDC market for Morpho Aave V2 Optimizer is still enabled so the OUSD detault strategy for USDC will remain the Morpho Aave strategy.

## Testing

* OUSD Fork tests have been added for the Aave Strategy.

## Deploy checklist

Two reviewers complete the following checklist:

```
- [ ] All deployed contracts are listed in the deploy PR's description
- [ ] Deployed contract's verified code (and all dependencies) match the code in master
- [ ] The transactions that interacted with the newly deployed contract match the deploy script.
- [ ] Governance proposal matches the deploy script
- [ ] Smoke tests pass after fork test execution of the governance proposal
```

