### PR TITLE
L-03 Missing Docstrings

### DIFF
--- a/contracts/contracts/vault/VaultCore.sol
+++ b/contracts/contracts/vault/VaultCore.sol
@@ -23,9 +23,9 @@ import "./VaultInitializer.sol";
 contract VaultCore is VaultInitializer {
     using SafeERC20 for IERC20;
     using StableMath for uint256;
-    // max signed int
+    /// @dev max signed int
     uint256 internal constant MAX_INT = 2**255 - 1;
-    // max un-signed int
+    /// @dev max un-signed int
     uint256 internal constant MAX_UINT =
         0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
 
@@ -45,6 +45,9 @@ contract VaultCore is VaultInitializer {
         _;
     }
 
+    /**
+     * @dev Verifies that the caller is the AMO strategy.
+     */
     modifier onlyOusdMetaStrategy() {
         require(
             msg.sender == ousdMetaStrategy,
@@ -67,6 +70,12 @@ contract VaultCore is VaultInitializer {
         _mint(_asset, _amount, _minimumOusdAmount);
     }
 
+    /**
+     * @dev Deposit a supported asset and mint OTokens.
+     * @param _asset Address of the asset being deposited
+     * @param _amount Amount of the asset being deposited
+     * @param _minimumOusdAmount Minimum OTokens to mint
+     */
     function _mint(
         address _asset,
         uint256 _amount,
@@ -731,6 +740,11 @@ contract VaultCore is VaultInitializer {
         }
     }
 
+    /**
+     * @dev Get the number of decimals of a token asset
+     * @param _asset Address of the asset
+     * @return decimals number of decimals
+     */
     function _getDecimals(address _asset)
         internal
         view
@@ -749,6 +763,7 @@ contract VaultCore is VaultInitializer {
 
     /**
      * @notice Gets the vault configuration of a supported asset.
+     * @param _asset Address of the token asset
      */
     function getAssetConfig(address _asset)
         public

--- a/contracts/contracts/vault/VaultStorage.sol
+++ b/contracts/contracts/vault/VaultStorage.sol
@@ -122,14 +122,15 @@ contract VaultStorage is Initializable, Governable {
     // slither-disable-next-line uninitialized-state
     OUSD internal oUSD;
 
-    //keccak256("OUSD.vault.governor.admin.impl");
+    /// @dev Storage slot for the address of the VaultAdmin contract that is delegated to
+    // keccak256("OUSD.vault.governor.admin.impl");
     bytes32 constant adminImplPosition =
         0xa2bd3d3cf188a41358c8b401076eb59066b09dec5775650c0de4c55187d17bd9;
 
-    // Address of the contract responsible for post rebase syncs with AMMs
+    /// @dev Address of the contract responsible for post rebase syncs with AMMs
     address private _deprecated_rebaseHooksAddr = address(0);
 
-    // Deprecated: Address of Uniswap
+    /// @dev Deprecated: Address of Uniswap
     // slither-disable-next-line constable-states
     address private _deprecated_uniswapAddr = address(0);
 
@@ -221,8 +222,8 @@ contract VaultStorage is Initializable, Governable {
     /// @notice Mapping of withdrawal request indices to the user withdrawal request data
     mapping(uint256 => WithdrawalRequest) public withdrawalRequests;
 
-    // For future use
-    uint256[46] private __gap;
+    /// @dev For future use
+    uint256[45] private __gap;
 
     /**
      * @notice set the implementation for the admin, this needs to be in a base class else we cannot set it


### PR DESCRIPTION
# OZ Audit Fix

## L-03 Missing Docstrings

Throughout the codebase, a few instances of missing docstrings were identified:

* The [IVault interface](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/interfaces/IVault.sol#L6-L253) in `IVault.sol`
* The [VaultStorage contract](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/VaultStorage.sol#L20-L242) in `VaultStorage.sol`
* The [VaultCore contract](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/VaultCore.sol#L23-L834) in `VaultCore.sol`

Consider thoroughly documenting all functions (and their parameters) that are part of any contract's public API. Functions implementing sensitive functionality, even if not public, should be clearly documented as well. When writing docstrings, consider following the [Ethereum Natural Specification Format](https://solidity.readthedocs.io/en/latest/natspec-format.html) (NatSpec).

