### PR TITLE
N-04 Multiple Optimizable Storage Operations

### DIFF
--- a/contracts/contracts/token/OUSD.sol
+++ b/contracts/contracts/token/OUSD.sol
@@ -392,8 +392,9 @@ contract OUSD is Governable {
         view
         returns (uint256)
     {
-        if (alternativeCreditsPerToken[_account] != 0) {
-            return alternativeCreditsPerToken[_account];
+        uint256 alternativeCreditsPerTokenMem = alternativeCreditsPerToken[_account];
+        if (alternativeCreditsPerTokenMem != 0) {
+            return alternativeCreditsPerTokenMem;
         } else {
             return rebasingCreditsPerToken_;
         }


### PR DESCRIPTION
**Issue by Open Zeppelin team:**
Multiple optimizable storage reads and writes were identified in the OUSD contract:

- In the _creditsPerToken function, the alternativeCreditsPerToken mapping is [accessed twice ](https://github.com/OriginProtocol/origin-dollar/blob/44951300cd2bb7eb1d387461465edbfc440f2779/contracts/contracts/token/OUSD.sol#L395-L396)for the same key.
- In the changeSupply function, the [totalSupply](https://github.com/OriginProtocol/origin-dollar/blob/44951300cd2bb7eb1d387461465edbfc440f2779/contracts/contracts/token/OUSD.sol#L536), [rebasingCredits_](https://github.com/OriginProtocol/origin-dollar/blob/44951300cd2bb7eb1d387461465edbfc440f2779/contracts/contracts/token/OUSD.sol#L557), and [rebasingCreditsPerToken_](https://github.com/OriginProtocol/origin-dollar/blob/44951300cd2bb7eb1d387461465edbfc440f2779/contracts/contracts/token/OUSD.sol#L558) state variables are read multiple times.
- In the undelegateYield function, the yieldTo mapping is [accessed twice](https://github.com/OriginProtocol/origin-dollar/blob/44951300cd2bb7eb1d387461465edbfc440f2779/contracts/contracts/token/OUSD.sol#L631-L633) for the same key.
Within the _adjustAccount function, the alternativeCreditsPerToken for non-rebasing accounts is always [set to 1e18](https://github.com/OriginProtocol/origin-dollar/blob/44951300cd2bb7eb1d387461465edbfc440f2779/contracts/contracts/token/OUSD.sol#L290), even when the mapping already has that value.

To lower gas consumption, consider reducing unnecessary storage reads by caching these values in memory variables, and only write to storage when the value needs to be updated.

**Origin comment:** 
- `_creditsPerToken` fixed as suggested
- `changeSupply` is a called rarely and by the vault and we'd rather keep better code readability compared to gas optimisation 
- `undelegateYield` is a called rarely by the governor we'd rather keep better code readability compared to gas optimisation 
- `_adjustAccount` needs to stay as is, since current (on chain) state of the contract doesn't have `alternativeCreditsPerToken` set to `1e18` (rather to a much larger number). Not adjusting for this value would result in critical errors greatly underreporting non rebasing user balances. 