### PR TITLE
Aerodrome AMO remove liquidity proper fix

### DIFF
--- a/contracts/contracts/interfaces/aerodrome/ISugarHelper.sol
+++ b/contracts/contracts/interfaces/aerodrome/ISugarHelper.sol
@@ -29,7 +29,7 @@ interface ISugarHelper {
         uint160 sqrtRatioX96,
         uint160 sqrtRatioAX96,
         uint160 sqrtRatioBX96
-    ) external pure returns (uint256 liquidity);
+    ) external pure returns (uint128 liquidity);
 
     /// @notice Computes the amount of token0 for a given amount of token1 and price range
     /// @param amount1 Amount of token1 to estimate liquidity

--- a/contracts/contracts/strategies/aerodrome/AerodromeAMOStrategy.sol
+++ b/contracts/contracts/strategies/aerodrome/AerodromeAMOStrategy.sol
@@ -499,9 +499,6 @@ contract AerodromeAMOStrategy is InitializableAbstractStrategy {
             return;
         }
 
-        // safe since _liquidity != 0 check happens 1 line above
-        uint256 _liquidityToDecreasePct = _liquidityToDecrease / _liquidity;
-
         (uint256 _amountWeth, uint256 _amountOethb) = positionManager
             .decreaseLiquidity(
                 // Both expected amounts can be 0 since we don't really care if any swaps
@@ -528,6 +525,9 @@ contract AerodromeAMOStrategy is InitializableAbstractStrategy {
             );
 
         _updateUnderlyingAssets();
+
+        // safe since _liquidity != 0 check happens above
+        uint256 _liquidityToDecreasePct = _liquidityToDecrease / _liquidity;
 
         emit LiquidityRemoved(
             _liquidityToDecreasePct,

--- a/contracts/contracts/strategies/aerodrome/AerodromeAMOStrategy.sol
+++ b/contracts/contracts/strategies/aerodrome/AerodromeAMOStrategy.sol
@@ -858,7 +858,8 @@ contract AerodromeAMOStrategy is InitializableAbstractStrategy {
          *
          * If token addresses were reversed estimateAmount0 would be required here
          *
-         * The function calculates exactly how much OETH
+         * The function calculates exactly how much OETH will be withdrawn alongside 
+         * specific amount of WETH.
          */
         uint160 _currentPrice = getPoolX96Price();
         uint256 _oethbToWithdraw = helper.estimateAmount1(

--- a/contracts/contracts/strategies/aerodrome/AerodromeAMOStrategy.sol
+++ b/contracts/contracts/strategies/aerodrome/AerodromeAMOStrategy.sol
@@ -525,11 +525,8 @@ contract AerodromeAMOStrategy is InitializableAbstractStrategy {
 
         _updateUnderlyingAssets();
 
-        // safe since _liquidity != 0 check happens above
-        uint256 _liquidityToDecreasePct = _liquidityToDecrease / _liquidity;
-
         emit LiquidityRemoved(
-            _liquidityToRemove,
+            _liquidityToDecrease,
             _amountWeth, //removedWethAmount
             _amountOethb, //removedOethbAmount
             _amountWethCollected,
@@ -836,10 +833,6 @@ contract AerodromeAMOStrategy is InitializableAbstractStrategy {
         }
 
         require(tokenId != 0, "No liquidity available");
-        // there are rounding issues when calling the combination of `estimateAmount1` &
-        // `getLiquidityForAmounts` when estimating the exact required amount of liquidity
-        // to withdraw in order to get the desired amount of tokens. For that reason we overshoot
-        // for 1 wei offsetting the potential rounding error.
         uint256 _additionalWethRequired = _amount - _wethBalance;
         (uint256 _wethInThePool, ) = getPositionPrincipal();
 
@@ -854,7 +847,6 @@ contract AerodromeAMOStrategy is InitializableAbstractStrategy {
             _additionalWethRequired.divPrecisely(_wethInThePool) + 1,
             1e18
         );
-
         _removeLiquidity(shareOfWethToRemove);
     }
 

--- a/contracts/test/strategies/aerodrome-amo.base.fork-test.js
+++ b/contracts/test/strategies/aerodrome-amo.base.fork-test.js
@@ -682,7 +682,7 @@ describe("ForkTest: Aerodrome AMO Strategy (Base)", async function () {
         oethUnits("0")
       );
 
-      await assetLpNOTStakedInGauge();
+      await verifyEndConditions(false);
     });
 
     it("Should withdraw when there's little OETHb in the pool", async () => {
@@ -774,13 +774,15 @@ describe("ForkTest: Aerodrome AMO Strategy (Base)", async function () {
         oethUnits("0")
       );
 
-      await assetLpNOTStakedInGauge();
+      await verifyEndConditions(false);
     });
   });
 
   describe("Deposit and rebalance", function () {
     it("Should be able to deposit to the strategy", async () => {
       await mintAndDepositToStrategy();
+
+      await verifyEndConditions();
     });
 
     it("Should revert when not depositing WETH or amount is 0", async () => {
@@ -1219,8 +1221,12 @@ describe("ForkTest: Aerodrome AMO Strategy (Base)", async function () {
    * - nft LP token should remain staked
    * - there should be no substantial amount of WETH / OETHb left on the strategy contract
    */
-  const verifyEndConditions = async () => {
-    await assetLpStakedInGauge();
+  const verifyEndConditions = async (lpStaked = true) => {
+    if (lpStaked) {
+      await assetLpStakedInGauge();
+    } else {
+      await assetLpNOTStakedInGauge();
+    }
 
     await expect(await weth.balanceOf(aerodromeAmoStrategy.address)).to.lte(
       oethUnits("0.00001")


### PR DESCRIPTION
In this PR: 
- not deposits to the pool when there is dust WETH on the contract
- OETHb is burned only at the lowest level in `_removeLiquidity`, `_swapToDesiredPosition`, and `_addLiquidity` functions. See discussion here: https://github.com/OriginProtocol/origin-dollar/pull/2276#discussion_r1816674819

**Reasons:** 
There is a growing concern that the strategy contract won't burn all of the OETHb after executing operations which have the potential to receive OETHb. There are a lot of code paths to keep in mind, and while we can confirm that all are covered in the current implementation there is a non negligible concern that future changes to the code would introduce errors. 

The problem was further exacerbated by tests not really catching all codepaths since we would overshoot when withdrawing WETH and would probably(?) always trigger `addLuquidity` in rebalance function which calls `burnOETH`. Potentially masking the problem of other functions in rebalance not burning the OETHb or rebalance itself not burning it.

For that reason a threshold to not deposit WETH dust has been added. This should expose any code paths not cleaning after themselves in the tests