### PR TITLE
Harvest Action now collects if there is more than 0.5 execution rewards

### DIFF
--- a/contracts/utils/addresses.js
+++ b/contracts/utils/addresses.js
@@ -267,6 +267,8 @@ addresses.mainnet.beaconChainDepositContract =
 // Native Staking Strategy
 addresses.mainnet.NativeStakingSSVStrategyProxy =
   "0x34eDb2ee25751eE67F68A45813B22811687C0238";
+addresses.mainnet.NativeStakingSSVStrategy2Proxy =
+  "0x4685dB8bF2Df743c861d71E6cFb5347222992076";
 
 // Defender relayer
 addresses.mainnet.validatorRegistrator =


### PR DESCRIPTION
## Changes

* The Defender Action that harvests native staking rewards has been updated to collect if there is more than 0.5 ETH of execution rewards. It previously only collected if there was more than 1 ETH of consensus rewards.
