### PR TITLE
Add deployment script for multichain strategist

### DIFF
--- a/contracts/deploy/mainnet/117_multichain_strategist.js
+++ b/contracts/deploy/mainnet/117_multichain_strategist.js
@@ -1,0 +1,84 @@
+const { deploymentWithGovernanceProposal } = require("../../utils/deploy");
+
+module.exports = deploymentWithGovernanceProposal(
+  {
+    deployName: "117_multichain_strategist",
+    forceDeploy: false,
+    //forceSkip: true,
+    reduceQueueTime: true,
+    deployerIsProposer: false,
+    proposalId: "",
+  },
+  async () => {
+    const { multichainStrategistAddr } = await getNamedAccounts();
+
+    const cOETHVaultProxy = await ethers.getContract("OETHVaultProxy");
+    const cOETHVault = await ethers.getContractAt(
+      "IVault",
+      cOETHVaultProxy.address
+    );
+
+    const cOUSDVaultProxy = await ethers.getContract("VaultProxy");
+    const cOUSDVault = await ethers.getContractAt(
+      "IVault",
+      cOUSDVaultProxy.address
+    );
+
+    const cOETHBuybackProxy = await ethers.getContract("OETHBuybackProxy");
+    const cOETHBuyback = await ethers.getContractAt(
+      "OETHBuyback",
+      cOETHBuybackProxy.address
+    );
+
+    const cOUSDBuybackProxy = await ethers.getContract("BuybackProxy");
+    const cOUSDBuyback = await ethers.getContractAt(
+      "OUSDBuyback",
+      cOUSDBuybackProxy.address
+    );
+
+    const cOETHHarvesterSimple = await ethers.getContract(
+      "OETHHarvesterSimple"
+    );
+
+    // const cAuraWETHPriceFeed = await ethers.getContract("AuraWETHPriceFeed")
+
+    // Governance Actions
+    // ----------------
+    return {
+      name: "Switch to multichain guardian",
+      actions: [
+        {
+          contract: cOETHVault,
+          signature: "setStrategistAddr(address)",
+          args: [multichainStrategistAddr],
+        },
+        {
+          contract: cOUSDVault,
+          signature: "setStrategistAddr(address)",
+          args: [multichainStrategistAddr],
+        },
+        {
+          contract: cOETHBuyback,
+          signature: "setStrategistAddr(address)",
+          args: [multichainStrategistAddr],
+        },
+        {
+          contract: cOUSDBuyback,
+          signature: "setStrategistAddr(address)",
+          args: [multichainStrategistAddr],
+        },
+        // Ignoring changing this since we no longer use the OracleRouter or the old Harvester
+        // {
+        //   contract: cAuraWETHPriceFeed,
+        //   signature: "setStrategistAddr(address)",
+        //   args: [multichainStrategistAddr],
+        // },
+        {
+          contract: cOETHHarvesterSimple,
+          signature: "setStrategistAddr(address)",
+          args: [multichainStrategistAddr],
+        },
+      ],
+    };
+  }
+);

--- a/contracts/deploy/mainnet/118_multichain_strategist.js
+++ b/contracts/deploy/mainnet/118_multichain_strategist.js
@@ -41,8 +41,6 @@ module.exports = deploymentWithGovernanceProposal(
       "OETHHarvesterSimple"
     );
 
-    // const cAuraWETHPriceFeed = await ethers.getContract("AuraWETHPriceFeed")
-
     // Governance Actions
     // ----------------
     return {
@@ -68,12 +66,6 @@ module.exports = deploymentWithGovernanceProposal(
           signature: "setStrategistAddr(address)",
           args: [multichainStrategistAddr],
         },
-        // Ignoring changing this since we no longer use the OracleRouter or the old Harvester
-        // {
-        //   contract: cAuraWETHPriceFeed,
-        //   signature: "setStrategistAddr(address)",
-        //   args: [multichainStrategistAddr],
-        // },
         {
           contract: cOETHHarvesterSimple,
           signature: "setStrategistAddr(address)",

--- a/contracts/deploy/mainnet/118_multichain_strategist.js
+++ b/contracts/deploy/mainnet/118_multichain_strategist.js
@@ -2,7 +2,7 @@ const { deploymentWithGovernanceProposal } = require("../../utils/deploy");
 
 module.exports = deploymentWithGovernanceProposal(
   {
-    deployName: "117_multichain_strategist",
+    deployName: "118_multichain_strategist",
     forceDeploy: false,
     //forceSkip: true,
     reduceQueueTime: true,

--- a/contracts/deploy/mainnet/118_multichain_strategist.js
+++ b/contracts/deploy/mainnet/118_multichain_strategist.js
@@ -7,7 +7,8 @@ module.exports = deploymentWithGovernanceProposal(
     //forceSkip: true,
     reduceQueueTime: true,
     deployerIsProposer: false,
-    proposalId: "",
+    proposalId:
+      "29029286887383246507190904901480289164471194993284788972189545670391461770154",
   },
   async () => {
     const { multichainStrategistAddr } = await getNamedAccounts();

--- a/contracts/deploy/mainnet/999_fork_test_setup.js
+++ b/contracts/deploy/mainnet/999_fork_test_setup.js
@@ -23,8 +23,13 @@ const main = async (hre) => {
     await tokenContract.connect(signer).approve(toAddress, allowance);
   }
 
-  const { deployerAddr, timelockAddr, governorAddr, strategistAddr } =
-    await getNamedAccounts();
+  const {
+    deployerAddr,
+    timelockAddr,
+    governorAddr,
+    strategistAddr,
+    multichainStrategistAddr,
+  } = await getNamedAccounts();
 
   hardhatSetBalance(deployerAddr, "1000000");
 
@@ -60,6 +65,7 @@ const main = async (hre) => {
   await impersonateAndFund(deployerAddr);
   await impersonateAndFund(governorAddr);
   await impersonateAndFund(strategistAddr);
+  await impersonateAndFund(multichainStrategistAddr);
   await impersonateAndFund(addresses.mainnet.OldTimelock);
   log("Unlocked and funded named accounts with ETH");
 

--- a/contracts/test/_fixture.js
+++ b/contracts/test/_fixture.js
@@ -144,8 +144,8 @@ const simpleOETHFixture = deployments.createFixture(async () => {
   const [matt, josh, anna, domen, daniel, franck] = signers.slice(4);
 
   if (isFork) {
-    governor = await ethers.provider.getSigner(governorAddr);
-    strategist = await ethers.provider.getSigner(multichainStrategistAddr);
+    governor = await impersonateAndFund(governorAddr);
+    strategist = await impersonateAndFund(multichainStrategistAddr);
 
     for (const user of [matt, josh, anna, domen, daniel, franck]) {
       // Everyone gets free weth
@@ -1003,10 +1003,16 @@ const defaultFixture = deployments.createFixture(async () => {
   const [matt, josh, anna, domen, daniel, franck] = signers.slice(4);
 
   if (isFork) {
-    governor = await ethers.provider.getSigner(governorAddr);
-    strategist = await ethers.provider.getSigner(multichainStrategistAddr);
+    governor = await impersonateAndFund(governorAddr);
+    strategist = await impersonateAndFund(multichainStrategistAddr);
     timelock = await impersonateAndFund(timelockAddr);
     oldTimelock = await impersonateAndFund(addresses.mainnet.OldTimelock);
+
+    // Just a hack to get around using `.getAddress()` on the signer
+    governor.address = governorAddr;
+    strategist.address = multichainStrategistAddr;
+    timelock.address = timelockAddr;
+    oldTimelock.address = addresses.mainnet.OldTimelock;
   } else {
     timelock = governor;
   }

--- a/contracts/test/_fixture.js
+++ b/contracts/test/_fixture.js
@@ -73,7 +73,7 @@ const simpleOETHFixture = deployments.createFixture(async () => {
   });
   log(`Block after deployments: ${await hre.ethers.provider.getBlockNumber()}`);
 
-  const { governorAddr, strategistAddr } = await getNamedAccounts();
+  const { governorAddr, multichainStrategistAddr } = await getNamedAccounts();
   const sGovernor = await ethers.provider.getSigner(governorAddr);
 
   const oethProxy = await ethers.getContract("OETHProxy");
@@ -145,7 +145,7 @@ const simpleOETHFixture = deployments.createFixture(async () => {
 
   if (isFork) {
     governor = await ethers.provider.getSigner(governorAddr);
-    strategist = await ethers.provider.getSigner(strategistAddr);
+    strategist = await ethers.provider.getSigner(multichainStrategistAddr);
 
     for (const user of [matt, josh, anna, domen, daniel, franck]) {
       // Everyone gets free weth
@@ -490,7 +490,7 @@ const loadTokenTransferFixture = deployments.createFixture(async () => {
 
   log(`Block after deployments: ${await hre.ethers.provider.getBlockNumber()}`);
 
-  const { governorAddr, strategistAddr, timelockAddr } =
+  const { governorAddr, multichainStrategistAddr, timelockAddr } =
     await getNamedAccounts();
 
   const vaultAndTokenConracts = await getVaultAndTokenConracts();
@@ -510,7 +510,7 @@ const loadTokenTransferFixture = deployments.createFixture(async () => {
     ...vaultAndTokenConracts,
     ...accountTypes,
     governorAddr,
-    strategistAddr,
+    strategistAddr: multichainStrategistAddr,
     timelockAddr,
     governor,
     strategist,
@@ -534,7 +534,7 @@ const defaultFixture = deployments.createFixture(async () => {
 
   log(`Block after deployments: ${await hre.ethers.provider.getBlockNumber()}`);
 
-  const { governorAddr, strategistAddr, timelockAddr } =
+  const { governorAddr, multichainStrategistAddr, timelockAddr } =
     await getNamedAccounts();
 
   const vaultAndTokenConracts = await getVaultAndTokenConracts();
@@ -1004,7 +1004,7 @@ const defaultFixture = deployments.createFixture(async () => {
 
   if (isFork) {
     governor = await ethers.provider.getSigner(governorAddr);
-    strategist = await ethers.provider.getSigner(strategistAddr);
+    strategist = await ethers.provider.getSigner(multichainStrategistAddr);
     timelock = await impersonateAndFund(timelockAddr);
     oldTimelock = await impersonateAndFund(addresses.mainnet.OldTimelock);
   } else {

--- a/contracts/test/harvest/simple-harvester.mainnet.fork-test.js
+++ b/contracts/test/harvest/simple-harvester.mainnet.fork-test.js
@@ -31,11 +31,7 @@ describe("ForkTest: CurvePoolBooster", function () {
   });
 
   it("Should support Strategy as governor", async () => {
-    const { simpleOETHHarvester } = fixture;
-    const timelock = await ethers.provider.getSigner(
-      addresses.mainnet.Timelock
-    );
-
+    const { simpleOETHHarvester, timelock } = fixture;
     expect(
       await simpleOETHHarvester.supportedStrategies(
         addresses.mainnet.ConvexOETHAMOStrategy
@@ -63,9 +59,9 @@ describe("ForkTest: CurvePoolBooster", function () {
       .connect(strategist)
       .setSupportedStrategy(addresses.mainnet.ConvexOETHAMOStrategy, true);
     expect(
-      await simpleOETHHarvester.connect(strategist).supportedStrategies(
-        addresses.mainnet.ConvexOETHAMOStrategy
-      )
+      await simpleOETHHarvester
+        .connect(strategist)
+        .supportedStrategies(addresses.mainnet.ConvexOETHAMOStrategy)
     ).to.be.equal(true);
   });
 
@@ -92,10 +88,7 @@ describe("ForkTest: CurvePoolBooster", function () {
   });
 
   it("Should Set strategist", async () => {
-    const { simpleOETHHarvester, josh } = fixture;
-    const timelock = await ethers.provider.getSigner(
-      addresses.mainnet.Timelock
-    );
+    const { simpleOETHHarvester, timelock, josh } = fixture;
 
     expect(await simpleOETHHarvester.strategistAddr()).not.to.equal(
       josh.address
@@ -105,11 +98,10 @@ describe("ForkTest: CurvePoolBooster", function () {
   });
 
   it("Should Harvest and transfer rewards as strategist", async () => {
-    const { simpleOETHHarvester, convexEthMetaStrategy, crv } = fixture;
-    const strategistAddress = await simpleOETHHarvester.strategistAddr();
-    const strategist = await ethers.provider.getSigner(strategistAddress);
+    const { simpleOETHHarvester, convexEthMetaStrategy, crv, strategist } =
+      fixture;
 
-    const balanceBeforeCRV = await crv.balanceOf(strategistAddress);
+    const balanceBeforeCRV = await crv.balanceOf(strategist.address);
     await simpleOETHHarvester
       .connect(strategist)
       .setSupportedStrategy(convexEthMetaStrategy.address, true);
@@ -117,18 +109,21 @@ describe("ForkTest: CurvePoolBooster", function () {
     await simpleOETHHarvester
       .connect(strategist)["harvestAndTransfer(address)"](convexEthMetaStrategy.address);
 
-    const balanceAfterCRV = await crv.balanceOf(strategistAddress);
+    const balanceAfterCRV = await crv.balanceOf(strategist.address);
     expect(balanceAfterCRV).to.be.gt(balanceBeforeCRV);
   });
 
   it("Should Harvest and transfer rewards as governor", async () => {
-    const { simpleOETHHarvester, convexEthMetaStrategy, crv } = fixture;
-    const timelock = await ethers.provider.getSigner(
-      addresses.mainnet.Timelock
-    );
-    const strategist = await simpleOETHHarvester.strategistAddr();
+    const {
+      simpleOETHHarvester,
+      convexEthMetaStrategy,
+      strategist,
+      timelock,
+      crv,
+    } = fixture;
 
-    const balanceBeforeCRV = await crv.balanceOf(strategist);
+    const balanceBeforeCRV = await crv.balanceOf(strategist.address);
+
     await simpleOETHHarvester
       .connect(timelock)
       .setSupportedStrategy(convexEthMetaStrategy.address, true);
@@ -136,15 +131,12 @@ describe("ForkTest: CurvePoolBooster", function () {
     await simpleOETHHarvester
       .connect(timelock)["harvestAndTransfer(address)"](convexEthMetaStrategy.address);
 
-    const balanceAfterCRV = await crv.balanceOf(strategist);
+    const balanceAfterCRV = await crv.balanceOf(strategist.address);
     expect(balanceAfterCRV).to.be.gt(balanceBeforeCRV);
   });
 
   it("Should revert if strategy is not authorized", async () => {
-    const { simpleOETHHarvester, convexEthMetaStrategy } = fixture;
-    const timelock = await ethers.provider.getSigner(
-      addresses.mainnet.Timelock
-    );
+    const { simpleOETHHarvester, convexEthMetaStrategy, timelock } = fixture;
 
     await expect(
       // prettier-ignore
@@ -154,10 +146,7 @@ describe("ForkTest: CurvePoolBooster", function () {
   });
 
   it("Should revert if strategy is address 0", async () => {
-    const { simpleOETHHarvester } = fixture;
-    const timelock = await ethers.provider.getSigner(
-      addresses.mainnet.Timelock
-    );
+    const { simpleOETHHarvester, timelock } = fixture;
 
     await expect(
       // prettier-ignore
@@ -167,10 +156,7 @@ describe("ForkTest: CurvePoolBooster", function () {
   });
 
   it("Should test to rescue tokens as governor", async () => {
-    const { simpleOETHHarvester, crv } = fixture;
-    const timelock = await ethers.provider.getSigner(
-      addresses.mainnet.Timelock
-    );
+    const { simpleOETHHarvester, timelock, crv } = fixture;
 
     await setERC20TokenBalance(simpleOETHHarvester.address, crv, "1000");
     const balanceBeforeCRV = await crv.balanceOf(simpleOETHHarvester.address);
@@ -182,9 +168,7 @@ describe("ForkTest: CurvePoolBooster", function () {
   });
 
   it("Should test to rescue tokens as strategist", async () => {
-    const { simpleOETHHarvester, crv } = fixture;
-    const strategistAddress = await simpleOETHHarvester.strategistAddr();
-    const strategist = await ethers.provider.getSigner(strategistAddress);
+    const { simpleOETHHarvester, strategist, crv } = fixture;
 
     await setERC20TokenBalance(simpleOETHHarvester.address, crv, "1000");
     const balanceBeforeCRV = await crv.balanceOf(simpleOETHHarvester.address);

--- a/contracts/test/harvest/simple-harvester.mainnet.fork-test.js
+++ b/contracts/test/harvest/simple-harvester.mainnet.fork-test.js
@@ -19,14 +19,14 @@ describe("ForkTest: CurvePoolBooster", function () {
 
   it("Should have correct parameters", async () => {
     const { simpleOETHHarvester } = fixture;
-    const { strategistAddr } = await getNamedAccounts();
+    const { multichainStrategistAddr } = await getNamedAccounts();
 
     expect(await simpleOETHHarvester.governor()).to.be.equal(
       addresses.mainnet.Timelock
     );
 
     expect(await simpleOETHHarvester.strategistAddr()).to.be.equal(
-      strategistAddr
+      multichainStrategistAddr
     );
   });
 
@@ -52,21 +52,18 @@ describe("ForkTest: CurvePoolBooster", function () {
   });
 
   it("Should support Strategy as strategist", async () => {
-    const { simpleOETHHarvester } = fixture;
-    const strategist = await ethers.provider.getSigner(
-      await simpleOETHHarvester.strategistAddr()
-    );
+    const { simpleOETHHarvester, strategist } = fixture;
 
     expect(
-      await simpleOETHHarvester.supportedStrategies(
-        addresses.mainnet.ConvexOETHAMOStrategy
-      )
+      await simpleOETHHarvester
+        .connect(strategist)
+        .supportedStrategies(addresses.mainnet.ConvexOETHAMOStrategy)
     ).to.be.equal(false);
     await simpleOETHHarvester
       .connect(strategist)
       .setSupportedStrategy(addresses.mainnet.ConvexOETHAMOStrategy, true);
     expect(
-      await simpleOETHHarvester.supportedStrategies(
+      await simpleOETHHarvester.connect(strategist).supportedStrategies(
         addresses.mainnet.ConvexOETHAMOStrategy
       )
     ).to.be.equal(true);

--- a/contracts/test/harvest/simple-harvester.mainnet.fork-test.js
+++ b/contracts/test/harvest/simple-harvester.mainnet.fork-test.js
@@ -6,7 +6,7 @@ const { setERC20TokenBalance } = require("../_fund");
 
 const { loadDefaultFixture } = require("../_fixture");
 
-describe("ForkTest: CurvePoolBooster", function () {
+describe("ForkTest: SimpleHarvester", function () {
   this.timeout(0);
 
   // Retry up to 3 times on CI


### PR DESCRIPTION
## Overview
- Updates our contracts to use multi-chain guardian (replacing our old 2/8 on mainnet)
- All our strategy contracts use the Vault to read the `strategistAddr`, so no update is needed there
- Have intentionally skipped updating a few contracts like `AuraWETHPriceFeed` since they are no longer in use by any of our other contracts

## Governance Proposal
- Proposal ID: [29029286887383246507190904901480289164471194993284788972189545670391461770154](<https://app.originprotocol.com/#/more/1:0x1d3fbd4d129ddd2372ea85c5fa00b2682081c9ec:29029286887383246507190904901480289164471194993284788972189545670391461770154>)
- Proposal Tx: [0x3f4d97f3293e4d3f71a60adfad227597791e80b414cfac5ea8839e5fa15f04ef](<https://etherscan.io/tx/0x3f4d97f3293e4d3f71a60adfad227597791e80b414cfac5ea8839e5fa15f04ef/advanced#eventlog>)

## Deploy checklist

Two reviewers complete the following checklist:

```
- [ ] All deployed contracts are listed in the deploy PR's description
- [ ] Deployed contract's verified code (and all dependencies) match the code in master
- [ ] Contract constructors have correct arguments
- [ ] The transactions that interacted with the newly deployed contract match the deploy script.
- [ ] Governance proposal matches the deploy script
- [ ] Smoke tests pass after fork test execution of the governance proposal
```

