### PR TITLE
[OETHb] Post Deploy 004 - Migration Timestamp

### DIFF
--- a/contracts/deployments/base/.migrations.json
+++ b/contracts/deployments/base/.migrations.json
@@ -1,5 +1,6 @@
 {
   "001_woeth_on_base": 1713443798,
   "002_base_oracles": 1722427908,
-  "003_base_vault_and_token": 1722429523
+  "003_base_vault_and_token": 1722429523,
+  "004_super_oeth": 1723219797
 }


### PR DESCRIPTION
Related PR: #2181 

#### Note
We don't have support for executing governance action of already executed deployment files when using the multisig as Governor. Committing the timestamp with the deployment artifacts will cause the fork tests to fail until we have executed the governance actions on the multisig. 

Moving this timestamp to a different branch makes sure that the fork tests don't fail on that PR, will make it easier to review things there