### PR TITLE
N-08 Variables Are Initialized to Their Default Values

### DIFF
--- a/contracts/contracts/vault/OETHVaultCore.sol
+++ b/contracts/contracts/vault/OETHVaultCore.sol
@@ -35,7 +35,7 @@ contract OETHVaultCore is VaultCore {
      */
     function cacheWETHAssetIndex() external onlyGovernor {
         uint256 assetCount = allAssets.length;
-        for (uint256 i = 0; i < assetCount; ++i) {
+        for (uint256 i; i < assetCount; ++i) {
             if (allAssets[i] == weth) {
                 wethAssetIndex = i;
                 break;
@@ -268,7 +268,7 @@ contract OETHVaultCore is VaultCore {
         _addWithdrawalQueueLiquidity();
 
         amounts = new uint256[](_requestIds.length);
-        for (uint256 i = 0; i < _requestIds.length; ++i) {
+        for (uint256 i; i < _requestIds.length; ++i) {
             amounts[i] = _claimWithdrawal(_requestIds[i]);
             totalAmount += amounts[i];
         }

--- a/contracts/contracts/vault/VaultCore.sol
+++ b/contracts/contracts/vault/VaultCore.sol
@@ -437,7 +437,7 @@ contract VaultCore is VaultInitializer {
         returns (uint256 value)
     {
         uint256 assetCount = allAssets.length;
-        for (uint256 y = 0; y < assetCount; ++y) {
+        for (uint256 y; y < assetCount; ++y) {
             address assetAddr = allAssets[y];
             uint256 balance = IERC20(assetAddr).balanceOf(address(this));
             if (balance > 0) {
@@ -469,7 +469,7 @@ contract VaultCore is VaultInitializer {
     {
         IStrategy strategy = IStrategy(_strategyAddr);
         uint256 assetCount = allAssets.length;
-        for (uint256 y = 0; y < assetCount; ++y) {
+        for (uint256 y; y < assetCount; ++y) {
             address assetAddr = allAssets[y];
             if (strategy.supportsAsset(assetAddr)) {
                 uint256 balance = strategy.checkBalance(assetAddr);

--- a/contracts/contracts/vault/VaultCore.sol
+++ b/contracts/contracts/vault/VaultCore.sol
@@ -25,9 +25,6 @@ contract VaultCore is VaultInitializer {
     using StableMath for uint256;
     /// @dev max signed int
     uint256 internal constant MAX_INT = 2**255 - 1;
-    /// @dev max un-signed int
-    uint256 internal constant MAX_UINT =
-        0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
 
     /**
      * @dev Verifies that the rebasing is not paused.


### PR DESCRIPTION
Throughout the codebase, a few instances of variables being initialized to their default values were identified:

* The [i variable](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/OETHVaultCore.sol#L38) in OETHVaultCore.sol
* The [i variable](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/OETHVaultCore.sol#L271) in OETHVaultCore.sol
* The [y variable](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/VaultCore.sol#L434) in VaultCore.sol
* The [ousdMetaStrategy variable](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/VaultStorage.sol#L160) in VaultStorage.sol
* The [netOusdMintedForStrategy variable](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/VaultStorage.sol#L163) in VaultStorage.sol
* The [netOusdMintForStrategyThreshold variable](https://github.com/OriginProtocol/origin-dollar/blob/eca6ffa74d9d0c5fb467551a30912cb722fab9c2/contracts/contracts/vault/VaultStorage.sol#L166) in VaultStorage.sol

To avoid wasting gas, consider not initializing variables to the same values they would have by default when they are being declared.
