### PR TITLE
N-01 Redundant Code

### DIFF
--- a/contracts/contracts/token/OUSD.sol
+++ b/contracts/contracts/token/OUSD.sol
@@ -640,8 +640,10 @@ contract OUSD is Governable {
         rebaseState[to] = RebaseOptions.StdRebasing;
 
         // Local
-        // alternativeCreditsPerToken[from] already 1e18 from `delegateYield()`
-        creditBalances[_from] = fromBalance;
+        // from account doesn't require any changes as
+        // - alternativeCreditsPerToken[from] already 1e18 from `delegateYield()`
+        // - creditBalances already equal `fromBalance` returned by the balanceOf(_from)
+
         // alternativeCreditsPerToken[to] already 0 from `delegateYield()`
         (creditBalances[to], ) = _balanceToRebasingCredits(toBalance);
         // Global


### PR DESCRIPTION
**Issue by Open Zeppelin team:**
Multiple instances of redundant code were identified in the OUSD contract:

The [initialize](https://github.com/OriginProtocol/origin-dollar/blob/44951300cd2bb7eb1d387461465edbfc440f2779/contracts/contracts/token/OUSD.sol#L60) function [cannot](https://github.com/OriginProtocol/origin-dollar/blob/44951300cd2bb7eb1d387461465edbfc440f2779/contracts/contracts/token/OUSD.sol#L65) be executed since the contract was already initialized in previous versions. To avoid unnecessarily increasing code size, consider removing the function or commenting it out for future reference.
In the [delegateYield](https://github.com/OriginProtocol/origin-dollar/blob/44951300cd2bb7eb1d387461465edbfc440f2779/contracts/contracts/token/OUSD.sol#L566) function, checking both the [yieldFrom/yieldTo mappings](https://github.com/OriginProtocol/origin-dollar/blob/44951300cd2bb7eb1d387461465edbfc440f2779/contracts/contracts/token/OUSD.sol#L571-L577) and the [rebaseState mapping](https://github.com/OriginProtocol/origin-dollar/blob/44951300cd2bb7eb1d387461465edbfc440f2779/contracts/contracts/token/OUSD.sol#L578-L586) is redundant, as the first check will only pass if the second passes, and vice versa. Consider removing the first check, as it involves more storage reads than the second one.
In the [undelegateYield](https://github.com/OriginProtocol/origin-dollar/blob/44951300cd2bb7eb1d387461465edbfc440f2779/contracts/contracts/token/OUSD.sol#L629) function, there is no need to [set the credit balance](https://github.com/OriginProtocol/origin-dollar/blob/44951300cd2bb7eb1d387461465edbfc440f2779/contracts/contracts/token/OUSD.sol#L645) of the delegation source, as it was [already set](https://github.com/OriginProtocol/origin-dollar/blob/44951300cd2bb7eb1d387461465edbfc440f2779/contracts/contracts/token/OUSD.sol#L612) to their balance within delegateYield.
Consider removing these redundancies to enhance the clarity and efficiency of the codebase.

**Origin comment:**
 - We require the `initialize` function for any future fresh token contract deploys that would extend `OUSD.sol`
 - We recognize the redundancy of code in the `delegateYield` function and have intentionally written in that way in the spirit of code readability and defensive programming. The exaggeration of verbosity is in place to prevent any current or future changes that could introduce an error in this critical part. 
 - Redundant storage slot write in `undelegateYield` has been removed