### PR TITLE
N-07 Unused State Variable

### DIFF
--- a/contracts/contracts/vault/VaultCore.sol
+++ b/contracts/contracts/vault/VaultCore.sol
@@ -25,9 +25,6 @@ contract VaultCore is VaultInitializer {
     using StableMath for uint256;
     /// @dev max signed int
     uint256 internal constant MAX_INT = 2**255 - 1;
-    /// @dev max un-signed int
-    uint256 internal constant MAX_UINT =
-        0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
 
     /**
      * @dev Verifies that the rebasing is not paused.


### PR DESCRIPTION
Unused state variables can affect code readability and make it difficult to understand.

Within the `VaultCore` contract, the [MAX_UINT state variable](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/VaultCore.sol#L29-L30) is unused.

To improve the overall clarity and readability of the codebase, consider removing any unused state variables.