### PR TITLE
N-01 Use calldata Instead of memory

### DIFF
--- a/contracts/contracts/vault/OETHVaultCore.sol
+++ b/contracts/contracts/vault/OETHVaultCore.sol
@@ -252,7 +252,7 @@ contract OETHVaultCore is VaultCore {
      * @return amounts Amount of WETH received for each request
      * @return totalAmount Total amount of WETH transferred to the withdrawer
      */
-    function claimWithdrawals(uint256[] memory _requestIds)
+    function claimWithdrawals(uint256[] calldata _requestIds)
         external
         whenNotCapitalPaused
         nonReentrant


### PR DESCRIPTION
## N-01 Use calldata Instead of memory

When dealing with function parameters in `external` functions, it is more efficient to use `calldata` instead of `memory`. `calldata` is a read-only region of memory that contains the function arguments, which makes it cheaper and more efficient compared to `memory`. Using `calldata` can save gas and improve the performance of a smart contract.

Within `OETHVaultCore.sol`, the [_requestIds](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/OETHVaultCore.sol#L255) parameter should use `calldata` instead of `memory`.

Consider using `calldata` for function parameters in `external` functions to optimize gas usage.