### PR TITLE
Deploy 105 - remove Flux strategy from OUSD

### DIFF
--- a/contracts/deploy/mainnet/105_ousd_remove_flux_strat.js
+++ b/contracts/deploy/mainnet/105_ousd_remove_flux_strat.js
@@ -1,0 +1,35 @@
+const { deploymentWithGovernanceProposal } = require("../../utils/deploy");
+
+module.exports = deploymentWithGovernanceProposal(
+  {
+    deployName: "105_ousd_remove_flux_strat",
+    forceDeploy: false,
+    // forceSkip: true,
+    reduceQueueTime: false,
+    deployerIsProposer: true,
+    // proposalId: "",
+  },
+  async () => {
+    // Current OUSD Vault contracts
+    const cVaultProxy = await ethers.getContract("VaultProxy");
+    const cVaultAdmin = await ethers.getContractAt(
+      "VaultAdmin",
+      cVaultProxy.address
+    );
+
+    const cFluxStrategy = await ethers.getContract("FluxStrategyProxy");
+
+    // Governance Actions
+    // ----------------
+    return {
+      name: "Remove Flux strategy from the OUSD Vault",
+      actions: [
+        {
+          contract: cVaultAdmin,
+          signature: "removeStrategy(address)",
+          args: [cFluxStrategy.address],
+        },
+      ],
+    };
+  }
+);

--- a/contracts/deploy/mainnet/105_ousd_remove_flux_strat.js
+++ b/contracts/deploy/mainnet/105_ousd_remove_flux_strat.js
@@ -6,8 +6,9 @@ module.exports = deploymentWithGovernanceProposal(
     forceDeploy: false,
     // forceSkip: true,
     reduceQueueTime: false,
-    deployerIsProposer: true,
-    // proposalId: "",
+    deployerIsProposer: false,
+    proposalId:
+      "34347268131529952700500536280019071045711956672151609598093869968201379596367",
   },
   async () => {
     // Current OUSD Vault contracts

--- a/contracts/deployments/mainnet/.migrations.json
+++ b/contracts/deployments/mainnet/.migrations.json
@@ -93,5 +93,6 @@
   "100_remove_multisig_from_timelock": 1719822421,
   "102_2nd_native_ssv_staking": 1720787923,
   "103_oeth_withdraw_queue": 1722834443,
-  "104_upgrade_staking_strategies": 1723926635
+  "104_upgrade_staking_strategies": 1723926635,
+  "105_ousd_remove_flux_strat": 1724650407
 }

--- a/contracts/test/vault/vault.mainnet.fork-test.js
+++ b/contracts/test/vault/vault.mainnet.fork-test.js
@@ -347,7 +347,6 @@ describe("ForkTest: Vault", function () {
         "0x5e3646A1Db86993f73E6b74A57D8640B69F7e259", // Aave
         "0x89Eb88fEdc50FC77ae8a18aAD1cA0ac27f777a90", // OUSD MetaStrategy
         "0x79F2188EF9350A1dC11A062cca0abE90684b0197", // MorphoAaveStrategy
-        "0x76Bf500B6305Dc4ea851384D3d5502f1C7a0ED44", // Flux Strategy
         "0x6b69B755C629590eD59618A2712d8a2957CA98FC", // Maker DSR Strategy
       ];
 


### PR DESCRIPTION
## Deployment

Deploy script `105_ousd_remove_flux_strat.js` will create the Origin Governance proposal

## Governance
- Proposal: [34347268131529952700500536280019071045711956672151609598093869968201379596367](https://originprotocol.eth.limo/#/more/1:0x1d3fbd4d129ddd2372ea85c5fa00b2682081c9ec:34347268131529952700500536280019071045711956672151609598093869968201379596367)
- Proposal Tx: [0x061ad3972803ca87da8c844ab634536e310269021ca13f8abc79a7688f87c374](https://etherscan.io/tx/0x061ad3972803ca87da8c844ab634536e310269021ca13f8abc79a7688f87c374#eventlog)

## Deploy checklist

Two reviewers complete the following checklist:

```
- [ ] All deployed contracts are listed in the deploy PR's description
- [ ] Deployed contract's verified code (and all dependencies) match the code in master
- [ ] The transactions that interacted with the newly deployed contract match the deploy script.
- [ ] Governance proposal matches the deploy script
- [ ] Smoke tests pass after fork test execution of the governance proposal
```

