### PR TITLE
Fix denomination issues with implementation 

### DIFF
--- a/contracts/contracts/token/OUSD.sol
+++ b/contracts/contracts/token/OUSD.sol
@@ -10,7 +10,6 @@ pragma solidity ^0.8.0;
 import { Governable } from "../governance/Governable.sol";
 import { SafeCast } from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
-import "hardhat/console.sol";
 /**
  * NOTE that this is an ERC20 token but the invariant that the sum of
  * balanceOf(x) for all x is not >= totalSupply(). This is a consequence of the
@@ -142,10 +141,6 @@ contract OUSD is Governable {
         uint256 baseBalance = (_creditBalances[_account] * 1e18) /
             _creditsPerToken(_account);
         if (state == RebaseOptions.YieldDelegationTarget) {
-            console.log("Balance of ");
-            console.log(baseBalance);
-            console.log(_creditBalances[_account]);
-            console.log(_creditsPerToken(_account));
             return baseBalance - _creditBalances[yieldFrom[_account]] / RESOLUTION_INCREASE;
         }
         return baseBalance;
@@ -295,12 +290,9 @@ contract OUSD is Governable {
             _creditBalances[target] = targetNewCredits;
             alternativeCreditsPerToken[account] = 1e27;
         } else if (state == RebaseOptions.YieldDelegationTarget) {
-            console.log("Execute transfer");
             uint256 newCredits = _balanceToRebasingCredits(
                 newBalance.toUint256() + _creditBalances[yieldFrom[account]] / RESOLUTION_INCREASE
             );
-            console.log(balanceOf(account));
-            console.log(newCredits);
             rebasingCreditsDiff =
                 newCredits.toInt256() -
                 _creditBalances[account].toInt256();

--- a/contracts/test/flipper/flipper.js
+++ b/contracts/test/flipper/flipper.js
@@ -62,7 +62,7 @@ describe("Flipper", function () {
           // eslint-disable-next-line
           `buyOusdWith${titleName}`
         ](ousdUnits("1"));
-        await expect(call).to.be.revertedWith("Transfer greater than balance");
+        await expect(call).to.be.revertedWith("Transfer amount exceeds balance");
       }
     );
   });

--- a/contracts/test/vault/oeth-vault.js
+++ b/contracts/test/vault/oeth-vault.js
@@ -1428,7 +1428,7 @@ describe("OETH Vault", function () {
             .connect(josh)
             .requestWithdrawal(dataBefore.userOeth.add(1));
 
-          await expect(tx).to.revertedWith("Remove exceeds balance");
+          await expect(tx).to.revertedWith("Transfer amount exceeds balance");
         });
         it("capital is paused", async () => {
           const { oethVault, governor, josh } = fixture;

--- a/contracts/test/vault/redeem.js
+++ b/contracts/test/vault/redeem.js
@@ -154,7 +154,7 @@ describe("Vault Redeem", function () {
     // Try to withdraw more than balance
     await expect(
       vault.connect(anna).redeem(ousdUnits("100.0"), 0)
-    ).to.be.revertedWith("Remove exceeds balance");
+    ).to.be.revertedWith("Transfer amount exceeds balance");
   });
 
   it("Should only allow Governor to set a redeem fee", async () => {


### PR DESCRIPTION
This PR fixes a problem where `creditBalances`, `creditsPerToken`, `alternativeCreditsPerToken` are 1e27 denominated. And while using creditBalances & credits per token with 1e18 denomination will yield correct balances the issues arises when those credit balances are added to contract's global rebasingCredits 