### PR TITLE
N-05 State Variable Visibility Not Explicitly Declared

### DIFF
--- a/contracts/contracts/vault/OETHVaultCore.sol
+++ b/contracts/contracts/vault/OETHVaultCore.sol
@@ -18,7 +18,7 @@ contract OETHVaultCore is VaultCore {
     using SafeERC20 for IERC20;
     using StableMath for uint256;
 
-    uint256 constant CLAIM_DELAY = 10 minutes;
+    uint256 public constant CLAIM_DELAY = 10 minutes;
     address public immutable weth;
     uint256 public wethAssetIndex;
 


### PR DESCRIPTION
Throughout the codebase, several instances of state variables lacking an explicitly declared visibility were identified:

* The [CLAIM_DELAY state variable](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/OETHVaultCore.sol#L21) in OETHVaultCore.sol
* The [adminImplPosition state variable](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/VaultStorage.sol#L126-L127) in VaultStorage.sol
* The [MINT_MINIMUM_UNIT_PRICE state variable](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/VaultStorage.sol#L157) in VaultStorage.sol
* The [MIN_UNIT_PRICE_DRIFT state variable](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/VaultStorage.sol#L168) in VaultStorage.sol
* The [MAX_UNIT_PRICE_DRIFT state variable](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/VaultStorage.sol#L169) in VaultStorage.sol
* 
For better code clarity, consider always explicitly declaring the visibility of variables, even when the default visibility matches the intended visibility.
