### PR TITLE
OUSD gas improvements

### DIFF
--- a/contracts/contracts/token/OUSD.sol
+++ b/contracts/contracts/token/OUSD.sol
@@ -495,7 +495,12 @@ contract OUSD is Initializable, InitializableERC20Detailed, Governable {
             // high resolution, and do not have to do any other bookkeeping
             nonRebasingCreditsPerToken[_account] = 1e27;
         } else {
-            // Migrate an existing account:
+            // Migrate an existing account
+            // this can happen if an address sends tokens to an EOA address
+            // and then deploys the contract to that same address using create2
+            // which allows for contract deploys to have predictable addresses.
+            // We don't need to update _creditBalances[_account] in this case since
+            // they already correspond to the global _rebasingCreditsPerToken.
 
             // Set fixed credits per token for this account
             nonRebasingCreditsPerToken[_account] = _rebasingCreditsPerToken;

--- a/contracts/contracts/token/OUSD.sol
+++ b/contracts/contracts/token/OUSD.sol
@@ -446,11 +446,13 @@ contract OUSD is Initializable, InitializableERC20Detailed, Governable {
         view
         returns (uint256)
     {
-        if (nonRebasingCreditsPerToken[_account] != 0) {
-            return nonRebasingCreditsPerToken[_account];
-        } else {
-            return _rebasingCreditsPerToken;
+        // Read the account's non-rebasing credits per token from storage
+        uint256 creditsPerTokenMem = nonRebasingCreditsPerToken[_account];
+        if (creditsPerTokenMem != 0) {
+            return creditsPerTokenMem;
         }
+
+        return _rebasingCreditsPerToken;
     }
 
     /**

--- a/contracts/contracts/token/OUSD.sol
+++ b/contracts/contracts/token/OUSD.sol
@@ -121,9 +121,10 @@ contract OUSD is Initializable, InitializableERC20Detailed, Governable {
         override
         returns (uint256)
     {
-        if (_creditBalances[_account] == 0) return 0;
-        return
-            _creditBalances[_account].divPrecisely(_creditsPerToken(_account));
+        // Read credits from storage
+        uint256 credits = _creditBalances[_account];
+        if (credits == 0) return 0;
+        return credits.divPrecisely(_creditsPerToken(_account));
     }
 
     /**

--- a/contracts/test/token/ousd.js
+++ b/contracts/test/token/ousd.js
@@ -24,6 +24,38 @@ describe("Token", function () {
     expect(await ousd.decimals()).to.equal(18);
   });
 
+  describe("Should measure gas of balanceOf from", async () => {
+    it("rebasing account", async () => {
+      const { matt, ousd } = fixture;
+
+      const tx = await ousd
+        .connect(matt)
+        .populateTransaction.balanceOf(matt.getAddress());
+      await matt.sendTransaction(tx);
+    });
+
+    it("non rebasing account", async () => {
+      const { matt, ousd } = fixture;
+
+      await ousd.connect(matt).rebaseOptOut();
+      const tx = await ousd
+        .connect(matt)
+        .populateTransaction.balanceOf(matt.getAddress());
+      await matt.sendTransaction(tx);
+    });
+
+    it("zero balance account", async () => {
+      const { matt, ousd } = fixture;
+
+      const tx = await ousd
+        .connect(matt)
+        .populateTransaction.balanceOf(
+          "0x0000000000000000000000000000000000000001"
+        );
+      await matt.sendTransaction(tx);
+    });
+  });
+
   it("Should return 0 balance for the zero address", async () => {
     const { ousd } = fixture;
     expect(

--- a/contracts/test/token/ousd.js
+++ b/contracts/test/token/ousd.js
@@ -2,6 +2,7 @@ const { expect } = require("chai");
 const { loadDefaultFixture } = require("../_fixture");
 const { utils } = require("ethers");
 
+const { impersonateAndFund } = require("../../utils/signers.js");
 const { daiUnits, ousdUnits, usdcUnits, isFork } = require("../helpers");
 
 describe("Token", function () {
@@ -54,6 +55,18 @@ describe("Token", function () {
         );
       await matt.sendTransaction(tx);
     });
+  });
+
+  it("Should measure gas of changeSupply", async () => {
+    const { ousd, vault } = fixture;
+
+    const vaultSigner = await impersonateAndFund(vault.address);
+    const currentSupply = await ousd.totalSupply();
+
+    const tx = await ousd
+      .connect(vaultSigner)
+      .populateTransaction.changeSupply(currentSupply.add(ousdUnits("1")));
+    await vaultSigner.sendTransaction(tx);
   });
 
   it("Should return 0 balance for the zero address", async () => {

--- a/contracts/test/token/ousd.js
+++ b/contracts/test/token/ousd.js
@@ -106,338 +106,358 @@ describe("Token", function () {
     ).to.equal(ousdUnits("999"));
   });
 
-  it("Should transfer the correct amount from a rebasing account to a non-rebasing account and set creditsPerToken", async () => {
-    let { ousd, vault, matt, usdc, josh, mockNonRebasing } = fixture;
+  describe("Should transfer the correct amount from a", () => {
+    it("rebasing account to a non-rebasing account and set creditsPerToken", async () => {
+      let { ousd, vault, matt, usdc, josh, mockNonRebasing } = fixture;
 
-    // Give contract 100 OUSD from Josh
-    await ousd
-      .connect(josh)
-      .transfer(mockNonRebasing.address, ousdUnits("100"));
+      // Give contract 100 OUSD from Josh
+      await ousd
+        .connect(josh)
+        .transfer(mockNonRebasing.address, ousdUnits("100"));
 
-    await expect(matt).has.an.approxBalanceOf("100.00", ousd);
-    await expect(mockNonRebasing).has.an.approxBalanceOf("100.00", ousd);
+      await expect(matt).has.an.approxBalanceOf("100.00", ousd);
+      await expect(mockNonRebasing).has.an.approxBalanceOf("100.00", ousd);
 
-    const contractCreditsPerToken = await ousd.creditsBalanceOf(
-      mockNonRebasing.address
-    );
+      const contractCreditsPerToken = await ousd.creditsBalanceOf(
+        mockNonRebasing.address
+      );
 
-    // Transfer USDC into the Vault to simulate yield
-    await usdc.connect(matt).transfer(vault.address, usdcUnits("200"));
-    await vault.rebase();
+      // Transfer USDC into the Vault to simulate yield
+      await usdc.connect(matt).transfer(vault.address, usdcUnits("200"));
+      await vault.rebase();
 
-    // Credits per token should be the same for the contract
-    contractCreditsPerToken ===
-      (await ousd.creditsBalanceOf(mockNonRebasing.address));
+      // Credits per token should be the same for the contract
+      contractCreditsPerToken ===
+        (await ousd.creditsBalanceOf(mockNonRebasing.address));
 
-    // Validate rebasing and non rebasing credit accounting by calculating'
-    // total supply manually
-    const calculatedTotalSupply = (await ousd.rebasingCreditsHighres())
-      .mul(utils.parseUnits("1", 18))
-      .div(await ousd.rebasingCreditsPerTokenHighres())
-      .add(await ousd.nonRebasingSupply());
-    await expect(calculatedTotalSupply).to.approxEqual(
-      await ousd.totalSupply()
-    );
-  });
+      // Validate rebasing and non rebasing credit accounting by calculating'
+      // total supply manually
+      const calculatedTotalSupply = (await ousd.rebasingCreditsHighres())
+        .mul(utils.parseUnits("1", 18))
+        .div(await ousd.rebasingCreditsPerTokenHighres())
+        .add(await ousd.nonRebasingSupply());
+      await expect(calculatedTotalSupply).to.approxEqual(
+        await ousd.totalSupply()
+      );
+    });
 
-  it("Should transfer the correct amount from a rebasing account to a non-rebasing account with previously set creditsPerToken", async () => {
-    let { ousd, vault, matt, usdc, josh, mockNonRebasing } = fixture;
+    it("rebasing account to a non-rebasing account with previously set creditsPerToken", async () => {
+      let { ousd, vault, matt, usdc, josh, mockNonRebasing } = fixture;
 
-    await ousd
-      .connect(josh)
-      .transfer(mockNonRebasing.address, ousdUnits("100"));
-    await expect(matt).has.an.approxBalanceOf("100.00", ousd);
-    await expect(josh).has.an.approxBalanceOf("0", ousd);
-    await expect(mockNonRebasing).has.an.approxBalanceOf("100.00", ousd);
-    // Transfer USDC into the Vault to simulate yield
-    await usdc.connect(matt).transfer(vault.address, usdcUnits("200"));
-    await vault.rebase();
-    // Matt received all the yield
-    await expect(matt).has.an.approxBalanceOf("300.00", ousd);
-    // Give contract 100 OUSD from Matt
-    await ousd.connect(matt).transfer(mockNonRebasing.address, ousdUnits("50"));
-    await expect(matt).has.an.approxBalanceOf("250", ousd);
-    await expect(mockNonRebasing).has.an.approxBalanceOf("150.00", ousd);
+      await ousd
+        .connect(josh)
+        .transfer(mockNonRebasing.address, ousdUnits("100"));
+      await expect(matt).has.an.approxBalanceOf("100.00", ousd);
+      await expect(josh).has.an.approxBalanceOf("0", ousd);
+      await expect(mockNonRebasing).has.an.approxBalanceOf("100.00", ousd);
+      // Transfer USDC into the Vault to simulate yield
+      await usdc.connect(matt).transfer(vault.address, usdcUnits("200"));
+      await vault.rebase();
+      // Matt received all the yield
+      await expect(matt).has.an.approxBalanceOf("300.00", ousd);
+      // Give contract 100 OUSD from Matt
+      await ousd
+        .connect(matt)
+        .transfer(mockNonRebasing.address, ousdUnits("50"));
+      await expect(matt).has.an.approxBalanceOf("250", ousd);
+      await expect(mockNonRebasing).has.an.approxBalanceOf("150.00", ousd);
 
-    // Validate rebasing and non rebasing credit accounting by calculating'
-    // total supply manually
-    const calculatedTotalSupply = (await ousd.rebasingCreditsHighres())
-      .mul(utils.parseUnits("1", 18))
-      .div(await ousd.rebasingCreditsPerTokenHighres())
-      .add(await ousd.nonRebasingSupply());
-    await expect(calculatedTotalSupply).to.approxEqual(
-      await ousd.totalSupply()
-    );
-  });
+      // Validate rebasing and non rebasing credit accounting by calculating'
+      // total supply manually
+      const calculatedTotalSupply = (await ousd.rebasingCreditsHighres())
+        .mul(utils.parseUnits("1", 18))
+        .div(await ousd.rebasingCreditsPerTokenHighres())
+        .add(await ousd.nonRebasingSupply());
+      await expect(calculatedTotalSupply).to.approxEqual(
+        await ousd.totalSupply()
+      );
+    });
 
-  it("Should transfer the correct amount from a non-rebasing account without previously set creditssPerToken to a rebasing account", async () => {
-    let { ousd, matt, josh, mockNonRebasing } = fixture;
+    it("non-rebasing account without previously set creditsPerToken to a rebasing account", async () => {
+      let { ousd, matt, josh, mockNonRebasing } = fixture;
 
-    // Give contract 100 OUSD from Josh
-    await ousd
-      .connect(josh)
-      .transfer(mockNonRebasing.address, ousdUnits("100"));
-    await expect(matt).has.an.approxBalanceOf("100.00", ousd);
-    await expect(josh).has.an.approxBalanceOf("0", ousd);
-    await expect(mockNonRebasing).has.an.approxBalanceOf("100.00", ousd);
-    await mockNonRebasing.transfer(await matt.getAddress(), ousdUnits("100"));
-    await expect(matt).has.an.approxBalanceOf("200.00", ousd);
-    await expect(josh).has.an.approxBalanceOf("0", ousd);
-    await expect(mockNonRebasing).has.an.approxBalanceOf("0", ousd);
+      // Give contract 100 OUSD from Josh
+      await ousd
+        .connect(josh)
+        .transfer(mockNonRebasing.address, ousdUnits("100"));
+      await expect(matt).has.an.approxBalanceOf("100.00", ousd);
+      await expect(josh).has.an.approxBalanceOf("0", ousd);
+      await expect(mockNonRebasing).has.an.approxBalanceOf("100.00", ousd);
+      await mockNonRebasing.transfer(await matt.getAddress(), ousdUnits("100"));
+      await expect(matt).has.an.approxBalanceOf("200.00", ousd);
+      await expect(josh).has.an.approxBalanceOf("0", ousd);
+      await expect(mockNonRebasing).has.an.approxBalanceOf("0", ousd);
 
-    // Validate rebasing and non rebasing credit accounting by calculating'
-    // total supply manually
-    const calculatedTotalSupply = (await ousd.rebasingCreditsHighres())
-      .mul(utils.parseUnits("1", 18))
-      .div(await ousd.rebasingCreditsPerTokenHighres())
-      .add(await ousd.nonRebasingSupply());
-    await expect(calculatedTotalSupply).to.approxEqual(
-      await ousd.totalSupply()
-    );
-  });
+      // Validate rebasing and non rebasing credit accounting by calculating'
+      // total supply manually
+      const calculatedTotalSupply = (await ousd.rebasingCreditsHighres())
+        .mul(utils.parseUnits("1", 18))
+        .div(await ousd.rebasingCreditsPerTokenHighres())
+        .add(await ousd.nonRebasingSupply());
+      await expect(calculatedTotalSupply).to.approxEqual(
+        await ousd.totalSupply()
+      );
+    });
 
-  it("Should transfer the correct amount from a non-rebasing account with previously set creditsPerToken to a rebasing account", async () => {
-    let { ousd, vault, matt, usdc, josh, mockNonRebasing } = fixture;
+    it("non-rebasing account with previously set creditsPerToken to a rebasing account", async () => {
+      let { ousd, vault, matt, usdc, josh, mockNonRebasing } = fixture;
 
-    // Give contract 100 OUSD from Josh
-    await ousd
-      .connect(josh)
-      .transfer(mockNonRebasing.address, ousdUnits("100"));
-    await expect(matt).has.an.approxBalanceOf("100.00", ousd);
-    await expect(josh).has.an.approxBalanceOf("0", ousd);
-    await expect(mockNonRebasing).has.an.approxBalanceOf("100.00", ousd);
-    // Transfer USDC into the Vault to simulate yield
-    await usdc.connect(matt).transfer(vault.address, usdcUnits("200"));
-    await vault.rebase();
-    // Matt received all the yield
-    await expect(matt).has.an.approxBalanceOf("300.00", ousd);
-    // Give contract 100 OUSD from Matt
-    await ousd.connect(matt).transfer(mockNonRebasing.address, ousdUnits("50"));
-    await expect(matt).has.an.approxBalanceOf("250", ousd);
-    await expect(mockNonRebasing).has.an.approxBalanceOf("150.00", ousd);
-    // Transfer contract balance to Josh
-    await mockNonRebasing.transfer(await josh.getAddress(), ousdUnits("150"));
-    await expect(matt).has.an.approxBalanceOf("250", ousd);
-    await expect(josh).has.an.approxBalanceOf("150", ousd);
-    await expect(mockNonRebasing).has.an.approxBalanceOf("0", ousd);
+      // Give contract 100 OUSD from Josh
+      await ousd
+        .connect(josh)
+        .transfer(mockNonRebasing.address, ousdUnits("100"));
+      await expect(matt).has.an.approxBalanceOf("100.00", ousd);
+      await expect(josh).has.an.approxBalanceOf("0", ousd);
+      await expect(mockNonRebasing).has.an.approxBalanceOf("100.00", ousd);
+      // Transfer USDC into the Vault to simulate yield
+      await usdc.connect(matt).transfer(vault.address, usdcUnits("200"));
+      await vault.rebase();
+      // Matt received all the yield
+      await expect(matt).has.an.approxBalanceOf("300.00", ousd);
+      // Give contract 100 OUSD from Matt
+      await ousd
+        .connect(matt)
+        .transfer(mockNonRebasing.address, ousdUnits("50"));
+      await expect(matt).has.an.approxBalanceOf("250", ousd);
+      await expect(mockNonRebasing).has.an.approxBalanceOf("150.00", ousd);
+      // Transfer contract balance to Josh
+      await mockNonRebasing.transfer(await josh.getAddress(), ousdUnits("150"));
+      await expect(matt).has.an.approxBalanceOf("250", ousd);
+      await expect(josh).has.an.approxBalanceOf("150", ousd);
+      await expect(mockNonRebasing).has.an.approxBalanceOf("0", ousd);
 
-    // Validate rebasing and non rebasing credit accounting by calculating'
-    // total supply manually
-    const calculatedTotalSupply = (await ousd.rebasingCreditsHighres())
-      .mul(utils.parseUnits("1", 18))
-      .div(await ousd.rebasingCreditsPerTokenHighres())
-      .add(await ousd.nonRebasingSupply());
-    await expect(calculatedTotalSupply).to.approxEqual(
-      await ousd.totalSupply()
-    );
-  });
+      // Validate rebasing and non rebasing credit accounting by calculating'
+      // total supply manually
+      const calculatedTotalSupply = (await ousd.rebasingCreditsHighres())
+        .mul(utils.parseUnits("1", 18))
+        .div(await ousd.rebasingCreditsPerTokenHighres())
+        .add(await ousd.nonRebasingSupply());
+      await expect(calculatedTotalSupply).to.approxEqual(
+        await ousd.totalSupply()
+      );
+    });
 
-  it("Should transfer the correct amount from a non-rebasing account to a non-rebasing account with different previously set creditsPerToken", async () => {
-    let { ousd, vault, matt, usdc, josh, mockNonRebasing, mockNonRebasingTwo } =
-      fixture;
-    // Give contract 100 OUSD from Josh
-    await ousd.connect(josh).transfer(mockNonRebasing.address, ousdUnits("50"));
-    await expect(mockNonRebasing).has.an.approxBalanceOf("50.00", ousd);
-    // Transfer USDC into the Vault to simulate yield
-    await usdc.connect(matt).transfer(vault.address, usdcUnits("200"));
-    await vault.rebase();
-    await ousd
-      .connect(josh)
-      .transfer(mockNonRebasingTwo.address, ousdUnits("50"));
-    await usdc.connect(matt).transfer(vault.address, usdcUnits("100"));
-    await vault.rebase();
-    await mockNonRebasing.transfer(mockNonRebasingTwo.address, ousdUnits("10"));
-    await expect(mockNonRebasing).has.an.approxBalanceOf("40", ousd);
-    await expect(mockNonRebasingTwo).has.an.approxBalanceOf("60", ousd);
+    it("non-rebasing account to a non-rebasing account with different previously set creditsPerToken", async () => {
+      let {
+        ousd,
+        vault,
+        matt,
+        usdc,
+        josh,
+        mockNonRebasing,
+        mockNonRebasingTwo,
+      } = fixture;
+      // Give contract 100 OUSD from Josh
+      await ousd
+        .connect(josh)
+        .transfer(mockNonRebasing.address, ousdUnits("50"));
+      await expect(mockNonRebasing).has.an.approxBalanceOf("50.00", ousd);
+      // Transfer USDC into the Vault to simulate yield
+      await usdc.connect(matt).transfer(vault.address, usdcUnits("200"));
+      await vault.rebase();
+      await ousd
+        .connect(josh)
+        .transfer(mockNonRebasingTwo.address, ousdUnits("50"));
+      await usdc.connect(matt).transfer(vault.address, usdcUnits("100"));
+      await vault.rebase();
+      await mockNonRebasing.transfer(
+        mockNonRebasingTwo.address,
+        ousdUnits("10")
+      );
+      await expect(mockNonRebasing).has.an.approxBalanceOf("40", ousd);
+      await expect(mockNonRebasingTwo).has.an.approxBalanceOf("60", ousd);
 
-    // Validate rebasing and non rebasing credit accounting by calculating'
-    // total supply manually
-    const creditBalanceMockNonRebasing = await ousd.creditsBalanceOf(
-      mockNonRebasing.address
-    );
-    const balanceMockNonRebasing = creditBalanceMockNonRebasing[0]
-      .mul(utils.parseUnits("1", 18))
-      .div(creditBalanceMockNonRebasing[1]);
-    const creditBalanceMockNonRebasingTwo = await ousd.creditsBalanceOf(
-      mockNonRebasingTwo.address
-    );
-    const balanceMockNonRebasingTwo = creditBalanceMockNonRebasingTwo[0]
-      .mul(utils.parseUnits("1", 18))
-      .div(creditBalanceMockNonRebasingTwo[1]);
+      // Validate rebasing and non rebasing credit accounting by calculating'
+      // total supply manually
+      const creditBalanceMockNonRebasing = await ousd.creditsBalanceOf(
+        mockNonRebasing.address
+      );
+      const balanceMockNonRebasing = creditBalanceMockNonRebasing[0]
+        .mul(utils.parseUnits("1", 18))
+        .div(creditBalanceMockNonRebasing[1]);
+      const creditBalanceMockNonRebasingTwo = await ousd.creditsBalanceOf(
+        mockNonRebasingTwo.address
+      );
+      const balanceMockNonRebasingTwo = creditBalanceMockNonRebasingTwo[0]
+        .mul(utils.parseUnits("1", 18))
+        .div(creditBalanceMockNonRebasingTwo[1]);
 
-    const calculatedTotalSupply = (await ousd.rebasingCreditsHighres())
-      .mul(utils.parseUnits("1", 18))
-      .div(await ousd.rebasingCreditsPerTokenHighres())
-      .add(balanceMockNonRebasing)
-      .add(balanceMockNonRebasingTwo);
+      const calculatedTotalSupply = (await ousd.rebasingCreditsHighres())
+        .mul(utils.parseUnits("1", 18))
+        .div(await ousd.rebasingCreditsPerTokenHighres())
+        .add(balanceMockNonRebasing)
+        .add(balanceMockNonRebasingTwo);
 
-    await expect(calculatedTotalSupply).to.approxEqual(
-      await ousd.totalSupply()
-    );
-  });
+      await expect(calculatedTotalSupply).to.approxEqual(
+        await ousd.totalSupply()
+      );
+    });
 
-  it("Should transferFrom the correct amount from a rebasing account to a non-rebasing account and set creditsPerToken", async () => {
-    let { ousd, vault, matt, usdc, josh, mockNonRebasing } = fixture;
+    it("rebasing account to a non-rebasing account and set creditsPerToken", async () => {
+      let { ousd, vault, matt, usdc, josh, mockNonRebasing } = fixture;
 
-    // Give Josh an allowance to move Matt's OUSD
-    await ousd
-      .connect(matt)
-      .increaseAllowance(await josh.getAddress(), ousdUnits("100"));
-    // Give contract 100 OUSD from Matt via Josh
-    await ousd
-      .connect(josh)
-      .transferFrom(
+      // Give Josh an allowance to move Matt's OUSD
+      await ousd
+        .connect(matt)
+        .increaseAllowance(await josh.getAddress(), ousdUnits("100"));
+      // Give contract 100 OUSD from Matt via Josh
+      await ousd
+        .connect(josh)
+        .transferFrom(
+          await matt.getAddress(),
+          mockNonRebasing.address,
+          ousdUnits("100")
+        );
+      await expect(matt).has.an.approxBalanceOf("0", ousd);
+      await expect(mockNonRebasing).has.an.approxBalanceOf("100.00", ousd);
+      const contractCreditsPerToken = await ousd.creditsBalanceOf(
+        mockNonRebasing.address
+      );
+      // Transfer USDC into the Vault to simulate yield
+      await usdc.connect(matt).transfer(vault.address, usdcUnits("200"));
+      await vault.rebase();
+      // Credits per token should be the same for the contract
+      contractCreditsPerToken ===
+        (await ousd.creditsBalanceOf(mockNonRebasing.address));
+
+      // Validate rebasing and non rebasing credit accounting by calculating'
+      // total supply manually
+      const calculatedTotalSupply = (await ousd.rebasingCreditsHighres())
+        .mul(utils.parseUnits("1", 18))
+        .div(await ousd.rebasingCreditsPerTokenHighres())
+        .add(await ousd.nonRebasingSupply());
+      await expect(calculatedTotalSupply).to.approxEqual(
+        await ousd.totalSupply()
+      );
+    });
+
+    it("rebasing account to a non-rebasing account with previously set creditsPerToken", async () => {
+      let { ousd, vault, matt, usdc, josh, mockNonRebasing } = fixture;
+
+      // Give Josh an allowance to move Matt's OUSD
+      await ousd
+        .connect(matt)
+        .increaseAllowance(await josh.getAddress(), ousdUnits("150"));
+      // Give contract 100 OUSD from Matt via Josh
+      await ousd
+        .connect(josh)
+        .transferFrom(
+          await matt.getAddress(),
+          mockNonRebasing.address,
+          ousdUnits("50")
+        );
+      await expect(matt).has.an.approxBalanceOf("50", ousd);
+      await expect(mockNonRebasing).has.an.approxBalanceOf("50", ousd);
+      // Transfer USDC into the Vault to simulate yield
+      await usdc.connect(matt).transfer(vault.address, usdcUnits("200"));
+      await vault.rebase();
+      // Give contract 50 more OUSD from Matt via Josh
+      await ousd
+        .connect(josh)
+        .transferFrom(
+          await matt.getAddress(),
+          mockNonRebasing.address,
+          ousdUnits("50")
+        );
+      await expect(mockNonRebasing).has.an.approxBalanceOf("100", ousd);
+
+      // Validate rebasing and non rebasing credit accounting by calculating'
+      // total supply manually
+      const calculatedTotalSupply = (await ousd.rebasingCreditsHighres())
+        .mul(utils.parseUnits("1", 18))
+        .div(await ousd.rebasingCreditsPerTokenHighres())
+        .add(await ousd.nonRebasingSupply());
+      await expect(calculatedTotalSupply).to.approxEqual(
+        await ousd.totalSupply()
+      );
+    });
+
+    it("non-rebasing account without previously set creditsPerToken to a rebasing account", async () => {
+      let { ousd, matt, josh, mockNonRebasing } = fixture;
+
+      // Give contract 100 OUSD from Josh
+      await ousd
+        .connect(josh)
+        .transfer(mockNonRebasing.address, ousdUnits("100"));
+      await expect(matt).has.an.approxBalanceOf("100.00", ousd);
+      await expect(josh).has.an.approxBalanceOf("0", ousd);
+      await expect(mockNonRebasing).has.an.approxBalanceOf("100.00", ousd);
+      await mockNonRebasing.increaseAllowance(
         await matt.getAddress(),
-        mockNonRebasing.address,
         ousdUnits("100")
       );
-    await expect(matt).has.an.approxBalanceOf("0", ousd);
-    await expect(mockNonRebasing).has.an.approxBalanceOf("100.00", ousd);
-    const contractCreditsPerToken = await ousd.creditsBalanceOf(
-      mockNonRebasing.address
-    );
-    // Transfer USDC into the Vault to simulate yield
-    await usdc.connect(matt).transfer(vault.address, usdcUnits("200"));
-    await vault.rebase();
-    // Credits per token should be the same for the contract
-    contractCreditsPerToken ===
-      (await ousd.creditsBalanceOf(mockNonRebasing.address));
 
-    // Validate rebasing and non rebasing credit accounting by calculating'
-    // total supply manually
-    const calculatedTotalSupply = (await ousd.rebasingCreditsHighres())
-      .mul(utils.parseUnits("1", 18))
-      .div(await ousd.rebasingCreditsPerTokenHighres())
-      .add(await ousd.nonRebasingSupply());
-    await expect(calculatedTotalSupply).to.approxEqual(
-      await ousd.totalSupply()
-    );
-  });
+      await ousd
+        .connect(matt)
+        .transferFrom(
+          mockNonRebasing.address,
+          await matt.getAddress(),
+          ousdUnits("100")
+        );
+      await expect(matt).has.an.approxBalanceOf("200.00", ousd);
+      await expect(josh).has.an.approxBalanceOf("0", ousd);
+      await expect(mockNonRebasing).has.an.approxBalanceOf("0", ousd);
 
-  it("Should transferFrom the correct amount from a rebasing account to a non-rebasing account with previously set creditsPerToken", async () => {
-    let { ousd, vault, matt, usdc, josh, mockNonRebasing } = fixture;
-
-    // Give Josh an allowance to move Matt's OUSD
-    await ousd
-      .connect(matt)
-      .increaseAllowance(await josh.getAddress(), ousdUnits("150"));
-    // Give contract 100 OUSD from Matt via Josh
-    await ousd
-      .connect(josh)
-      .transferFrom(
-        await matt.getAddress(),
-        mockNonRebasing.address,
-        ousdUnits("50")
+      // Validate rebasing and non rebasing credit accounting by calculating'
+      // total supply manually
+      const calculatedTotalSupply = (await ousd.rebasingCreditsHighres())
+        .mul(utils.parseUnits("1", 18))
+        .div(await ousd.rebasingCreditsPerTokenHighres())
+        .add(await ousd.nonRebasingSupply());
+      await expect(calculatedTotalSupply).to.approxEqual(
+        await ousd.totalSupply()
       );
-    await expect(matt).has.an.approxBalanceOf("50", ousd);
-    await expect(mockNonRebasing).has.an.approxBalanceOf("50", ousd);
-    // Transfer USDC into the Vault to simulate yield
-    await usdc.connect(matt).transfer(vault.address, usdcUnits("200"));
-    await vault.rebase();
-    // Give contract 50 more OUSD from Matt via Josh
-    await ousd
-      .connect(josh)
-      .transferFrom(
-        await matt.getAddress(),
-        mockNonRebasing.address,
-        ousdUnits("50")
-      );
-    await expect(mockNonRebasing).has.an.approxBalanceOf("100", ousd);
+    });
 
-    // Validate rebasing and non rebasing credit accounting by calculating'
-    // total supply manually
-    const calculatedTotalSupply = (await ousd.rebasingCreditsHighres())
-      .mul(utils.parseUnits("1", 18))
-      .div(await ousd.rebasingCreditsPerTokenHighres())
-      .add(await ousd.nonRebasingSupply());
-    await expect(calculatedTotalSupply).to.approxEqual(
-      await ousd.totalSupply()
-    );
-  });
+    it("non-rebasing account with previously set creditsPerToken to a rebasing account", async () => {
+      let { ousd, vault, matt, usdc, josh, mockNonRebasing } = fixture;
 
-  it("Should transferFrom the correct amount from a non-rebasing account without previously set creditsPerToken to a rebasing account", async () => {
-    let { ousd, matt, josh, mockNonRebasing } = fixture;
-
-    // Give contract 100 OUSD from Josh
-    await ousd
-      .connect(josh)
-      .transfer(mockNonRebasing.address, ousdUnits("100"));
-    await expect(matt).has.an.approxBalanceOf("100.00", ousd);
-    await expect(josh).has.an.approxBalanceOf("0", ousd);
-    await expect(mockNonRebasing).has.an.approxBalanceOf("100.00", ousd);
-    await mockNonRebasing.increaseAllowance(
-      await matt.getAddress(),
-      ousdUnits("100")
-    );
-
-    await ousd
-      .connect(matt)
-      .transferFrom(
-        mockNonRebasing.address,
-        await matt.getAddress(),
-        ousdUnits("100")
-      );
-    await expect(matt).has.an.approxBalanceOf("200.00", ousd);
-    await expect(josh).has.an.approxBalanceOf("0", ousd);
-    await expect(mockNonRebasing).has.an.approxBalanceOf("0", ousd);
-
-    // Validate rebasing and non rebasing credit accounting by calculating'
-    // total supply manually
-    const calculatedTotalSupply = (await ousd.rebasingCreditsHighres())
-      .mul(utils.parseUnits("1", 18))
-      .div(await ousd.rebasingCreditsPerTokenHighres())
-      .add(await ousd.nonRebasingSupply());
-    await expect(calculatedTotalSupply).to.approxEqual(
-      await ousd.totalSupply()
-    );
-  });
-
-  it("Should transferFrom the correct amount from a non-rebasing account with previously set creditsPerToken to a rebasing account", async () => {
-    let { ousd, vault, matt, usdc, josh, mockNonRebasing } = fixture;
-
-    // Give contract 100 OUSD from Josh
-    await ousd
-      .connect(josh)
-      .transfer(mockNonRebasing.address, ousdUnits("100"));
-    await expect(matt).has.an.approxBalanceOf("100.00", ousd);
-    await expect(josh).has.an.approxBalanceOf("0", ousd);
-    await expect(mockNonRebasing).has.an.approxBalanceOf("100.00", ousd);
-    // Transfer USDC into the Vault to simulate yield
-    await usdc.connect(matt).transfer(vault.address, usdcUnits("200"));
-    await vault.rebase();
-    // Matt received all the yield
-    await expect(matt).has.an.approxBalanceOf("300.00", ousd);
-    // Give contract 100 OUSD from Matt
-    await ousd.connect(matt).transfer(mockNonRebasing.address, ousdUnits("50"));
-    await expect(matt).has.an.approxBalanceOf("250", ousd);
-    await expect(mockNonRebasing).has.an.approxBalanceOf("150.00", ousd);
-    // Transfer contract balance to Josh
-    await mockNonRebasing.increaseAllowance(
-      await matt.getAddress(),
-      ousdUnits("150")
-    );
-
-    await ousd
-      .connect(matt)
-      .transferFrom(
-        mockNonRebasing.address,
+      // Give contract 100 OUSD from Josh
+      await ousd
+        .connect(josh)
+        .transfer(mockNonRebasing.address, ousdUnits("100"));
+      await expect(matt).has.an.approxBalanceOf("100.00", ousd);
+      await expect(josh).has.an.approxBalanceOf("0", ousd);
+      await expect(mockNonRebasing).has.an.approxBalanceOf("100.00", ousd);
+      // Transfer USDC into the Vault to simulate yield
+      await usdc.connect(matt).transfer(vault.address, usdcUnits("200"));
+      await vault.rebase();
+      // Matt received all the yield
+      await expect(matt).has.an.approxBalanceOf("300.00", ousd);
+      // Give contract 100 OUSD from Matt
+      await ousd
+        .connect(matt)
+        .transfer(mockNonRebasing.address, ousdUnits("50"));
+      await expect(matt).has.an.approxBalanceOf("250", ousd);
+      await expect(mockNonRebasing).has.an.approxBalanceOf("150.00", ousd);
+      // Transfer contract balance to Josh
+      await mockNonRebasing.increaseAllowance(
         await matt.getAddress(),
         ousdUnits("150")
       );
 
-    await expect(matt).has.an.approxBalanceOf("400", ousd);
-    await expect(josh).has.an.approxBalanceOf("0", ousd);
-    await expect(mockNonRebasing).has.an.approxBalanceOf("0", ousd);
+      await ousd
+        .connect(matt)
+        .transferFrom(
+          mockNonRebasing.address,
+          await matt.getAddress(),
+          ousdUnits("150")
+        );
 
-    // Validate rebasing and non rebasing credit accounting by calculating'
-    // total supply manually
-    const calculatedTotalSupply = (await ousd.rebasingCreditsHighres())
-      .mul(utils.parseUnits("1", 18))
-      .div(await ousd.rebasingCreditsPerTokenHighres())
-      .add(await ousd.nonRebasingSupply());
-    await expect(calculatedTotalSupply).to.approxEqual(
-      await ousd.totalSupply()
-    );
+      await expect(matt).has.an.approxBalanceOf("400", ousd);
+      await expect(josh).has.an.approxBalanceOf("0", ousd);
+      await expect(mockNonRebasing).has.an.approxBalanceOf("0", ousd);
+
+      // Validate rebasing and non rebasing credit accounting by calculating'
+      // total supply manually
+      const calculatedTotalSupply = (await ousd.rebasingCreditsHighres())
+        .mul(utils.parseUnits("1", 18))
+        .div(await ousd.rebasingCreditsPerTokenHighres())
+        .add(await ousd.nonRebasingSupply());
+      await expect(calculatedTotalSupply).to.approxEqual(
+        await ousd.totalSupply()
+      );
+    });
   });
 
   it("Should maintain the correct balances when rebaseOptIn is called from non-rebasing contract", async () => {


### PR DESCRIPTION
## Contract Changes

* Changes to the following OUSD functions
  * balanceOf
  * _creditsPerToken
  * _isNonRebasingAccount
  * _ensureRebasingMigration
  * _burn
  * _rebaseOptIn

The approach was to not change the storage structure. The improvements are from not re-reading storage slots or avoiding unnecessary storage reads.

## Code Change Checklist

To be completed before internal review begins:

- [ ]  The contract code is complete
- [ ]  Executable deployment file
- [ ]  Fork tests that test after the deployment file runs
- [ ]  Unit tests *if needed
- [ ]  The owner has done a [full checklist review](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) of the code + tests

Internal review:

- [ ] Two approvals by internal reviewers

# Gas changes

## balanceOf

Set `.only` in `contracts/test/token/ousd.js`

```js
describe.only("Should measure gas of balanceOf from", async () => {
```

Before

|  Contract                               |  Method                          |  Min        |  Max        |  Avg        |  # calls |
|----------------------------|------------------------|----------|----------|----------|---------|
|  ERC20                                  |  balanceOf                 |        28950  |    34016  |    31688  |             3  |

After
|  Contract                               |  Method                          |  Min        |  Max        |  Avg        |  # calls |
|----------------------------|------------------------|----------|---------|----------|---------|
|  ERC20                                  |  balanceOf                 |      28967  |      33842  |      31515  |            3 |


## transfer

Set `.only` in `contracts/test/token/ousd.js`

```js
describe.only("Should transfer the correct amount from a", () => {
```

Before

|  Contract                               |  Method                          |  Min        |  Max        |  Avg        |  # calls |
|----------------------------|------------------------|----------|---------|----------|---------|
|  ERC20                                  |  transfer                  |      64385  |     119947  |     100621  |            11   │
|  MockNonRebasing              |  transfer                  |      60338  |      77545  |      66109  |             3    │

After

|  Contract                               |  Method                          |  Min        |  Max        |  Avg        |  # calls |
|----------------------------|------------------------|----------|---------|----------|---------|
|  ERC20                                  |  transfer                  |      58967  |     119432  |      98769  |       11   │
|  MockNonRebasing              |  transfer                  |      51929  |      74429  |      61229  |        3   │

## changeSupply

Set `.only` in `contracts/test/token/ousd.js`

```js
it.only("Should measure gas of changeSupply", async () => {
```

Before

|  Contract                               |  Method                          |  Min        |  Max       |  Avg        |  # calls |
|----------------------------|------------------------|--------- |---------|----------|---------|
|  Echidna                                |  changeSupply               |         -      |          -   |     48572 |             1 │

After

|  Contract                               |  Method                          |  Min        |  Max       |  Avg        |  # calls  |
|----------------------------|------------------------|----------|---------|----------|---------|
|  Echidna                                |  changeSupply               |         -      |          -   |     47883 |             1 │


