### PR TITLE
Add FixedRateDripper

### DIFF
--- a/contracts/contracts/harvest/Dripper.sol
+++ b/contracts/contracts/harvest/Dripper.sol
@@ -19,10 +19,10 @@ import { IVault } from "../interfaces/IVault.sol";
  *
  * Design notes
  * - USDT has a smaller resolution than the number of seconds
- * in a week, which can make per block payouts have a rounding error. However
+ * in a week, which can make per second payouts have a rounding error. However
  * the total effect is not large - cents per day, and this money is
  * not lost, just distributed in the future. While we could use a higher
- * decimal precision for the drip perBlock, we chose simpler code.
+ * decimal precision for the drip perSecond, we chose simpler code.
  * - By calculating the changing drip rates on collects only, harvests and yield
  * events don't have to call anything on this contract or pay any extra gas.
  * Collect() is already be paying for a single write, since it has to reset
@@ -49,7 +49,7 @@ contract Dripper is Governable {
 
     struct Drip {
         uint64 lastCollect; // overflows 262 billion years after the sun dies
-        uint192 perBlock; // drip rate per block
+        uint192 perSecond; // drip rate per second
     }
 
     address immutable vault; // OUSD vault
@@ -86,7 +86,11 @@ contract Dripper is Governable {
     /// @dev Change the drip duration. Governor only.
     /// @param _durationSeconds the number of seconds to drip out the entire
     ///  balance over if no collects were called during that time.
-    function setDripDuration(uint256 _durationSeconds) external onlyGovernor {
+    function setDripDuration(uint256 _durationSeconds)
+        external
+        virtual
+        onlyGovernor
+    {
         require(_durationSeconds > 0, "duration must be non-zero");
         dripDuration = _durationSeconds;
         _collect(); // duration change take immediate effect
@@ -113,21 +117,21 @@ contract Dripper is Governable {
         returns (uint256)
     {
         uint256 elapsed = block.timestamp - _drip.lastCollect;
-        uint256 allowed = (elapsed * _drip.perBlock);
+        uint256 allowed = (elapsed * _drip.perSecond);
         return (allowed > _balance) ? _balance : allowed;
     }
 
     /// @dev Sends the currently dripped funds to be vault, and sets
     ///  the new drip rate based on the new balance.
-    function _collect() internal {
+    function _collect() internal virtual {
         // Calculate send
         uint256 balance = IERC20(token).balanceOf(address(this));
         uint256 amountToSend = _availableFunds(balance, drip);
         uint256 remaining = balance - amountToSend;
-        // Calculate new drip perBlock
+        // Calculate new drip perSecond
         //   Gas savings by setting entire struct at one time
         drip = Drip({
-            perBlock: uint192(remaining / dripDuration),
+            perSecond: uint192(remaining / dripDuration),
             lastCollect: uint64(block.timestamp)
         });
         // Send funds

--- a/contracts/contracts/harvest/FixedRateDripper.sol
+++ b/contracts/contracts/harvest/FixedRateDripper.sol
@@ -60,6 +60,13 @@ contract FixedRateDripper is Dripper {
     function setDripRate(uint192 _perSecond) external onlyGovernorOrStrategist {
         emit DripRateUpdated(_perSecond, drip.perSecond);
 
+        /**
+         * Note: It's important to call `_collect` before updating
+         * the drip rate especially on a new proxy contract.
+         * When `lastCollect` is not set/initialized, the elapsed
+         * time would be calculated as `block.number` seconds,
+         * resulting in a huge yield, if `collect` isn't called first.
+         */
         // Collect at existing rate
         _collect();
 

--- a/contracts/contracts/harvest/FixedRateDripper.sol
+++ b/contracts/contracts/harvest/FixedRateDripper.sol
@@ -3,121 +3,67 @@ pragma solidity ^0.8.0;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import { Governable } from "../governance/Governable.sol";
 import { IVault } from "../interfaces/IVault.sol";
+import { Dripper } from "./Dripper.sol";
 
 /**
- * @title OUSD Dripper
+ * @title Fixed Rate Dripper
  *
- * The dripper contract smooths out the yield from point-in-time yield events
- * and spreads the yield out over a configurable time period. This ensures a
- * continuous per block yield to makes users happy as their next rebase
- * amount is always moving up. Also, this makes historical day to day yields
- * smooth, rather than going from a near zero day, to a large APY day, then
- * back to a near zero day again.
- *
- *
- * Design notes
- * - USDT has a smaller resolution than the number of seconds
- * in a week, which can make per block payouts have a rounding error. However
- * the total effect is not large - cents per day, and this money is
- * not lost, just distributed in the future. While we could use a higher
- * decimal precision for the drip perBlock, we chose simpler code.
- * - By calculating the changing drip rates on collects only, harvests and yield
- * events don't have to call anything on this contract or pay any extra gas.
- * Collect() is already be paying for a single write, since it has to reset
- * the lastCollect time.
- * - By having a collectAndRebase method, and having our external systems call
- * that, the OUSD vault does not need any changes, not even to know the address
- * of the dripper.
- * - A rejected design was to retro-calculate the drip rate on each collect,
- * based on the balance at the time of the collect. While this would have
- * required less state, and would also have made the contract respond more quickly
- * to new income, it would break the predictability that is this contract's entire
- * purpose. If we did this, the amount of fundsAvailable() would make sharp increases
- * when funds were deposited.
- * - When the dripper recalculates the rate, it targets spending the balance over
- * the duration. This means that every time that collect is called, if no
- * new funds have been deposited the duration is being pushed back and the
- * rate decreases. This is expected, and ends up following a smoother but
- * longer curve the more collect() is called without incoming yield.
+ * Similar to the Dripper, Fixed Rate Dripper drips out yield per second.
+ * However the Strategist decides the rate and it doesn't change after
+ * a drip.
  *
  */
 
-contract FixedRateDripper is Governable {
+contract FixedRateDripper is Dripper {
     using SafeERC20 for IERC20;
 
-    address immutable vault; // OUSD vault
-    address immutable token; // token to drip out
-    uint256 public dripRate; // WETH per second
-    uint256 public lastCollect; // Last collect timestamp
+    event DripRateUpdated(uint192 oldDripRate, uint192 newDripRate);
 
-    constructor(address _vault, address _token) {
-        vault = _vault;
-        token = _token;
+    /**
+     * @dev Verifies that the caller is the Governor or Strategist.
+     */
+    modifier onlyGovernorOrStrategist() {
+        require(
+            isGovernor() || msg.sender == IVault(vault).strategistAddr(),
+            "Caller is not the Strategist or Governor"
+        );
+        _;
     }
 
-    /// @notice How much funds have dripped out already and are currently
-    //   available to be sent to the vault.
-    /// @return The amount that would be sent if a collect was called
-    function availableFunds() external view returns (uint256) {
+    constructor(address _vault, address _token) Dripper(_vault, _token) {}
+
+    /// @inheritdoc Dripper
+    function setDripDuration(uint256) external virtual override {
+        // Not used in FixedRateDripper
+        revert("Drip duration disabled");
+    }
+
+    /// @inheritdoc Dripper
+    function _collect() internal virtual override {
+        // Calculate amount to send
         uint256 balance = IERC20(token).balanceOf(address(this));
-        return _availableFunds(balance);
-    }
+        uint256 amountToSend = _availableFunds(balance, drip);
 
-    /// @notice Collect all dripped funds and send to vault.
-    ///  Recalculate new drip rate.
-    function collect() external {
-        _collect();
-    }
-
-    /// @notice Collect all dripped funds, send to vault, recalculate new drip
-    ///  rate, and rebase OUSD.
-    function collectAndRebase() external {
-        _collect();
-        IVault(vault).rebase();
-    }
-
-    /// @dev Change the drip rate. Governor only.
-    /// @param _rate Amount of token to drip per second
-    ///  balance over if no collects were called during that time.
-    function setDripRate(uint256 _rate) external onlyGovernor {
-        require(_rate > 0, "rate must be non-zero");
-        // Collect at current rate
-        _collect();
-        // Update the rate
-        dripRate = _rate;
-    }
-
-    /// @dev Transfer out ERC20 tokens held by the contract. Governor only.
-    /// @param _asset ERC20 token address
-    /// @param _amount amount to transfer
-    function transferToken(address _asset, uint256 _amount)
-        external
-        onlyGovernor
-    {
-        IERC20(_asset).safeTransfer(governor(), _amount);
-    }
-
-    /// @dev Calculate available funds by taking the lower of either the
-    ///  currently dripped out funds or the balance available.
-    ///  Uses passed in parameters to calculate with for gas savings.
-    /// @param _balance current balance in contract
-    function _availableFunds(uint256 _balance) internal view returns (uint256) {
-        uint256 elapsed = block.timestamp - lastCollect;
-        uint256 allowed = (elapsed * dripRate);
-        return (allowed > _balance) ? _balance : allowed;
-    }
-
-    /// @dev Sends the currently dripped funds to be vault, and sets
-    ///  the new drip rate based on the new balance.
-    function _collect() internal {
-        // Calculate send
-        uint256 balance = IERC20(token).balanceOf(address(this));
-        uint256 amountToSend = _availableFunds(balance);
-        lastCollect = block.timestamp;
+        // Update timestamp
+        drip.lastCollect = uint64(block.timestamp);
 
         // Send funds
         IERC20(token).safeTransfer(vault, amountToSend);
+    }
+
+    /**
+     * @dev Sets the drip rate. Callable by Strategist or Governor.
+     *      Can be set to zero to stop dripper.
+     * @param _perSecond Rate of WETH to drip per second
+     */
+    function setDripRate(uint192 _perSecond) external onlyGovernorOrStrategist {
+        emit DripRateUpdated(_perSecond, drip.perSecond);
+
+        // Collect at existing rate
+        _collect();
+
+        // Update rate
+        drip.perSecond = _perSecond;
     }
 }

--- a/contracts/contracts/harvest/FixedRateDripper.sol
+++ b/contracts/contracts/harvest/FixedRateDripper.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Governable } from "../governance/Governable.sol";
+import { IVault } from "../interfaces/IVault.sol";
+
+/**
+ * @title OUSD Dripper
+ *
+ * The dripper contract smooths out the yield from point-in-time yield events
+ * and spreads the yield out over a configurable time period. This ensures a
+ * continuous per block yield to makes users happy as their next rebase
+ * amount is always moving up. Also, this makes historical day to day yields
+ * smooth, rather than going from a near zero day, to a large APY day, then
+ * back to a near zero day again.
+ *
+ *
+ * Design notes
+ * - USDT has a smaller resolution than the number of seconds
+ * in a week, which can make per block payouts have a rounding error. However
+ * the total effect is not large - cents per day, and this money is
+ * not lost, just distributed in the future. While we could use a higher
+ * decimal precision for the drip perBlock, we chose simpler code.
+ * - By calculating the changing drip rates on collects only, harvests and yield
+ * events don't have to call anything on this contract or pay any extra gas.
+ * Collect() is already be paying for a single write, since it has to reset
+ * the lastCollect time.
+ * - By having a collectAndRebase method, and having our external systems call
+ * that, the OUSD vault does not need any changes, not even to know the address
+ * of the dripper.
+ * - A rejected design was to retro-calculate the drip rate on each collect,
+ * based on the balance at the time of the collect. While this would have
+ * required less state, and would also have made the contract respond more quickly
+ * to new income, it would break the predictability that is this contract's entire
+ * purpose. If we did this, the amount of fundsAvailable() would make sharp increases
+ * when funds were deposited.
+ * - When the dripper recalculates the rate, it targets spending the balance over
+ * the duration. This means that every time that collect is called, if no
+ * new funds have been deposited the duration is being pushed back and the
+ * rate decreases. This is expected, and ends up following a smoother but
+ * longer curve the more collect() is called without incoming yield.
+ *
+ */
+
+contract FixedRateDripper is Governable {
+    using SafeERC20 for IERC20;
+
+    address immutable vault; // OUSD vault
+    address immutable token; // token to drip out
+    uint256 public dripRate; // WETH per second
+    uint256 public lastCollect; // Last collect timestamp
+
+    constructor(address _vault, address _token) {
+        vault = _vault;
+        token = _token;
+    }
+
+    /// @notice How much funds have dripped out already and are currently
+    //   available to be sent to the vault.
+    /// @return The amount that would be sent if a collect was called
+    function availableFunds() external view returns (uint256) {
+        uint256 balance = IERC20(token).balanceOf(address(this));
+        return _availableFunds(balance);
+    }
+
+    /// @notice Collect all dripped funds and send to vault.
+    ///  Recalculate new drip rate.
+    function collect() external {
+        _collect();
+    }
+
+    /// @notice Collect all dripped funds, send to vault, recalculate new drip
+    ///  rate, and rebase OUSD.
+    function collectAndRebase() external {
+        _collect();
+        IVault(vault).rebase();
+    }
+
+    /// @dev Change the drip rate. Governor only.
+    /// @param _rate Amount of token to drip per second
+    ///  balance over if no collects were called during that time.
+    function setDripRate(uint256 _rate) external onlyGovernor {
+        require(_rate > 0, "rate must be non-zero");
+        // Collect at current rate
+        _collect();
+        // Update the rate
+        dripRate = _rate;
+    }
+
+    /// @dev Transfer out ERC20 tokens held by the contract. Governor only.
+    /// @param _asset ERC20 token address
+    /// @param _amount amount to transfer
+    function transferToken(address _asset, uint256 _amount)
+        external
+        onlyGovernor
+    {
+        IERC20(_asset).safeTransfer(governor(), _amount);
+    }
+
+    /// @dev Calculate available funds by taking the lower of either the
+    ///  currently dripped out funds or the balance available.
+    ///  Uses passed in parameters to calculate with for gas savings.
+    /// @param _balance current balance in contract
+    function _availableFunds(uint256 _balance) internal view returns (uint256) {
+        uint256 elapsed = block.timestamp - lastCollect;
+        uint256 allowed = (elapsed * dripRate);
+        return (allowed > _balance) ? _balance : allowed;
+    }
+
+    /// @dev Sends the currently dripped funds to be vault, and sets
+    ///  the new drip rate based on the new balance.
+    function _collect() internal {
+        // Calculate send
+        uint256 balance = IERC20(token).balanceOf(address(this));
+        uint256 amountToSend = _availableFunds(balance);
+        lastCollect = block.timestamp;
+
+        // Send funds
+        IERC20(token).safeTransfer(vault, amountToSend);
+    }
+}

--- a/contracts/deploy/base/013_fixed_rate_dripper.js
+++ b/contracts/deploy/base/013_fixed_rate_dripper.js
@@ -1,0 +1,30 @@
+const { deployOnBaseWithGuardian } = require("../../utils/deploy-l2");
+const { deployWithConfirmation } = require("../../utils/deploy");
+const addresses = require("../../utils/addresses");
+
+module.exports = deployOnBaseWithGuardian(
+  {
+    deployName: "013_fixed_rate_dripper",
+  },
+  async ({ ethers }) => {
+    const cOETHbDripperProxy = await ethers.getContract("OETHBaseDripperProxy");
+    const cOETHbVaultProxy = await ethers.getContract("OETHBaseVaultProxy");
+
+    // Deploy new implementation
+    const dOETHbDripper = await deployWithConfirmation("FixedRateDripper", [
+      cOETHbVaultProxy.address,
+      addresses.base.WETH,
+    ]);
+
+    return {
+      actions: [
+        {
+          // 1. Upgrade Dripper
+          contract: cOETHbDripperProxy,
+          signature: "upgradeTo(address)",
+          args: [dOETHbDripper.address],
+        },
+      ],
+    };
+  }
+);

--- a/contracts/docs/DripperStorage.svg
+++ b/contracts/docs/DripperStorage.svg
@@ -39,7 +39,7 @@
 <polyline fill="none" stroke="black" points="512.47,-0.5 512.47,-50.1 "/>
 <text text-anchor="middle" x="717.5" y="-33.5" font-family="Courier New" font-size="14.00">type: variable (bytes)</text>
 <polyline fill="none" stroke="black" points="512.47,-25.3 922.53,-25.3 "/>
-<text text-anchor="middle" x="612.88" y="-8.7" font-family="Courier New" font-size="14.00">uint192: perBlock (24)</text>
+<text text-anchor="middle" x="612.88" y="-8.7" font-family="Courier New" font-size="14.00">uint192: perSecond (24)</text>
 <polyline fill="none" stroke="black" points="713.3,-0.5 713.3,-25.3 "/>
 <text text-anchor="middle" x="817.92" y="-8.7" font-family="Courier New" font-size="14.00">uint64: lastCollect (8)</text>
 </g>

--- a/contracts/docs/OETHDripperStorage.svg
+++ b/contracts/docs/OETHDripperStorage.svg
@@ -39,7 +39,7 @@
 <polyline fill="none" stroke="black" points="512.47,-0.5 512.47,-50.1 "/>
 <text text-anchor="middle" x="717.5" y="-33.5" font-family="Courier New" font-size="14.00">type: variable (bytes)</text>
 <polyline fill="none" stroke="black" points="512.47,-25.3 922.53,-25.3 "/>
-<text text-anchor="middle" x="612.88" y="-8.7" font-family="Courier New" font-size="14.00">uint192: perBlock (24)</text>
+<text text-anchor="middle" x="612.88" y="-8.7" font-family="Courier New" font-size="14.00">uint192: perSecond (24)</text>
 <polyline fill="none" stroke="black" points="713.3,-0.5 713.3,-25.3 "/>
 <text text-anchor="middle" x="817.92" y="-8.7" font-family="Courier New" font-size="14.00">uint64: lastCollect (8)</text>
 </g>

--- a/contracts/test/_fixture-base.js
+++ b/contracts/test/_fixture-base.js
@@ -20,7 +20,7 @@ const BURNER_ROLE =
 
 let snapshotId;
 const defaultBaseFixture = deployments.createFixture(async () => {
-  let aerodromeAmoStrategy;
+  let aerodromeAmoStrategy, dripper;
 
   if (!snapshotId && !isFork) {
     snapshotId = await nodeSnapshot();
@@ -70,6 +70,13 @@ const defaultBaseFixture = deployments.createFixture(async () => {
     aerodromeAmoStrategy = await ethers.getContractAt(
       "AerodromeAMOStrategy",
       aerodromeAmoStrategyProxy.address
+    );
+
+    // Dripper
+    const dripperProxy = await ethers.getContract("OETHBaseDripperProxy");
+    dripper = await ethers.getContractAt(
+      "FixedRateDripper",
+      dripperProxy.address
     );
   }
 
@@ -167,11 +174,13 @@ const defaultBaseFixture = deployments.createFixture(async () => {
     aeroNftManager,
     aeroClGauge,
     aero,
+
     // OETHb
     oethb,
     oethbVault,
     wOETHb,
     zapper,
+    dripper,
 
     // Bridged WOETH
     woeth,

--- a/contracts/test/dripper/fixed-rate-dripper.base.fork-test.js
+++ b/contracts/test/dripper/fixed-rate-dripper.base.fork-test.js
@@ -1,0 +1,106 @@
+const { createFixtureLoader } = require("../_fixture");
+const { defaultBaseFixture } = require("../_fixture-base");
+const { expect } = require("chai");
+const { oethUnits, getBlockTimestamp, advanceTime } = require("../helpers");
+const { impersonateAndFund } = require("../../utils/signers");
+const { BigNumber } = require("ethers");
+
+const baseFixture = createFixtureLoader(defaultBaseFixture);
+
+describe("ForkTest: OETHb FixedRateDripper", function () {
+  let fixture;
+  beforeEach(async () => {
+    fixture = await baseFixture();
+  });
+
+  it("Should collect reward at fixed rate", async () => {
+    const { dripper, weth, oethbVault } = fixture;
+
+    // Fund dripper with some WETH
+    const dripperSigner = await impersonateAndFund(dripper.address);
+    await weth.connect(dripperSigner).deposit({ value: oethUnits("50") });
+
+    const dripperBalanceBefore = await weth.balanceOf(dripper.address);
+    const vaultBalanceBefore = await weth.balanceOf(oethbVault.address);
+
+    // Get current rate
+    const drip = await dripper.drip();
+    const currTimestamp = await getBlockTimestamp();
+
+    // Fast forward time
+    const oneDay = 24 * 60 * 60;
+    await advanceTime(oneDay); // 1d
+
+    const pendingTime = BigNumber.from(currTimestamp)
+      .sub(drip.lastCollect)
+      .add(oneDay);
+    const expectedRewards = pendingTime.mul(drip.perSecond);
+
+    // Do a collect
+    await dripper.collect();
+
+    // Check state
+    const dripperBalanceAfter = await weth.balanceOf(dripper.address);
+    const vaultBalanceAfter = await weth.balanceOf(oethbVault.address);
+
+    expect(dripperBalanceAfter).to.approxEqual(
+      dripperBalanceBefore.sub(expectedRewards)
+    );
+    expect(vaultBalanceAfter).to.approxEqual(
+      vaultBalanceBefore.add(expectedRewards)
+    );
+
+    // Make sure drip rate hasn't changed
+    const dripAfter = await dripper.drip();
+    expect(dripAfter.perSecond).to.eq(drip.perSecond);
+  });
+
+  it("Should allow strategist/governor to change rate", async () => {
+    const { dripper, strategist, governor } = fixture;
+
+    let tx = await dripper.connect(strategist).setDripRate(
+      oethUnits("1") // 1 WETH per second
+    );
+    await expect(tx).to.emit(dripper, "DripRateUpdated");
+
+    let rate = (await dripper.drip()).perSecond;
+    expect(rate).to.eq(oethUnits("1"));
+
+    tx = await dripper.connect(governor).setDripRate(
+      oethUnits("2") // 2 WETH per second
+    );
+    await expect(tx).to.emit(dripper, "DripRateUpdated");
+
+    rate = (await dripper.drip()).perSecond;
+    expect(rate).to.eq(oethUnits("2"));
+  });
+
+  it("Should not allow anyone else to change rate", async () => {
+    const { dripper, nick } = fixture;
+
+    const tx = dripper.connect(nick).setDripRate(
+      oethUnits("1") // 1 WETH per second
+    );
+    await expect(tx).to.be.revertedWith(
+      "Caller is not the Strategist or Governor"
+    );
+  });
+
+  it("Should allow to disable rate", async () => {
+    const { dripper, strategist } = fixture;
+
+    const tx = await dripper.connect(strategist).setDripRate(
+      "0" // Disable dripping
+    );
+    await expect(tx).to.emit(dripper, "DripRateUpdated");
+
+    expect((await dripper.drip()).perSecond).to.eq("0");
+  });
+
+  it("Should have disabled drip duration", async () => {
+    const { dripper, governor } = fixture;
+
+    const tx = dripper.connect(governor).setDripDuration("7");
+    await expect(tx).to.be.revertedWith("Drip duration disabled");
+  });
+});

--- a/contracts/test/dripper/fixed-rate-dripper.base.fork-test.js
+++ b/contracts/test/dripper/fixed-rate-dripper.base.fork-test.js
@@ -31,10 +31,10 @@ describe("ForkTest: OETHb FixedRateDripper", function () {
     const oneDay = 24 * 60 * 60;
     await advanceTime(oneDay); // 1d
 
-    const pendingTime = BigNumber.from(currTimestamp)
+    const elapsedTime = BigNumber.from(currTimestamp)
       .sub(drip.lastCollect)
       .add(oneDay);
-    const expectedRewards = pendingTime.mul(drip.perSecond);
+    const expectedRewards = elapsedTime.mul(drip.perSecond);
 
     // Do a collect
     await dripper.collect();
@@ -53,6 +53,8 @@ describe("ForkTest: OETHb FixedRateDripper", function () {
     // Make sure drip rate hasn't changed
     const dripAfter = await dripper.drip();
     expect(dripAfter.perSecond).to.eq(drip.perSecond);
+    // ... and lastCollect has been updated
+    expect(dripAfter.lastCollect).to.gte(drip.lastCollect.add(elapsedTime));
   });
 
   it("Should allow strategist/governor to change rate", async () => {


### PR DESCRIPTION
## Changes Overview
- Rename `perBlock` to `perSecond` in the Dripper contract
- Add `FixedRateDripper` that inherits from `Dripper` but strategist sets the drip rate and it doesn't change with `collect`

## Code Change Checklist

To be completed before internal review begins:

- [ ]  The contract code is complete
- [ ]  Executable deployment file
- [ ]  Fork tests that test after the deployment file runs
- [ ]  Unit tests *if needed
- [ ]  The owner has done a [full checklist review](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) of the code + tests

Internal review:

- [ ] Two approvals by internal reviewers

