### PR TITLE
Fix checkBalance bug in new OETHVaultCore

### DIFF
--- a/contracts/contracts/vault/OETHVaultCore.sol
+++ b/contracts/contracts/vault/OETHVaultCore.sol
@@ -397,11 +397,11 @@ contract OETHVaultCore is VaultCore {
         override
         returns (uint256 balance)
     {
-        balance = super._checkBalance(_asset);
-
         if (_asset != weth) {
             return 0;
         }
+
+        balance = super._checkBalance(_asset);
 
         WithdrawalQueueMetadata memory queue = withdrawalQueueMetadata;
         // If there is not enough WETH in the vault and strategies to cover the outstanding withdrawals.

--- a/contracts/contracts/vault/OETHVaultCore.sol
+++ b/contracts/contracts/vault/OETHVaultCore.sol
@@ -399,13 +399,19 @@ contract OETHVaultCore is VaultCore {
     {
         balance = super._checkBalance(_asset);
 
-        if (_asset == weth) {
-            WithdrawalQueueMetadata memory queue = withdrawalQueueMetadata;
-            // Need to remove WETH that is reserved for the withdrawal queue
-            if (balance + queue.claimed >= queue.queued) {
-                return balance + queue.claimed - queue.queued;
-            }
+        if (_asset != weth) {
+            return 0;
         }
+
+        WithdrawalQueueMetadata memory queue = withdrawalQueueMetadata;
+        // If there is not enough WETH in the vault and strategies to cover the outstanding withdrawals.
+        // It can happen if more than half of the users have requested a withdrawal but have not claimed.
+        if (balance + queue.claimed < queue.queued) {
+            return 0;
+        }
+
+        // Need to remove WETH that is reserved for the withdrawal queue
+        return balance + queue.claimed - queue.queued;
     }
 
     /**

--- a/contracts/test/vault/oeth-vault.js
+++ b/contracts/test/vault/oeth-vault.js
@@ -2149,6 +2149,11 @@ describe("OETH Vault", function () {
           // 100 from mints - 99 outstanding withdrawals - 2 from slashing = -1 value which is rounder up to zero
           expect(await fixture.oethVault.totalValue()).to.equal(0);
         });
+        it("Should have check balance of zero", async () => {
+          const { oethVault, weth } = fixture;
+          // 100 from mints - 99 outstanding withdrawals - 2 from slashing = -1 value which is rounder up to zero
+          expect(await oethVault.checkBalance(weth.address)).to.equal(0);
+        });
         it("Fail to allow user to create a new request due to too many outstanding requests", async () => {
           const { oethVault, matt } = fixture;
 


### PR DESCRIPTION
## Contract changes

* `checkBalance` has the same bug as `_wethAvailable()`. If there is more outstanding withdrawal requests than WETH in the vault and strategies, the checkBalance will not return 0. It will return the balance
* Unit test added to cover this bug

This bug is not on mainnet. It's only on `master` after the OETH Withdrawal Queue changes were merged.

## Code Change Checklist

To be completed before internal review begins:

- [ ]  The contract code is complete
- [ ]  Executable deployment file
- [ ]  Fork tests that test after the deployment file runs
- [ ]  Unit tests *if needed
- [ ]  The owner has done a [full checklist review](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) of the code + tests

Internal review:

- [ ] Two approvals by internal reviewers

