### PR TITLE
Deploy a Fixed Rate Dripper for OETH.

### DIFF
--- a/contracts/contracts/harvest/Dripper.sol
+++ b/contracts/contracts/harvest/Dripper.sol
@@ -140,7 +140,10 @@ contract Dripper is Governable {
 
     /// @dev Transfer out all ERC20 held by the contract. Governor only.
     /// @param _asset ERC20 token address
-    function transferAllToken(address _asset, address _receiver) external onlyGovernor {
+    function transferAllToken(address _asset, address _receiver)
+        external
+        onlyGovernor
+    {
         IERC20(_asset).safeTransfer(
             _receiver,
             IERC20(_asset).balanceOf(address(this))

--- a/contracts/contracts/harvest/Dripper.sol
+++ b/contracts/contracts/harvest/Dripper.sol
@@ -137,4 +137,13 @@ contract Dripper is Governable {
         // Send funds
         IERC20(token).safeTransfer(vault, amountToSend);
     }
+
+    /// @dev Transfer out all ERC20 held by the contract. Governor only.
+    /// @param _asset ERC20 token address
+    function transferAllToken(address _asset) external onlyGovernor {
+        IERC20(_asset).safeTransfer(
+            governor(),
+            IERC20(_asset).balanceOf(address(this))
+        );
+    }
 }

--- a/contracts/contracts/harvest/Dripper.sol
+++ b/contracts/contracts/harvest/Dripper.sol
@@ -140,9 +140,9 @@ contract Dripper is Governable {
 
     /// @dev Transfer out all ERC20 held by the contract. Governor only.
     /// @param _asset ERC20 token address
-    function transferAllToken(address _asset) external onlyGovernor {
+    function transferAllToken(address _asset, address _receiver) external onlyGovernor {
         IERC20(_asset).safeTransfer(
-            governor(),
+            _receiver,
             IERC20(_asset).balanceOf(address(this))
         );
     }

--- a/contracts/contracts/harvest/OETHFixedRateDripper.sol
+++ b/contracts/contracts/harvest/OETHFixedRateDripper.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { FixedRateDripper } from "./FixedRateDripper.sol";
+
+/**
+ * @title OETH FixedRateDripper Contract
+ * @author Origin Protocol Inc
+ */
+contract OETHFixedRateDripper is FixedRateDripper {
+    constructor(address _vault, address _token)
+        FixedRateDripper(_vault, _token)
+    {}
+}

--- a/contracts/contracts/proxies/Proxies.sol
+++ b/contracts/contracts/proxies/Proxies.sol
@@ -358,3 +358,10 @@ contract MorphoGauntletPrimeUSDTStrategyProxy is
 {
 
 }
+
+/**
+ * @notice OETHFixedRateDripperProxy delegates calls to a OETHFixedRateDripper implementation
+ */
+contract OETHFixedRateDripperProxy is InitializeGovernedUpgradeabilityProxy {
+
+}

--- a/contracts/deploy/mainnet/117_oeth_fixed_rate_dripper.js
+++ b/contracts/deploy/mainnet/117_oeth_fixed_rate_dripper.js
@@ -28,6 +28,10 @@ module.exports = deploymentWithGovernanceProposal(
 
     // --- 1 ---
     // 1.a. Get the current OETH Dripper Proxy
+    const cOETHDripperProxy = await ethers.getContractAt(
+      "OETHDripperProxy",
+      "0xc0F42F73b8f01849a2DD99753524d4ba14317EB3"
+    );
 
     // 1.b. Deploy the new OETH Dripper implementation
     const dOETHDripper = await deployWithConfirmation(
@@ -37,13 +41,9 @@ module.exports = deploymentWithGovernanceProposal(
       true
     );
 
-    const cOETHDripperProxy = await ethers.getContractAt(
-      "OETHDripperProxy",
-      dOETHDripper.address
-    );
     const cOETHDripper = await ethers.getContractAt(
       "OETHDripper",
-      dOETHDripper.address
+      "0xc0F42F73b8f01849a2DD99753524d4ba14317EB3"
     );
 
     // --- 2 ---
@@ -86,10 +86,10 @@ module.exports = deploymentWithGovernanceProposal(
         // 3. Transfer all funds from the old dripper to the new dripper
         {
           contract: cOETHDripper,
-          signature: "transferAllToken(address)",
-          args: [addresses.mainnet.WETH],
+          signature: "transferAllToken(address,address)",
+          args: [addresses.mainnet.WETH, cOETHFixedRateDripperProxy.address],
         },
-        // Collect on the current OETH dripper
+        // 4. Set new dripper address on the vault
         {
           contract: cOETHVaultProxy,
           signature: "setDripper(address)",

--- a/contracts/deploy/mainnet/117_oeth_fixed_rate_dripper.js
+++ b/contracts/deploy/mainnet/117_oeth_fixed_rate_dripper.js
@@ -1,0 +1,63 @@
+const addresses = require("../../utils/addresses");
+const { deploymentWithGovernanceProposal } = require("../../utils/deploy");
+
+module.exports = deploymentWithGovernanceProposal(
+  {
+    deployName: "117_oeth_fixed_rate_dripper",
+    forceDeploy: false,
+    //forceSkip: true,
+    reduceQueueTime: true,
+    deployerIsProposer: false,
+    proposalId: "",
+  },
+  async ({ deployWithConfirmation, withConfirmation }) => {
+    const cOETHVaultProxy = await ethers.getContractAt(
+      "VaultAdmin",
+      addresses.mainnet.OETHVaultProxy
+    );
+
+    // Deployer Actions
+    // ----------------
+    const { deployerAddr } = await getNamedAccounts();
+    const sDeployer = await ethers.provider.getSigner(deployerAddr);
+
+    // 1. Deploy the Fixed Rate Dripper Proxy
+    const dOETHFixedRateDripperProxy = await deployWithConfirmation(
+      "OETHFixedRateDripperProxy"
+    );
+
+    const cOETHFixedRateDripperProxy = await ethers.getContract(
+      "OETHFixedRateDripperProxy"
+    );
+
+    // 2. Deploy the OETH Fixed Rate Dripper implementation
+    const dOETHFixedRateDripper = await deployWithConfirmation(
+      "OETHFixedRateDripper",
+      [addresses.mainnet.OETHVaultProxy, addresses.mainnet.WETH]
+    );
+
+    // 3. Initialize the Fixed Rate Dripper Proxy
+    const initFunction = "initialize(address,address,bytes)";
+    await withConfirmation(
+      cOETHFixedRateDripperProxy.connect(sDeployer)[initFunction](
+        dOETHFixedRateDripper.address,
+        addresses.mainnet.Timelock, // governor
+        "0x" // no init data
+      )
+    );
+
+    // Governance Actions
+    // ----------------
+    return {
+      name: "",
+      actions: [
+        // Collect on the current OETH dripper
+        {
+          contract: cOETHVaultProxy,
+          signature: "setDripper(address)",
+          args: [dOETHFixedRateDripperProxy.address],
+        },
+      ],
+    };
+  }
+);

--- a/contracts/deploy/mainnet/117_oeth_fixed_rate_dripper.js
+++ b/contracts/deploy/mainnet/117_oeth_fixed_rate_dripper.js
@@ -28,10 +28,7 @@ module.exports = deploymentWithGovernanceProposal(
 
     // --- 1 ---
     // 1.a. Get the current OETH Dripper Proxy
-    const cOETHDripperProxy = await ethers.getContractAt(
-      "OETHDripperProxy",
-      "0xc0F42F73b8f01849a2DD99753524d4ba14317EB3"
-    );
+    const cOETHDripperProxy = await ethers.getContract("OETHDripperProxy");
 
     // 1.b. Deploy the new OETH Dripper implementation
     const dOETHDripper = await deployWithConfirmation(
@@ -43,7 +40,7 @@ module.exports = deploymentWithGovernanceProposal(
 
     const cOETHDripper = await ethers.getContractAt(
       "OETHDripper",
-      "0xc0F42F73b8f01849a2DD99753524d4ba14317EB3"
+      cOETHDripperProxy.address
     );
 
     // --- 2 ---


### PR DESCRIPTION
This PR aims to:
- Add a new function to the current Dripper.sol contract, that allows the governor to transfer all tokens sitting in the Dripper to a specified address.
- Deploy this new implementation and upgrade the current Dripper contract on OETH.
- Deploy a new proxy + implementation for a Fixed Rate Dripper (no new code).
- Transfer all remaining WETH from the current Dripper to the new one.
- Set the new dripper address on the vault.




## Code Change Checklist

To be completed before internal review begins:

- [x]  The contract code is complete
- [x]  Executable deployment file
- [x]  Fork tests that test after the deployment file runs
- [x]  Unit tests *if needed
- [x]  The owner has done a [full checklist review](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) of the code + tests

Internal review:

- [ ] Two approvals by internal reviewers