### PR TITLE
L-01 Disable Initializers for Implementation Contract

### DIFF
--- a/contracts/contracts/strategies/aerodrome/AerodromeAMOStrategy.sol
+++ b/contracts/contracts/strategies/aerodrome/AerodromeAMOStrategy.sol
@@ -251,6 +251,10 @@ contract AerodromeAMOStrategy is InitializableAbstractStrategy {
         lowerTick = _lowerBoundingTick;
         upperTick = _upperBoundingTick;
         tickSpacing = _tickSpacing;
+
+        // prevent implementation contract to be governed or initialized
+        initialized = true;
+        _setGovernor(address(0));
     }
 
     /**

--- a/contracts/contracts/strategies/aerodrome/AerodromeAMOStrategy.sol
+++ b/contracts/contracts/strategies/aerodrome/AerodromeAMOStrategy.sol
@@ -188,6 +188,12 @@ contract AerodromeAMOStrategy is InitializableAbstractStrategy {
     // slither-disable-end reentrancy-no-eth
 
     /// @notice the constructor
+    /// @dev This contract is intended to be used as a proxy. To prevent the
+    ///      potential confusion of having a functional implementation contract
+    ///      the constructor has the `initializer` modifier. This way the
+    ///      `initialize` function can not be called on the implementation contract.
+    ///      For the same reason the implementation contract also has the governor
+    ///      set to a zero address.
     /// @param _stratConfig the basic strategy configuration
     /// @param _wethAddress Address of the Erc20 WETH Token contract
     /// @param _oethbAddress Address of the Erc20 OETHb Token contract
@@ -252,7 +258,7 @@ contract AerodromeAMOStrategy is InitializableAbstractStrategy {
         upperTick = _upperBoundingTick;
         tickSpacing = _tickSpacing;
 
-        // prevent implementation contract to be governed or initialized
+        // prevent implementation contract to be governed
         _setGovernor(address(0));
     }
 

--- a/contracts/contracts/strategies/aerodrome/AerodromeAMOStrategy.sol
+++ b/contracts/contracts/strategies/aerodrome/AerodromeAMOStrategy.sol
@@ -212,7 +212,7 @@ contract AerodromeAMOStrategy is InitializableAbstractStrategy {
         int24 _lowerBoundingTick,
         int24 _upperBoundingTick,
         int24 _tickClosestToParity
-    ) InitializableAbstractStrategy(_stratConfig) {
+    ) initializer InitializableAbstractStrategy(_stratConfig) {
         require(
             _lowerBoundingTick == _tickClosestToParity ||
                 _upperBoundingTick == _tickClosestToParity,
@@ -253,7 +253,6 @@ contract AerodromeAMOStrategy is InitializableAbstractStrategy {
         tickSpacing = _tickSpacing;
 
         // prevent implementation contract to be governed or initialized
-        initialized = true;
         _setGovernor(address(0));
     }
 


### PR DESCRIPTION
**OpenZeppelin comment:** 
[AerodromeAMOStrategy](https://github.com/OriginProtocol/origin-dollar/blob/4345b525828dba92b6c38a978a9242c27aacfd1f/contracts/contracts/strategies/aerodrome/AerodromeAMOStrategy.sol) is intended to be the implementation for a proxy contract, meaning all the functions the proxy can call can be called directly on the implementation within its own storage context. Currently, only the Governor, Strategist, and Vault can call any non-view functions meaning we do not see an issue with the implementation contract. However, it is best practice and we do recommend effectively disabling initializing functions explicitly so that future contracts are developed with that habit. Consider setting `initialized` to `true` in the constructor.

**Origin' response:**
Fixed as suggested by making the constructor the initialiser. The implementation contract also sets the `governor` to a zero address
