### PR TITLE
M-02 Incorrect __gap Variable Decrement in VaultStorage

### DIFF
--- a/contracts/contracts/vault/VaultStorage.sol
+++ b/contracts/contracts/vault/VaultStorage.sol
@@ -222,7 +222,7 @@ contract VaultStorage is Initializable, Governable {
     mapping(uint256 => WithdrawalRequest) public withdrawalRequests;
 
     // For future use
-    uint256[46] private __gap;
+    uint256[45] private __gap;
 
     /**
      * @notice set the implementation for the admin, this needs to be in a base class else we cannot set it


### PR DESCRIPTION
# OZ Audit fix

## M-02 Incorrect __gap Variable Decrement in VaultStorage

In the audited version of the contract, 4 slots were added to the storage of the `VaultStorage` contract:

* `dripper`, which [occupies](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/VaultStorage.sol#L186) 1 slot.
* `withdrawalQueueMetadata`, which [occupies](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/VaultStorage.sol#L208) 2 slots given the packing of the 4 uint128 values.
* `withdrawalRequests`, which [occupies](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/VaultStorage.sol#L222) 1 slot.

However, the `__gap` variable was only decreased by 3 slots from 49 to 46 instead of 4 slots. This discrepancy in the `__gap` value could lead to a storage collision if a contract upgrade occurs. In addition, the starting point for the `__gap` variable count is not clearly indicated in the code, making it prone to errors that could lead to storage collisions in future versions.

Consider updating the `__gap` variable to the correct value to prevent potential storage collisions. Moreover, adding code comments that clarify where the count for the `__gap` variable starts would help prevent similar issues in the future.

## Tracking

This was fixed post the OZ Audit commit in the following commit which has been cherry picked into this PR:

* 231459a8be5d21762aea4c9e02b5ef4fa7007e1b
