### PR TITLE
M-01 _checkBalance Returns an Incorrect Value During Insolvency

### DIFF
--- a/contracts/contracts/vault/OETHVaultCore.sol
+++ b/contracts/contracts/vault/OETHVaultCore.sol
@@ -395,15 +395,21 @@ contract OETHVaultCore is VaultCore {
         override
         returns (uint256 balance)
     {
+        if (_asset != weth) {
+            return 0;
+        }
+
         balance = super._checkBalance(_asset);
 
-        if (_asset == weth) {
-            WithdrawalQueueMetadata memory queue = withdrawalQueueMetadata;
-            // Need to remove WETH that is reserved for the withdrawal queue
-            if (balance + queue.claimed >= queue.queued) {
-                return balance + queue.claimed - queue.queued;
-            }
+        WithdrawalQueueMetadata memory queue = withdrawalQueueMetadata;
+        // If there is not enough WETH in the vault and strategies to cover the outstanding withdrawals.
+        // It can happen if more than half of the users have requested a withdrawal but have not claimed.
+        if (balance + queue.claimed < queue.queued) {
+            return 0;
         }
+
+        // Need to remove WETH that is reserved for the withdrawal queue
+        return balance + queue.claimed - queue.queued;
     }
 
     /**

--- a/contracts/contracts/vault/OETHVaultCore.sol
+++ b/contracts/contracts/vault/OETHVaultCore.sol
@@ -399,11 +399,14 @@ contract OETHVaultCore is VaultCore {
             return 0;
         }
 
+        // Get the WETH in the vault and the strategies
         balance = super._checkBalance(_asset);
 
         WithdrawalQueueMetadata memory queue = withdrawalQueueMetadata;
-        // If there is not enough WETH in the vault and strategies to cover the outstanding withdrawals.
-        // It can happen if more than half of the users have requested a withdrawal but have not claimed.
+
+        // If the vault becomes insolvent enough that the total value in the vault and all strategies
+        // is less than the outstanding withdrawals.
+        // For example, there was a mass slashing event and most users request a withdrawal.
         if (balance + queue.claimed < queue.queued) {
             return 0;
         }
@@ -452,29 +455,14 @@ contract OETHVaultCore is VaultCore {
         emit AssetAllocated(weth, depositStrategyAddr, allocateAmount);
     }
 
-    /// @dev The total value of all assets held by the vault and all its strategies
+    /// @dev The total value of all WETH held by the vault and all its strategies
     /// less any WETH that is reserved for the withdrawal queue.
-    /// For OETH, this is just WETH in the vault and strategies.
     ///
     // If there is not enough WETH in the vault and all strategies to cover all outstanding
     // withdrawal requests then return a total value of 0.
     function _totalValue() internal view override returns (uint256 value) {
-        value = _totalValueInVault() + _totalValueInStrategies();
-
-        // Need to remove WETH that is reserved for the withdrawal queue.
-        WithdrawalQueueMetadata memory queue = withdrawalQueueMetadata;
-        // reserved for the withdrawal queue = cumulative queued total - total claimed
-        uint256 reservedForQueue = queue.queued - queue.claimed;
-
-        if (value < reservedForQueue) {
-            // This can happen if the vault becomes insolvent enough that the
-            // total value in the vault and all strategies is less than the outstanding withdrawals.
-            // For example, there was a mass slashing event and most users request a withdrawal.
-            return 0;
-        }
-
-        // Adjust the total value by the amount reserved for the withdrawal queue
-        return value - reservedForQueue;
+        // As WETH is the only asset, just return the WETH balance
+        return _checkBalance(weth);
     }
 
     /// @dev Only WETH is supported in the OETH Vault so return the WETH balance only

--- a/contracts/test/vault/oeth-vault.js
+++ b/contracts/test/vault/oeth-vault.js
@@ -2149,6 +2149,11 @@ describe("OETH Vault", function () {
           // 100 from mints - 99 outstanding withdrawals - 2 from slashing = -1 value which is rounder up to zero
           expect(await fixture.oethVault.totalValue()).to.equal(0);
         });
+        it("Should have check balance of zero", async () => {
+          const { oethVault, weth } = fixture;
+          // 100 from mints - 99 outstanding withdrawals - 2 from slashing = -1 value which is rounder up to zero
+          expect(await oethVault.checkBalance(weth.address)).to.equal(0);
+        });
         it("Fail to allow user to create a new request due to too many outstanding requests", async () => {
           const { oethVault, matt } = fixture;
 


### PR DESCRIPTION
# OZ Audit Fix

## M-01 _checkBalance Returns an Incorrect Value During Insolvency

The [_checkBalance](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/OETHVaultCore.sol#L392-L407) function returns the balance of an asset held in the vault and all the strategies. If the requested asset is WETH, the amount of WETH reserved for the withdrawal queue is subtracted from this balance to reflect the correct amount of workable assets. In this specific case, the function returns the same result as [the _totalValue function](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/OETHVaultCore.sol#L455-L472).

In the event that the vault becomes insolvent (e.g., during a mass slashing event) and multiple users are requesting to withdraw their OETH, the WETH in the withdrawal queue may exceed the total amount of workable assets. In this case, the function should return a balance of 0. However, it will actually [return](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/OETHVaultCore.sol#L398) the amount of WETH in the vault and strategies without subtracting the WETH reserved for the withdrawal queue.

Consider returning 0 in case the amount of WETH reserved for the withdrawal queue exceeds the total amount of workable assets. In addition, since the `_checkBalance` function should return the same value as the `_totalValue` function if the asset is WETH, consider calling `_totalValue` in `_checkBalance` or vice versa.

## Tracking

This was fixed post the OZ Audit commit in the following commits which has been cherry picked into this PR:

* ed40c7922bdfc8e3d3b793e7dce6c04dab7df232
* 2860b38e9b8349b6824a0101f8ace3a84e6c1a33
