### PR TITLE
AMO automatic deposits

### DIFF
--- a/contracts/contracts/strategies/aerodrome/AerodromeAMOStrategy.sol
+++ b/contracts/contracts/strategies/aerodrome/AerodromeAMOStrategy.sol
@@ -555,8 +555,7 @@ contract AerodromeAMOStrategy is InitializableAbstractStrategy {
 
         // approve the specific amount of WETH required
         if (_swapWeth) {
-            IERC20(WETH).safeApprove(address(swapRouter), 0);
-            IERC20(WETH).safeApprove(address(swapRouter), _amountToSwap);
+            IERC20(WETH).approve(address(swapRouter), _amountToSwap);
         }
 
         // Swap it
@@ -631,8 +630,7 @@ contract AerodromeAMOStrategy is InitializableAbstractStrategy {
         }
 
         // approve the specific amount of WETH required
-        IERC20(WETH).safeApprove(address(positionManager), 0);
-        IERC20(WETH).safeApprove(address(positionManager), _wethBalance);
+        IERC20(WETH).approve(address(positionManager), _wethBalance);
 
         uint256 _wethAmountSupplied;
         uint256 _oethbAmountSupplied;
@@ -907,8 +905,8 @@ contract AerodromeAMOStrategy is InitializableAbstractStrategy {
          * un-approving WETH to the swapRouter & positionManager and only approving
          * the required amount before a transaction
          */
-        IERC20(WETH).safeApprove(address(swapRouter), 0);
-        IERC20(WETH).safeApprove(address(positionManager), 0);
+        IERC20(WETH).approve(address(swapRouter), 0);
+        IERC20(WETH).approve(address(positionManager), 0);
     }
 
     /***************************************

--- a/contracts/contracts/strategies/aerodrome/AerodromeAMOStrategy.sol
+++ b/contracts/contracts/strategies/aerodrome/AerodromeAMOStrategy.sol
@@ -894,11 +894,9 @@ contract AerodromeAMOStrategy is InitializableAbstractStrategy {
         nonReentrant
     {
         // to add liquidity to the clPool
-        IERC20(OETHb).safeApprove(address(positionManager), 0);
-        IERC20(OETHb).safeApprove(address(positionManager), type(uint256).max);
+        IERC20(OETHb).approve(address(positionManager), type(uint256).max);
         // to be able to rebalance using the swapRouter
-        IERC20(OETHb).safeApprove(address(swapRouter), 0);
-        IERC20(OETHb).safeApprove(address(swapRouter), type(uint256).max);
+        IERC20(OETHb).approve(address(swapRouter), type(uint256).max);
 
         /* the behaviour of this strategy has slightly changed and WETH could be
          * present on the contract between the transactions. For that reason we are

--- a/contracts/deploy/base/006_base_amo_strategy.js
+++ b/contracts/deploy/base/006_base_amo_strategy.js
@@ -5,6 +5,9 @@ const {
 } = require("../../utils/deploy");
 const addresses = require("../../utils/addresses");
 const { oethUnits } = require("../../test/helpers");
+const {
+  deployBaseAerodromeAMOStrategyImplementation,
+} = require("../deployActions");
 
 //const aeroVoterAbi = require("../../test/abi/aerodromeVoter.json");
 //const slipstreamPoolAbi = require("../../test/abi/aerodromeSlipstreamPool.json")
@@ -47,35 +50,18 @@ module.exports = deployOnBaseWithGuardian(
   async ({ ethers }) => {
     const { deployerAddr, governorAddr } = await getNamedAccounts();
     const sDeployer = await ethers.provider.getSigner(deployerAddr);
-    const cOETHbProxy = await ethers.getContract("OETHBaseProxy");
     const cOETHbVaultProxy = await ethers.getContract("OETHBaseVaultProxy");
     const cOETHbVault = await ethers.getContractAt(
       "IVault",
       cOETHbVaultProxy.address
     );
 
+    const cAMOStrategyImpl =
+      await deployBaseAerodromeAMOStrategyImplementation();
     await deployWithConfirmation("AerodromeAMOStrategyProxy");
-    await deployWithConfirmation("AerodromeAMOStrategy", [
-      /* The pool address is not yet known. Might be created before we deploy the
-       * strategy or after.
-       */
-      [addresses.zero, cOETHbVaultProxy.address], // platformAddress, VaultAddress
-      addresses.base.WETH, // weth address
-      cOETHbProxy.address, // OETHb address
-      addresses.base.swapRouter, // swapRouter
-      addresses.base.nonFungiblePositionManager, // nonfungiblePositionManager
-      addresses.base.aerodromeOETHbWETHClPool, // clOETHbWethPool
-      addresses.base.aerodromeOETHbWETHClGauge, // gauge address
-      addresses.base.sugarHelper, // sugarHelper
-      -1, // lowerBoundingTick
-      0, // upperBoundingTick
-      0, // tickClosestToParity
-    ]);
-
     const cAMOStrategyProxy = await ethers.getContract(
       "AerodromeAMOStrategyProxy"
     );
-    const cAMOStrategyImpl = await ethers.getContract("AerodromeAMOStrategy");
     const cAMOStrategy = await ethers.getContractAt(
       "AerodromeAMOStrategy",
       cAMOStrategyProxy.address

--- a/contracts/deploy/base/016_upgrade_amo.js
+++ b/contracts/deploy/base/016_upgrade_amo.js
@@ -1,0 +1,67 @@
+const { deployOnBaseWithGuardian } = require("../../utils/deploy-l2");
+const addresses = require("../../utils/addresses");
+const { utils } = require("ethers");
+const {
+  deployBaseAerodromeAMOStrategyImplementation,
+} = require("../deployActions");
+
+module.exports = deployOnBaseWithGuardian(
+  {
+    deployName: "016_upgrade_amo",
+  },
+  async ({ ethers }) => {
+    const cOETHbVaultProxy = await ethers.getContract("OETHBaseVaultProxy");
+    const cOETHbVault = await ethers.getContractAt(
+      "IVault",
+      cOETHbVaultProxy.address
+    );
+
+    const cAMOStrategyProxy = await ethers.getContract(
+      "AerodromeAMOStrategyProxy"
+    );
+    const cAMOStrategyImpl =
+      await deployBaseAerodromeAMOStrategyImplementation();
+    const cAMOStrategy = await ethers.getContractAt(
+      "AerodromeAMOStrategy",
+      cAMOStrategyProxy.address
+    );
+
+    return {
+      actions: [
+        {
+          // 1. Upgrade AMO
+          contract: cAMOStrategyProxy,
+          signature: "upgradeTo(address)",
+          args: [cAMOStrategyImpl.address],
+        },
+        {
+          // 2. Reset WETH approvals to 0 on swapRouter and positionManager
+          contract: cAMOStrategy,
+          signature: "safeApproveAllTokens()",
+          args: [],
+        },
+        {
+          // 2. set auto allocate threshold to 0
+          contract: cOETHbVault,
+          signature: "setAutoAllocateThreshold(uint256)",
+          args: [utils.parseUnits("0", 18)],
+        },
+        {
+          // 3. set that 0.04% (4 basis points) of Vualt TVL triggers the allocation.
+          // At the time of writing this is ~53 ETH
+          contract: cOETHbVault,
+          signature: "setVaultBuffer(uint256)",
+          //args: [utils.parseUnits("4", 14)],
+          // for now disable allocating WETH
+          args: [utils.parseUnits("1", 18)],
+        },
+        {
+          // 4. set aerodrome AMO as WETH asset default strategy
+          contract: cOETHbVault,
+          signature: "setAssetDefaultStrategy(address,address)",
+          args: [addresses.base.WETH, cAMOStrategyProxy.address],
+        },
+      ],
+    };
+  }
+);

--- a/contracts/deploy/base/017_upgrade_amo.js
+++ b/contracts/deploy/base/017_upgrade_amo.js
@@ -46,25 +46,19 @@ module.exports = deployOnBaseWithGuardian(
           signature: "setAutoAllocateThreshold(uint256)",
           args: [utils.parseUnits("0", 18)],
         },
+        {
+          // 3. set that 0.04% (4 basis points) of Vualt TVL triggers the allocation.
+          // At the time of writing this is ~53 ETH
+          contract: cOETHbVault,
+          signature: "setVaultBuffer(uint256)",
+          args: [utils.parseUnits("4", 14)],
+        },
         // {
-        //   // 3. set that 0.04% (4 basis points) of Vualt TVL triggers the allocation.
-        //   // At the time of writing this is ~53 ETH
+        //   // 3. for now disable allocating weth
         //   contract: cOETHbVault,
         //   signature: "setVaultBuffer(uint256)",
-        //   args: [utils.parseUnits("4", 14)],
+        //   args: [utils.parseUnits("1", 18)],
         // },
-        {
-          // 3. for now disable allocating weth
-          contract: cOETHbVault,
-          signature: "setVaultBuffer(uint256)",
-          args: [utils.parseUnits("1", 18)],
-        },
-        {
-          // 3. for now disable allocating weth
-          contract: cOETHbVault,
-          signature: "setVaultBuffer(uint256)",
-          args: [utils.parseUnits("0", 18)],
-        },
         {
           // 4. set aerodrome AMO as WETH asset default strategy
           contract: cOETHbVault,

--- a/contracts/deploy/base/017_upgrade_amo.js
+++ b/contracts/deploy/base/017_upgrade_amo.js
@@ -41,7 +41,7 @@ module.exports = deployOnBaseWithGuardian(
           args: [],
         },
         {
-          // 2. set auto allocate threshold to 1 - gas is cheap
+          // 2. set auto allocate threshold to 0.1 - gas is cheap
           contract: cOETHbVault,
           signature: "setAutoAllocateThreshold(uint256)",
           args: [utils.parseUnits("0.1", 18)],

--- a/contracts/deploy/base/017_upgrade_amo.js
+++ b/contracts/deploy/base/017_upgrade_amo.js
@@ -46,19 +46,19 @@ module.exports = deployOnBaseWithGuardian(
           signature: "setAutoAllocateThreshold(uint256)",
           args: [utils.parseUnits("0", 18)],
         },
-        {
-          // 3. set that 0.04% (4 basis points) of Vualt TVL triggers the allocation.
-          // At the time of writing this is ~53 ETH
-          contract: cOETHbVault,
-          signature: "setVaultBuffer(uint256)",
-          args: [utils.parseUnits("4", 14)],
-        },
         // {
-        //   // 3. for now disable allocating weth
+        //   // 3. set that 0.04% (4 basis points) of Vualt TVL triggers the allocation.
+        //   // At the time of writing this is ~53 ETH
         //   contract: cOETHbVault,
         //   signature: "setVaultBuffer(uint256)",
-        //   args: [utils.parseUnits("1", 18)],
+        //   args: [utils.parseUnits("4", 14)],
         // },
+        {
+          // 3. for now disable allocating weth
+          contract: cOETHbVault,
+          signature: "setVaultBuffer(uint256)",
+          args: [utils.parseUnits("1", 18)],
+        },
         {
           // 4. set aerodrome AMO as WETH asset default strategy
           contract: cOETHbVault,

--- a/contracts/deploy/base/017_upgrade_amo.js
+++ b/contracts/deploy/base/017_upgrade_amo.js
@@ -41,10 +41,10 @@ module.exports = deployOnBaseWithGuardian(
           args: [],
         },
         {
-          // 2. set auto allocate threshold to 0
+          // 2. set auto allocate threshold to 1 - gas is cheap
           contract: cOETHbVault,
           signature: "setAutoAllocateThreshold(uint256)",
-          args: [utils.parseUnits("0", 18)],
+          args: [utils.parseUnits("1", 18)],
         },
         // {
         //   // 3. set that 0.04% (4 basis points) of Vualt TVL triggers the allocation.

--- a/contracts/deploy/base/017_upgrade_amo.js
+++ b/contracts/deploy/base/017_upgrade_amo.js
@@ -7,7 +7,7 @@ const {
 
 module.exports = deployOnBaseWithGuardian(
   {
-    deployName: "016_upgrade_amo",
+    deployName: "017_upgrade_amo",
   },
   async ({ ethers }) => {
     const cOETHbVaultProxy = await ethers.getContract("OETHBaseVaultProxy");
@@ -46,14 +46,24 @@ module.exports = deployOnBaseWithGuardian(
           signature: "setAutoAllocateThreshold(uint256)",
           args: [utils.parseUnits("0", 18)],
         },
+        // {
+        //   // 3. set that 0.04% (4 basis points) of Vualt TVL triggers the allocation.
+        //   // At the time of writing this is ~53 ETH
+        //   contract: cOETHbVault,
+        //   signature: "setVaultBuffer(uint256)",
+        //   args: [utils.parseUnits("4", 14)],
+        // },
         {
-          // 3. set that 0.04% (4 basis points) of Vualt TVL triggers the allocation.
-          // At the time of writing this is ~53 ETH
+          // 3. for now disable allocating weth
           contract: cOETHbVault,
           signature: "setVaultBuffer(uint256)",
-          //args: [utils.parseUnits("4", 14)],
-          // for now disable allocating WETH
           args: [utils.parseUnits("1", 18)],
+        },
+        {
+          // 3. for now disable allocating weth
+          contract: cOETHbVault,
+          signature: "setVaultBuffer(uint256)",
+          args: [utils.parseUnits("0", 18)],
         },
         {
           // 4. set aerodrome AMO as WETH asset default strategy

--- a/contracts/deploy/base/017_upgrade_amo.js
+++ b/contracts/deploy/base/017_upgrade_amo.js
@@ -44,7 +44,7 @@ module.exports = deployOnBaseWithGuardian(
           // 2. set auto allocate threshold to 1 - gas is cheap
           contract: cOETHbVault,
           signature: "setAutoAllocateThreshold(uint256)",
-          args: [utils.parseUnits("1", 18)],
+          args: [utils.parseUnits("0.1", 18)],
         },
         // {
         //   // 3. set that 0.04% (4 basis points) of Vualt TVL triggers the allocation.

--- a/contracts/deploy/deployActions.js
+++ b/contracts/deploy/deployActions.js
@@ -1566,6 +1566,29 @@ const deployOUSDSwapper = async () => {
   await vault.connect(sGovernor).setOracleSlippage(assetAddresses.USDT, 50);
 };
 
+const deployBaseAerodromeAMOStrategyImplementation = async () => {
+  const cOETHbProxy = await ethers.getContract("OETHBaseProxy");
+  const cOETHbVaultProxy = await ethers.getContract("OETHBaseVaultProxy");
+
+  await deployWithConfirmation("AerodromeAMOStrategy", [
+    /* Check all these values match 006_base_amo_strategy deploy file
+     */
+    [addresses.zero, cOETHbVaultProxy.address], // platformAddress, VaultAddress
+    addresses.base.WETH, // weth address
+    cOETHbProxy.address, // OETHb address
+    addresses.base.swapRouter, // swapRouter
+    addresses.base.nonFungiblePositionManager, // nonfungiblePositionManager
+    addresses.base.aerodromeOETHbWETHClPool, // clOETHbWethPool
+    addresses.base.aerodromeOETHbWETHClGauge, // gauge address
+    addresses.base.sugarHelper, // sugarHelper
+    -1, // lowerBoundingTick
+    0, // upperBoundingTick
+    0, // tickClosestToParity
+  ]);
+
+  return await ethers.getContract("AerodromeAMOStrategy");
+};
+
 module.exports = {
   deployOracles,
   deployCore,
@@ -1600,4 +1623,5 @@ module.exports = {
   deployOUSDSwapper,
   upgradeNativeStakingSSVStrategy,
   upgradeNativeStakingFeeAccumulator,
+  deployBaseAerodromeAMOStrategyImplementation,
 };

--- a/contracts/test/_fixture-base.js
+++ b/contracts/test/_fixture-base.js
@@ -93,8 +93,6 @@ const defaultBaseFixture = deployments.createFixture(async () => {
 
     quoter = await hre.ethers.getContract("AerodromeAMOQuoter");
 
-    // Configure Aerodrome AMO
-
     // Dripper
     const dripperProxy = await ethers.getContract("OETHBaseDripperProxy");
     dripper = await ethers.getContractAt(

--- a/contracts/test/_fixture-base.js
+++ b/contracts/test/_fixture-base.js
@@ -93,6 +93,8 @@ const defaultBaseFixture = deployments.createFixture(async () => {
 
     quoter = await hre.ethers.getContract("AerodromeAMOQuoter");
 
+    // Configure Aerodrome AMO
+
     // Dripper
     const dripperProxy = await ethers.getContract("OETHBaseDripperProxy");
     dripper = await ethers.getContractAt(

--- a/contracts/test/_fixture-base.js
+++ b/contracts/test/_fixture-base.js
@@ -158,6 +158,9 @@ const defaultBaseFixture = deployments.createFixture(async () => {
 
     await impersonateAndFund(governor.address);
     await impersonateAndFund(timelock.address);
+
+    // configure Vault to not automatically deposit to strategy
+    await oethbVault.connect(governor).setVaultBuffer(oethUnits("1"));
   }
 
   // Make sure we can print bridged WOETH for tests

--- a/contracts/test/helpers.js
+++ b/contracts/test/helpers.js
@@ -161,12 +161,19 @@ chai.Assertion.addMethod(
       txSucceeded = true;
     } catch (e) {
       const errorHash = keccak256(toUtf8Bytes(errorSignature)).substr(0, 10);
-      chai
-        .expect(e.message)
-        .to.contain(
-          errorHash,
-          `Expected error message with signature ${errorSignature} but another was thrown.`
+      const errorName = errorSignature.substring(
+        0,
+        errorSignature.indexOf("(")
+      );
+
+      const containsError =
+        e.message.includes(errorHash) || e.message.includes(errorName);
+
+      if (!containsError) {
+        chai.expect.fail(
+          `Expected error message with signature ${errorSignature} but another was thrown: ${e.message}`
         );
+      }
     }
 
     if (txSucceeded) {

--- a/contracts/test/strategies/aerodrome-amo.base.fork-test.js
+++ b/contracts/test/strategies/aerodrome-amo.base.fork-test.js
@@ -838,15 +838,6 @@ describe("ForkTest: Aerodrome AMO Strategy (Base)", async function () {
           [weth.address],
           [amount]
         );
-      await expect(await weth.balanceOf(aerodromeAmoStrategy.address)).to.equal(
-        amount
-      );
-
-      await expect(
-        aerodromeAmoStrategy
-          .connect(strategist)
-          .rebalance(oethUnits("0"), false, oethUnits("0"))
-      );
 
       await expect(await weth.balanceOf(aerodromeAmoStrategy.address)).to.equal(
         oethUnits("0")
@@ -886,6 +877,9 @@ describe("ForkTest: Aerodrome AMO Strategy (Base)", async function () {
     it("Should be able to rebalance the pool when price pushed to 1:1", async () => {
       await depositLiquidityToPool();
 
+      // supply some WETH for the rebalance
+      await mintAndDepositToStrategy({ amount: oethUnits("1") });
+
       const priceAtTick0 = await aerodromeAmoStrategy.sqrtRatioX96TickHigher();
       let { value: value0, direction: direction0 } =
         await quoteAmountToSwapToReachPrice({
@@ -896,9 +890,6 @@ describe("ForkTest: Aerodrome AMO Strategy (Base)", async function () {
         amount: value0,
         swapWeth: direction0,
       });
-
-      // supply some WETH for the rebalance
-      await mintAndDepositToStrategy({ amount: oethUnits("1") });
 
       const { value, direction } = await quoteAmountToSwapBeforeRebalance({
         lowValue: oethUnits("0"),
@@ -912,8 +903,11 @@ describe("ForkTest: Aerodrome AMO Strategy (Base)", async function () {
         rebalance(value, direction, value.mul("99").div("100"))
       ).to.be.revertedWithCustomError("NotEnoughWethForSwap(uint256,uint256)");
 
-      // but if we help it out with some liquidity it should rebalance
-      await weth.connect(rafael).transfer(aerodromeAmoStrategy.address, value);
+      // but if we help it out with some liquidity it should rebalance. Add a surplus of 1 WETH so that
+      // some liquidity gets deployed on rebalance.
+      await weth
+        .connect(rafael)
+        .transfer(aerodromeAmoStrategy.address, value.add(oethUnits("1")));
       await rebalance(value, direction, value.mul("99").div("100"));
 
       await assetLpStakedInGauge();
@@ -943,9 +937,6 @@ describe("ForkTest: Aerodrome AMO Strategy (Base)", async function () {
     it("Should have the correct balance within some tolerance", async () => {
       const balance = await aerodromeAmoStrategy.checkBalance(weth.address);
       await mintAndDepositToStrategy({ amount: oethUnits("6") });
-      await expect(
-        await aerodromeAmoStrategy.checkBalance(weth.address)
-      ).to.equal(balance.add(oethUnits("6")));
 
       // just add liquidity don't move the active trading position
       await rebalance(BigNumber.from("0"), true, BigNumber.from("0"));
@@ -983,18 +974,29 @@ describe("ForkTest: Aerodrome AMO Strategy (Base)", async function () {
     });
 
     it("Should not be able to rebalance when protocol is insolvent", async () => {
-      const stratSigner = await impersonateAndFund(
-        aerodromeAmoStrategy.address
-      );
-
       await mintAndDepositToStrategy({ amount: oethUnits("1000") });
+      await aerodromeAmoStrategy.connect(oethbVaultSigner).withdrawAll();
+
+      // ensure there is a LP position
+      await mintAndDepositToStrategy({ amount: oethUnits("1") });
+
       // transfer WETH out making the protocol insolvent
-      const bal = await weth.balanceOf(aerodromeAmoStrategy.address);
-      await weth.connect(stratSigner).transfer(addresses.dead, bal);
+      const swapBal = oethUnits("0.00001");
+      const addLiquidityBal = oethUnits("1");
+      const balRemaining = (await weth.balanceOf(oethbVault.address))
+        .sub(swapBal)
+        .sub(addLiquidityBal);
+
+      await weth
+        .connect(oethbVaultSigner)
+        .transfer(aerodromeAmoStrategy.address, swapBal.add(addLiquidityBal));
+      await weth
+        .connect(oethbVaultSigner)
+        .transfer(addresses.dead, balRemaining);
 
       await expect(
         rebalance(
-          oethUnits("0.00001"),
+          swapBal,
           true, // _swapWETHs
           oethUnits("0.000009")
         )
@@ -1214,7 +1216,11 @@ describe("ForkTest: Aerodrome AMO Strategy (Base)", async function () {
       .rebalance(amountToSwap, swapWETH, minTokenReceived);
   };
 
-  const mintAndDepositToStrategy = async ({ userOverride, amount } = {}) => {
+  const mintAndDepositToStrategy = async ({
+    userOverride,
+    amount,
+    returnTransaction,
+  } = {}) => {
     const user = userOverride || rafael;
     amount = amount || oethUnits("5");
 
@@ -1226,12 +1232,18 @@ describe("ForkTest: Aerodrome AMO Strategy (Base)", async function () {
     await oethbVault.connect(user).mint(weth.address, amount, amount);
 
     const gov = await oethbVault.governor();
-    await oethbVault
+    const tx = await oethbVault
       .connect(await impersonateAndFund(gov))
       .depositToStrategy(
         aerodromeAmoStrategy.address,
         [weth.address],
         [amount]
       );
+
+    if (returnTransaction) {
+      return tx;
+    }
+
+    await expect(tx).to.emit(aerodromeAmoStrategy, "PoolRebalanced");
   };
 });

--- a/contracts/test/strategies/aerodrome-amo.base.fork-test.js
+++ b/contracts/test/strategies/aerodrome-amo.base.fork-test.js
@@ -1027,7 +1027,7 @@ describe("ForkTest: Aerodrome AMO Strategy (Base)", async function () {
       return minAmountReserved;
     };
 
-    it("Should not automatically deposit to strategy when below deposit threshold", async () => {
+    it("Should not automatically deposit to strategy when below vault buffer threshold", async () => {
       const minAmountReserved = await depositAllWethAndConfigure1Bp();
 
       await expect(await weth.balanceOf(aerodromeAmoStrategy.address)).to.equal(
@@ -1050,7 +1050,7 @@ describe("ForkTest: Aerodrome AMO Strategy (Base)", async function () {
       await assetLpStakedInGauge();
     });
 
-    it("Should deposit amount above the threshold to the strategy on mint", async () => {
+    it("Should deposit amount above the vault buffer threshold to the strategy on mint", async () => {
       const minAmountReserved = await depositAllWethAndConfigure1Bp();
 
       await expect(await weth.balanceOf(aerodromeAmoStrategy.address)).to.equal(

--- a/contracts/test/strategies/aerodrome-amo.base.fork-test.js
+++ b/contracts/test/strategies/aerodrome-amo.base.fork-test.js
@@ -297,6 +297,10 @@ describe("ForkTest: Aerodrome AMO Strategy (Base)", async function () {
       .approve(aeroSwapRouter.address, oethUnits("1000000000"));
   });
 
+  const cofigureAutomaticDepositOnMint = async () => {
+    await oethbVault.setVaultBuffer(oethUnits("0.0001"));
+  };
+
   // tests need liquidity outside AMO ticks in order to test for fail states
   const depositLiquidityToPool = async () => {
     await weth
@@ -1003,6 +1007,22 @@ describe("ForkTest: Aerodrome AMO Strategy (Base)", async function () {
       ).to.be.revertedWith("Protocol insolvent");
 
       await assetLpStakedInGauge();
+    });
+
+    it("Should automatically deposit to strategy when deposit threshold reached", async () => {
+
+    });
+
+    it("Should not automatically deposit to strategy when deposit threshold not reached", async () => {
+
+    });
+
+    it("Should leave WETH on the contract when pool price outside allowed limits", async () => {
+
+    });
+
+    it("Test that assetLpStakedInGauge also tests no WETH is left on the strategy contract (or very little)", async () => {
+
     });
   });
 


### PR DESCRIPTION
- configures Vault to have Aerodrome AMO as the default WETH strategy
- `vaultBuffer` set to 100% so that automatic deposits while configured are for now paused
- when unpaused OETHb mints deposit the WETH to Aerodrome AMO strategy with behaviour:
  - if pool within allowed WETH share WETH gets deposited to underlying Aerodrome pool respecting the current WETH to OETHb split shares
  - if pool is outside allowed WETH share the deposited tokens stay on the Aerodrome AMO strategy contract
- WETH allowances are reset and only required allowances granted to `swapRouter` and `positionManager` before `add liquidity` / `swap` actions
- custom error utils detector also checks for error name aside from error hash as sometimes hardhat returns the error by name (haven't gotten to the bottom of it why that is so)


## Code Change Checklist

To be completed before internal review begins:

- [x]  The contract code is complete
- [x]  Executable deployment file
- [x]  Fork tests that test after the deployment file runs
- [ ]  Unit tests *if needed
- [x]  The owner has done a [full checklist review](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) of the code + tests

Internal review:

- [ ] Two approvals by internal reviewers


## Deploy checklist

Two reviewers complete the following checklist:

```
- [ ] All deployed contracts are listed in the deploy PR's description
- [ ] Deployed contract's verified code (and all dependencies) match the code in master
- [ ] Contract constructors have correct arguments
- [ ] The transactions that interacted with the newly deployed contract match the deploy script.
- [ ] Governance proposal matches the deploy script
- [ ] Smoke tests pass after fork test execution of the governance proposal
```

