### PR TITLE
N-02 Unnecessary Cast

### DIFF
--- a/contracts/contracts/vault/VaultAdmin.sol
+++ b/contracts/contracts/vault/VaultAdmin.sol
@@ -205,7 +205,7 @@ contract VaultAdmin is VaultStorage {
         bytes calldata _data
     ) internal virtual returns (uint256 toAssetAmount) {
         // Check fromAsset and toAsset are valid
-        Asset memory fromAssetConfig = assets[address(_fromAsset)];
+        Asset memory fromAssetConfig = assets[_fromAsset];
         Asset memory toAssetConfig = assets[_toAsset];
         require(fromAssetConfig.isSupported, "From asset is not supported");
         require(toAssetConfig.isSupported, "To asset is not supported");


### PR DESCRIPTION
## N-02 Unnecessary Cast

Within the `VaultAdmin` contract, the [address(_fromAsset)](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/VaultAdmin.sol#L208) cast is unnecessary.

To improve code clarity, consider removing any unnecessary casts.
