### PR TITLE
N-01 Code Clarity

### DIFF
--- a/contracts/contracts/strategies/aerodrome/AerodromeAMOStrategy.sol
+++ b/contracts/contracts/strategies/aerodrome/AerodromeAMOStrategy.sol
@@ -366,7 +366,7 @@ contract AerodromeAMOStrategy is InitializableAbstractStrategy {
      *
      * This function has a slightly different behaviour depending on the status of the underlying Aerodrome
      * slipstream pool. The function consists of the following 3 steps:
-     * 1. withdrawPartialLiqidity -> so that moving the activeTrading price via  a swap is cheaper
+     * 1. withdrawPartialLiquidity -> so that moving the activeTrading price via  a swap is cheaper
      * 2. swapToDesiredPosition   -> move active trading price in the pool to be able to deposit WETH & OETHb
      *                               tokens with the desired pre-configured shares
      * 3. addLiquidity            -> add liquidity into the pool respecting share split configuration
@@ -456,7 +456,7 @@ contract AerodromeAMOStrategy is InitializableAbstractStrategy {
 
         uint128 _liquidity = _getLiquidity();
         // need to convert to uint256 since intermittent result is to big for uint128 to handle
-        uint128 _liqudityToRemove = uint256(_liquidity)
+        uint128 _liquidityToRemove = uint256(_liquidity)
             .mulTruncate(_liquidityToDecrease)
             .toUint128();
 
@@ -464,7 +464,7 @@ contract AerodromeAMOStrategy is InitializableAbstractStrategy {
          * There is no liquidity to remove -> exit function early. This can happen after a
          * withdraw/withdrawAll removes all of the liquidity while retaining the NFT token.
          */
-        if (_liquidity == 0 || _liqudityToRemove == 0) {
+        if (_liquidity == 0 || _liquidityToRemove == 0) {
             return;
         }
 
@@ -474,7 +474,7 @@ contract AerodromeAMOStrategy is InitializableAbstractStrategy {
                 // happen just before the liquidity removal.
                 INonfungiblePositionManager.DecreaseLiquidityParams({
                     tokenId: tokenId,
-                    liquidity: _liqudityToRemove,
+                    liquidity: _liquidityToRemove,
                     amount0Min: 0,
                     amount1Min: 0,
                     deadline: block.timestamp
@@ -548,7 +548,7 @@ contract AerodromeAMOStrategy is InitializableAbstractStrategy {
     /**
      * @dev Add liquidity into the pool in the pre-configured WETH to OETHb share ratios
      * defined by the allowedPoolWethShareStart|End interval. This function will respect
-     * liquidity ratios when there no liquidity yet in the pool. If liquidity is already
+     * liquidity ratios when there is no liquidity yet in the pool. If liquidity is already
      * present then it relies on the `_swapToDesiredPosition` function in a step before
      * to already move the trading price to desired position (with some tolerance).
      */


### PR DESCRIPTION
**OpenZeppelin comment:**
Here are some misleading comments we identified during our review:

- [The variable _liqudityToRemove](https://github.com/OriginProtocol/origin-dollar/blob/4345b525828dba92b6c38a978a9242c27aacfd1f/contracts/contracts/strategies/aerodrome/AerodromeAMOStrategy.sol#L459-L460) should be _liquidityToRemove.
- In [the documentation](https://github.com/OriginProtocol/origin-dollar/blob/4345b525828dba92b6c38a978a9242c27aacfd1f/contracts/contracts/strategies/aerodrome/AerodromeAMOStrategy.sol#L550-L552) of the _addLiquidity function, the second sentence should be '...when there is no liquidity...' instead of '...when there no liquidity...'.
- In [the documentation](https://github.com/OriginProtocol/origin-dollar/blob/4345b525828dba92b6c38a978a9242c27aacfd1f/contracts/contracts/strategies/aerodrome/AerodromeAMOStrategy.sol#L369-L370) of the rebalance function, 'withdrawPartialLiqidity' should be 'withdrawPartialLiquidity'.

**Origin' response:**
Agreed, fixed.
