### PR TITLE
N-04 Incorrect or Misleading Documentation

### DIFF
--- a/contracts/contracts/vault/OETHVaultCore.sol
+++ b/contracts/contracts/vault/OETHVaultCore.sol
@@ -158,12 +158,12 @@ contract OETHVaultCore is VaultCore {
      * The OETH is burned on request and the WETH is transferred to the withdrawer on claim.
      * This request can be claimed once the withdrawal queue's `claimable` amount
      * is greater than or equal this request's `queued` amount.
-     * There is no minimum time or block number before a request can be claimed. It just needs
+     * There is a minimum of 10 minutes before a request can be claimed. After that, the request just needs
      * enough WETH liquidity in the Vault to satisfy all the outstanding requests to that point in the queue.
      * OETH is converted to WETH at 1:1.
      * @param _amount Amount of OETH to burn.
-     * @param requestId Unique ID for the withdrawal request
-     * @param queued Cumulative total of all WETH queued including already claimed requests.
+     * @return requestId Unique ID for the withdrawal request
+     * @return queued Cumulative total of all WETH queued including already claimed requests.
      */
     function requestWithdrawal(uint256 _amount)
         external
@@ -383,7 +383,7 @@ contract OETHVaultCore is VaultCore {
 
     /// @dev Get the balance of an asset held in Vault and all strategies
     /// less any WETH that is reserved for the withdrawal queue.
-    /// This will only return a non-zero balance for WETH.
+    /// WETH is the only asset that can return a non-zero balance.
     /// All other assets will return 0 even if there is some dust amounts left in the Vault.
     /// For example, there is 1 wei left of stETH in the OETH Vault but will return 0 in this function.
     ///


### PR DESCRIPTION
Throughout the codebase, a few instances of incorrect or misleading documentation were identified:

* The documentation of the `requestWithdrawal` function [states](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/OETHVaultCore.sol#L157-L163) that there is no minimum time or block number before a request can be claimed. However, there is in fact a minimum time of 10 minutes before a request can be claimed.
* The NatSpec of the `requestWithdrawal` function [states](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/OETHVaultCore.sol#L164-L166) that the function has three parameters. However, the function only has a single `_amount` parameter and two return variables `requestId` and `queued`.
* The documentation of the `_checkBalance` function [states](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/OETHVaultCore.sol#L386) that it will only return a non-zero balance for WETH. However, it could return 0 in case the total amount of assets in the vault and the strategies is equal to the amount of assets requested for withdrawal. In addition, it should return 0 in case the total amount of assets in the vault and the strategies is equal to the amount of assets requested for withdrawal as described in issue [M-01](https://defender.openzeppelin.com/v2/#m01).
* The documentation of the `_checkBalance` function [states](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/OETHVaultCore.sol#L387) that all assets, except for WETH, will return 0 even if there is some dust amount left in the Vault. However, this function calls the `_checkBalance` function of the inherited `VaultCore` contract, which could return a non-zero balance for assets other than WETH.
* 
Clean and accurate documentation helps users and developers better understand the codebase. As such, consider updating the identified instances of incorrect or misleading documentation.