### PR TITLE
N-04 Multiple Optimizable Storage Operations Addendum

### DIFF
--- a/contracts/contracts/token/OUSD.sol
+++ b/contracts/contracts/token/OUSD.sol
@@ -333,9 +333,14 @@ contract OUSD is Governable {
             creditBalances[_account] = newCredits;
         } else {
             _autoMigrate(_account);
-            if (alternativeCreditsPerToken[_account] > 0) {
+            uint256 alternativeCreditsPerTokenMem = alternativeCreditsPerToken[
+                _account
+            ];
+            if (alternativeCreditsPerTokenMem > 0) {
                 nonRebasingSupplyDiff = _balanceChange;
-                alternativeCreditsPerToken[_account] = 1e18;
+                if (alternativeCreditsPerTokenMem != 1e18) {
+                    alternativeCreditsPerToken[_account] = 1e18;
+                }
                 creditBalances[_account] = newBalance;
             } else {
                 (uint256 newCredits, ) = _balanceToRebasingCredits(newBalance);
@@ -441,7 +446,9 @@ contract OUSD is Governable {
         view
         returns (uint256)
     {
-        uint256 alternativeCreditsPerTokenMem = alternativeCreditsPerToken[_account];
+        uint256 alternativeCreditsPerTokenMem = alternativeCreditsPerToken[
+            _account
+        ];
         if (alternativeCreditsPerTokenMem != 0) {
             return alternativeCreditsPerTokenMem;
         } else {


### PR DESCRIPTION
**OpenZeppelin comment:**
Within the _adjustAccount function, the alternativeCreditsPerToken for non-rebasing accounts is always [set to 1e18](https://github.com/OriginProtocol/origin-dollar/blob/44951300cd2bb7eb1d387461465edbfc440f2779/contracts/contracts/token/OUSD.sol#L290), even when the mapping already has that value.

**Origin's response:** Fixed as suggested