### PR TITLE
N-02 Incomplete Docstrings

### DIFF
--- a/contracts/contracts/token/OUSD.sol
+++ b/contracts/contracts/token/OUSD.sol
@@ -215,6 +215,7 @@ contract OUSD is Governable {
      * @param _from The address you want to send tokens from.
      * @param _to The address you want to transfer to.
      * @param _value The amount of tokens to be transferred.
+     * @return true on success.
      */
     function transferFrom(
         address _from,
@@ -333,6 +334,7 @@ contract OUSD is Governable {
      *      tokens on behalf of msg.sender.
      * @param _spender The address which will spend the funds.
      * @param _value The amount of tokens to be spent.
+     * @return true on success.
      */
     function approve(address _spender, uint256 _value) external returns (bool) {
         allowances[msg.sender][_spender] = _value;


### PR DESCRIPTION
**Issue by Open Zeppelin team:**
Within OUSD.sol, the return value of the [transferFrom](https://github.com/OriginProtocol/origin-dollar/blob/44951300cd2bb7eb1d387461465edbfc440f2779/contracts/contracts/token/OUSD.sol#L219-L233) and [approve](https://github.com/OriginProtocol/origin-dollar/blob/44951300cd2bb7eb1d387461465edbfc440f2779/contracts/contracts/token/OUSD.sol#L337-L341) functions is not documented.

Consider thoroughly documenting all functions and events that are part of a contract's public API. When writing docstrings, consider following the [Ethereum Natural Specification Format](https://solidity.readthedocs.io/en/latest/natspec-format.html) (NatSpec).

**Origin comment:** Missing NatSpec added