### PR TITLE
Upgrade any secp256k1 dependencies

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -99,6 +99,9 @@
     "uuid": "^9.0.1",
     "web3-utils": "^1.5.2"
   },
+  "resolutions": {
+    "secp256k1": ">=4.0.4"
+  },
   "husky": {
     "hooks": {
       "pre-push": "yarn run prettier:check"

--- a/contracts/yarn.lock
+++ b/contracts/yarn.lock
@@ -4788,7 +4788,7 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-elliptic@6.5.4, elliptic@^6.5.2, elliptic@^6.5.4:
+elliptic@6.5.4, elliptic@^6.5.2:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
@@ -4805,6 +4805,19 @@ elliptic@^6.4.0, elliptic@^6.5.3, elliptic@^6.5.5:
   version "6.5.5"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.5.tgz#c715e09f78b6923977610d4c2346d6ce22e6dded"
   integrity sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==
+  dependencies:
+    bn.js "^4.11.9"
+    brorand "^1.1.0"
+    hash.js "^1.0.0"
+    hmac-drbg "^1.0.1"
+    inherits "^2.0.4"
+    minimalistic-assert "^1.0.1"
+    minimalistic-crypto-utils "^1.0.1"
+
+elliptic@^6.5.7:
+  version "6.5.7"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.7.tgz#8ec4da2cb2939926a1b9a73619d768207e647c8b"
+  integrity sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==
   dependencies:
     bn.js "^4.11.9"
     brorand "^1.1.0"
@@ -8001,6 +8014,11 @@ node-addon-api@^2.0.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
   integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
 
+node-addon-api@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.1.0.tgz#49da1ca055e109a23d537e9de43c09cca21eb762"
+  integrity sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==
+
 node-emoji@^1.10.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.11.0.tgz#69a0150e6946e2f115e9d7ea4df7971e2628301c"
@@ -9056,13 +9074,13 @@ scrypt-js@3.0.1, scrypt-js@^3.0.0, scrypt-js@^3.0.1:
   resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
   integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
 
-secp256k1@4.0.3, secp256k1@^4.0.1:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-4.0.3.tgz#c4559ecd1b8d3c1827ed2d1b94190d69ce267303"
-  integrity sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==
+secp256k1@4.0.3, secp256k1@>=4.0.4, secp256k1@^4.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-5.0.1.tgz#dc2c86187d48ff2da756f0f7e96417ee03c414b1"
+  integrity sha512-lDFs9AAIaWP9UCdtWrotXWWF9t8PWgQDcxqgAnpM9rMqxb3Oaq2J0thzPVSxBwdJgyQtkU/sYtFtbM1RSt/iYA==
   dependencies:
-    elliptic "^6.5.4"
-    node-addon-api "^2.0.0"
+    elliptic "^6.5.7"
+    node-addon-api "^5.0.0"
     node-gyp-build "^4.2.0"
 
 seedrandom@3.0.5:


### PR DESCRIPTION
# Change

* This resolves the dependency issue with secp256k1 https://github.com/OriginProtocol/origin-dollar/security/dependabot/297 

The impacted dependencies

```
yarn audit --level critical
```

```Markdown
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ SQL Injection and Cross-site Scripting in class-validator    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ class-validator                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=0.14.0                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ ssv-keys                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ ssv-keys > class-validator                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1088816                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ flat vulnerable to Prototype Pollution                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ flat                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=5.0.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ solidity-coverage                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ solidity-coverage > mocha > yargs-unparser > flat            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1089152                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ flat vulnerable to Prototype Pollution                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ flat                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=5.0.1                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ hardhat-gas-reporter                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ hardhat-gas-reporter > eth-gas-reporter > mocha >            │
│               │ yargs-unparser > flat                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1089152                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ secp256k1-node allows private key extraction over ECDH       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ secp256k1                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.0.4                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @nomicfoundation/hardhat-network-helpers                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @nomicfoundation/hardhat-network-helpers > ethereumjs-util > │
│               │ ethereum-cryptography > secp256k1                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1100201                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ secp256k1-node allows private key extraction over ECDH       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ secp256k1                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.0.4                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @openzeppelin/hardhat-upgrades                               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @openzeppelin/hardhat-upgrades > @openzeppelin/upgrades-core │
│               │ > ethereumjs-util > ethereum-cryptography > secp256k1        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1100201                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ secp256k1-node allows private key extraction over ECDH       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ secp256k1                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.0.4                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ ssv-keys                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ ssv-keys > eth2-keystore-js > ethereumjs-wallet >            │
│               │ ethereumjs-util > ethereum-cryptography > secp256k1          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1100201                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ secp256k1-node allows private key extraction over ECDH       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ secp256k1                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.0.4                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ ssv-keys                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ ssv-keys > web3 > web3-core > web3-utils > ethereumjs-util > │
│               │ ethereum-cryptography > secp256k1                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1100201                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ secp256k1-node allows private key extraction over ECDH       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ secp256k1                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.0.4                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ ssv-keys                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ ssv-keys > web3 > web3-eth > web3-eth-accounts >             │
│               │ @ethereumjs/common > ethereumjs-util > ethereum-cryptography │
│               │ > secp256k1                                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1100201                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ secp256k1-node allows private key extraction over ECDH       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ secp256k1                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.0.4                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ ssv-keys                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ ssv-keys > web3 > web3-eth > web3-eth-accounts >             │
│               │ @ethereumjs/tx > @ethereumjs/common > ethereumjs-util >      │
│               │ ethereum-cryptography > secp256k1                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1100201                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ secp256k1-node allows private key extraction over ECDH       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ secp256k1                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.0.4                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ ethereum-waffle                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ ethereum-waffle > @ethereum-waffle/provider >                │
│               │ @ganache/ethereum-options > @ganache/ethereum-utils >        │
│               │ @ethereumjs/vm > @ethereumjs/block > @ethereumjs/common >    │
│               │ ethereumjs-util > ethereum-cryptography > secp256k1          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1100201                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ secp256k1-node allows private key extraction over ECDH       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ secp256k1                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.0.4                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ ethereum-waffle                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ ethereum-waffle > @ethereum-waffle/chai >                    │
│               │ @ethereum-waffle/provider > @ganache/ethereum-options >      │
│               │ @ganache/ethereum-utils > @ethereumjs/vm > @ethereumjs/block │
│               │ > @ethereumjs/common > ethereumjs-util >                     │
│               │ ethereum-cryptography > secp256k1                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1100201                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ secp256k1-node allows private key extraction over ECDH       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ secp256k1                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.0.4                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ ethereum-waffle                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ ethereum-waffle > @ethereum-waffle/chai >                    │
│               │ @ethereum-waffle/provider > @ganache/ethereum-options >      │
│               │ @ganache/ethereum-utils > @ethereumjs/vm >                   │
│               │ @ethereumjs/blockchain > @ethereumjs/block >                 │
│               │ @ethereumjs/common > ethereumjs-util > ethereum-cryptography │
│               │ > secp256k1                                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1100201                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ secp256k1-node allows private key extraction over ECDH       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ secp256k1                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.0.4                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ ethereum-waffle                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ ethereum-waffle > @ethereum-waffle/chai >                    │
│               │ @ethereum-waffle/provider > @ganache/ethereum-options >      │
│               │ @ganache/ethereum-utils > @ethereumjs/vm >                   │
│               │ @ethereumjs/blockchain > @ethereumjs/ethash >                │
│               │ @ethereumjs/block > @ethereumjs/common > ethereumjs-util >   │
│               │ ethereum-cryptography > secp256k1                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1100201                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ secp256k1-node allows private key extraction over ECDH       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ secp256k1                                                    │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.0.4                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ ethereum-waffle                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ ethereum-waffle > @ethereum-waffle/chai >                    │
│               │ @ethereum-waffle/provider > @ganache/ethereum-options >      │
│               │ @ganache/ethereum-utils > @ethereumjs/vm >                   │
│               │ @ethereumjs/blockchain > @ethereumjs/ethash >                │
│               │ @ethereumjs/block > @ethereumjs/tx > @ethereumjs/common >    │
│               │ ethereumjs-util > ethereum-cryptography > secp256k1          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1100201                     │
```