### PR TITLE
Use safecast for any downcasting

### DIFF
--- a/contracts/contracts/token/OUSD.sol
+++ b/contracts/contracts/token/OUSD.sol
@@ -8,6 +8,7 @@ pragma solidity ^0.8.0;
  * @author Origin Protocol Inc
  */
 import { Governable } from "../governance/Governable.sol";
+import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 /**
  * NOTE that this is an ERC20 token but the invariant that the sum of
@@ -16,6 +17,8 @@ import { Governable } from "../governance/Governable.sol";
  */
 
 contract OUSD is Governable {
+    using SafeCast for int256;
+
     event TotalSupplyUpdatedHighres(
         uint256 totalSupply,
         uint256 rebasingCredits,
@@ -275,9 +278,7 @@ contract OUSD is Governable {
     {
         RebaseOptions state = rebaseState[account];
         int256 currentBalance = int256(balanceOf(account));
-        uint256 newBalance = uint256(
-            int256(currentBalance) + int256(balanceChange)
-        );
+        uint256 newBalance = (currentBalance + balanceChange).toUint256();
         if (newBalance < 0) {
             revert("Transfer amount exceeds balance");
         }
@@ -320,20 +321,16 @@ contract OUSD is Governable {
         int256 nonRebasingSupplyDiff
     ) internal {
         if (rebasingCreditsDiff != 0) {
-            if (uint256(int256(_rebasingCredits) + rebasingCreditsDiff) < 0) {
+            if (int256(_rebasingCredits) + rebasingCreditsDiff < 0) {
                 revert("rebasingCredits underflow");
             }
-            _rebasingCredits = uint256(
-                int256(_rebasingCredits) + rebasingCreditsDiff
-            );
+            _rebasingCredits = (int256(_rebasingCredits) + rebasingCreditsDiff).toUint256();
         }
         if (nonRebasingSupplyDiff != 0) {
             if (int256(nonRebasingSupply) + nonRebasingSupplyDiff < 0) {
                 revert("nonRebasingSupply underflow");
             }
-            nonRebasingSupply = uint256(
-                int256(nonRebasingSupply) + nonRebasingSupplyDiff
-            );
+            nonRebasingSupply = (int256(nonRebasingSupply) + nonRebasingSupplyDiff).toUint256();
         }
     }
 

--- a/contracts/test/flipper/flipper.js
+++ b/contracts/test/flipper/flipper.js
@@ -62,7 +62,9 @@ describe("Flipper", function () {
           // eslint-disable-next-line
           `buyOusdWith${titleName}`
         ](ousdUnits("1"));
-        await expect(call).to.be.revertedWith("Transfer amount exceeds balance");
+        await expect(call).to.be.revertedWith(
+          "Transfer amount exceeds balance"
+        );
       }
     );
   });

--- a/contracts/test/flipper/flipper.js
+++ b/contracts/test/flipper/flipper.js
@@ -62,7 +62,7 @@ describe("Flipper", function () {
           // eslint-disable-next-line
           `buyOusdWith${titleName}`
         ](ousdUnits("1"));
-        await expect(call).to.be.revertedWith("Transfer greater than balance");
+        await expect(call).to.be.revertedWith("Transfer amount exceeds balance");
       }
     );
   });

--- a/contracts/test/vault/oeth-vault.js
+++ b/contracts/test/vault/oeth-vault.js
@@ -1428,7 +1428,7 @@ describe("OETH Vault", function () {
             .connect(josh)
             .requestWithdrawal(dataBefore.userOeth.add(1));
 
-          await expect(tx).to.revertedWith("Remove exceeds balance");
+          await expect(tx).to.revertedWith("Transfer amount exceeds balance");
         });
         it("capital is paused", async () => {
           const { oethVault, governor, josh } = fixture;

--- a/contracts/test/vault/redeem.js
+++ b/contracts/test/vault/redeem.js
@@ -154,7 +154,7 @@ describe("Vault Redeem", function () {
     // Try to withdraw more than balance
     await expect(
       vault.connect(anna).redeem(ousdUnits("100.0"), 0)
-    ).to.be.revertedWith("Remove exceeds balance");
+    ).to.be.revertedWith("Transfer amount exceeds balance");
   });
 
   it("Should only allow Governor to set a redeem fee", async () => {


### PR DESCRIPTION
 - Use safecast for any downcasting
 - fix one small bug that had an extra un-needed cast to `uint256`
 - fixes a bug where a negative balance would cause panic: https://github.com/OriginProtocol/origin-dollar/pull/2306/files#diff-9256f2c32e9ea588f87885ad1528ba06743860394c236fe4765adea760dd3c84L278
 - fixes unit tests