### PR TITLE
Test code simplification

### DIFF
--- a/contracts/test/token/ousd.js
+++ b/contracts/test/token/ousd.js
@@ -861,6 +861,17 @@ describe("Token", function () {
   });
 
   describe("Delegating yield", function () {
+    it.only("test gas consumption", async () => {
+      let { ousd, vault, matt, josh, anna, usdc, governor } = fixture;
+
+      await ousd
+        .connect(governor)
+        // matt delegates yield to anna
+        .delegateYield(matt.address, anna.address);
+
+      await ousd.connect(matt).transfer(anna.address, ousdUnits("10"));
+    });
+
     it("Should delegate rebase to another account", async () => {
       let { ousd, vault, matt, josh, anna, usdc, governor } = fixture;
 


### PR DESCRIPTION
As per [EIP 2200](https://eips.ethereum.org/EIPS/eip-2200) ethereum EVM does some gas recycling when storage slots are being written to multiple times. This sparked the idea of updating the global states each time withing the `_adjustAccount` function. 
The code simplification is really nice, though it comes at a cost of ~3k extra gas usage. 

Gas usage on transfer from the base branch:
![Screenshot 2024-11-11 at 23 48 35](https://github.com/user-attachments/assets/405e39af-2289-4b94-95f5-a443253a385f)

Gas usage on transfer from this branch: 
![Screenshot 2024-11-11 at 23 50 27](https://github.com/user-attachments/assets/2572519d-c6dc-4650-9ec9-0f8153c24972)



