### PR TITLE
Allow guardian to redeem instantly without fees

### DIFF
--- a/contracts/contracts/vault/OETHVaultCore.sol
+++ b/contracts/contracts/vault/OETHVaultCore.sol
@@ -130,9 +130,10 @@ contract OETHVaultCore is VaultCore {
         }
 
         // Amount excluding fees
-        uint256 amountMinusFee = _calculateRedeemOutputs(_amount)[
-            wethAssetIndex
-        ];
+        // No fee for the strategist, makes it easier to do operations
+        uint256 amountMinusFee = msg.sender == strategistAddr
+            ? _amount
+            : _calculateRedeemOutputs(_amount)[wethAssetIndex];
 
         require(
             amountMinusFee >= _minimumUnitAmount,

--- a/contracts/contracts/vault/OETHVaultCore.sol
+++ b/contracts/contracts/vault/OETHVaultCore.sol
@@ -130,7 +130,7 @@ contract OETHVaultCore is VaultCore {
         }
 
         // Amount excluding fees
-        // No fee for the strategist, makes it easier to do operations
+        // No fee for the strategist or the governor, makes it easier to do operations
         uint256 amountMinusFee = (msg.sender == strategistAddr || isGovernor())
             ? _amount
             : _calculateRedeemOutputs(_amount)[wethAssetIndex];

--- a/contracts/contracts/vault/OETHVaultCore.sol
+++ b/contracts/contracts/vault/OETHVaultCore.sol
@@ -131,7 +131,7 @@ contract OETHVaultCore is VaultCore {
 
         // Amount excluding fees
         // No fee for the strategist, makes it easier to do operations
-        uint256 amountMinusFee = msg.sender == strategistAddr
+        uint256 amountMinusFee = (msg.sender == strategistAddr || isGovernor())
             ? _amount
             : _calculateRedeemOutputs(_amount)[wethAssetIndex];
 

--- a/contracts/fork-test.sh
+++ b/contracts/fork-test.sh
@@ -77,7 +77,11 @@ main()
 
     # Run specific files when a param is given
     if [[ ! -z "$1" ]]; then
-        params+="--testfiles $@"
+        if [[ $is_coverage == "true" ]]; then
+            params+="--testfiles $@"
+        else
+            params+="$@"
+        fi
     fi
 
     # Add trace flag if enabled

--- a/contracts/test/strategies/base/aerodrome-amo.base.fork-test.js
+++ b/contracts/test/strategies/base/aerodrome-amo.base.fork-test.js
@@ -364,7 +364,7 @@ describe("ForkTest: Aerodrome AMO Strategy (Base)", async function () {
     it("Should have the correct initial state", async function () {
       // correct pool weth share interval
       expect(await aerodromeAmoStrategy.allowedWethShareStart()).to.equal(
-        oethUnits("0.05")
+        oethUnits("0.010000001")
       );
 
       expect(await aerodromeAmoStrategy.allowedWethShareEnd()).to.equal(

--- a/contracts/test/vault/oeth-vault.mainnet.fork-test.js
+++ b/contracts/test/vault/oeth-vault.mainnet.fork-test.js
@@ -181,14 +181,14 @@ describe("ForkTest: OETH Vault", function () {
       // Mint 1:1
       await oethVault.connect(strategist).mint(weth.address, amount, amount);
 
-      const oethBalanceBefore = await oeth.balanceOf(strategist);
-      const wethBalanceBefore = await weth.balanceOf(strategist);
+      const oethBalanceBefore = await oeth.balanceOf(strategist.address);
+      const wethBalanceBefore = await weth.balanceOf(strategist.address);
 
       // Redeem 1:1 instantly
       await oethVault.connect(strategist).redeem(amount, amount);
 
-      const oethBalanceAfter = await oeth.balanceOf(strategist);
-      const wethBalanceAfter = await weth.balanceOf(strategist);
+      const oethBalanceAfter = await oeth.balanceOf(strategist.address);
+      const wethBalanceAfter = await weth.balanceOf(strategist.address);
 
       expect(oethBalanceAfter).to.equal(oethBalanceBefore.sub(amount));
       expect(wethBalanceAfter).to.equal(wethBalanceBefore.add(amount));
@@ -205,14 +205,14 @@ describe("ForkTest: OETH Vault", function () {
       // Mint 1:1
       await oethVault.connect(josh).mint(weth.address, amount, amount);
 
-      const oethBalanceBefore = await oeth.balanceOf(josh);
-      const wethBalanceBefore = await weth.balanceOf(josh);
+      const oethBalanceBefore = await oeth.balanceOf(josh.address);
+      const wethBalanceBefore = await weth.balanceOf(josh.address);
 
       // Redeem 1:1 instantly
       await oethVault.connect(josh).redeem(amount, expectedWETH);
 
-      const oethBalanceAfter = await oeth.balanceOf(josh);
-      const wethBalanceAfter = await weth.balanceOf(josh);
+      const oethBalanceAfter = await oeth.balanceOf(josh.address);
+      const wethBalanceAfter = await weth.balanceOf(josh.address);
 
       expect(oethBalanceAfter).to.equal(oethBalanceBefore.sub(amount));
       expect(wethBalanceAfter).to.equal(wethBalanceBefore.add(expectedWETH));

--- a/contracts/test/vault/oeth-vault.mainnet.fork-test.js
+++ b/contracts/test/vault/oeth-vault.mainnet.fork-test.js
@@ -171,6 +171,53 @@ describe("ForkTest: OETH Vault", function () {
       });
     });
 
+    it("should allow strategist to redeem without fee", async () => {
+      const { oethVault, strategist, weth, oeth } = fixture;
+
+      const amount = oethUnits("10");
+
+      await weth.connect(strategist).approve(oethVault.address, amount);
+
+      // Mint 1:1
+      await oethVault.connect(strategist).mint(weth.address, amount, amount);
+
+      const oethBalanceBefore = await oeth.balanceOf(strategist);
+      const wethBalanceBefore = await weth.balanceOf(strategist);
+
+      // Redeem 1:1 instantly
+      await oethVault.connect(strategist).redeem(amount, amount);
+
+      const oethBalanceAfter = await oeth.balanceOf(strategist);
+      const wethBalanceAfter = await weth.balanceOf(strategist);
+
+      expect(oethBalanceAfter).to.equal(oethBalanceBefore.sub(amount));
+      expect(wethBalanceAfter).to.equal(wethBalanceBefore.add(amount));
+    });
+
+    it("should enforce fee on other users for instant redeem", async () => {
+      const { oethVault, josh, weth, oeth } = fixture;
+
+      const amount = oethUnits("10");
+      const expectedWETH = amount.mul("9990").div("10000");
+
+      await weth.connect(josh).approve(oethVault.address, amount);
+
+      // Mint 1:1
+      await oethVault.connect(josh).mint(weth.address, amount, amount);
+
+      const oethBalanceBefore = await oeth.balanceOf(josh);
+      const wethBalanceBefore = await weth.balanceOf(josh);
+
+      // Redeem 1:1 instantly
+      await oethVault.connect(josh).redeem(amount, expectedWETH);
+
+      const oethBalanceAfter = await oeth.balanceOf(josh);
+      const wethBalanceAfter = await weth.balanceOf(josh);
+
+      expect(oethBalanceAfter).to.equal(oethBalanceBefore.sub(amount));
+      expect(wethBalanceAfter).to.equal(wethBalanceBefore.add(expectedWETH));
+    });
+
     it("should partially redeem 10 OETH", async () => {
       const { domen, oeth, oethVault, weth } = fixture;
 


### PR DESCRIPTION
## Change overview
- Guardian (or `strategist` in the codebase) can now instantly redeem without paying the 10bps fee. Will help us a lot with operations. And this is something we already do on Base as well
- Doesn't add a separate deploy file. 108 is pending and it upgrades the Vault anyway


## Code Change Checklist

To be completed before internal review begins:

- [ ]  The contract code is complete
- [ ]  Executable deployment file
- [ ]  Fork tests that test after the deployment file runs
- [ ]  Unit tests *if needed
- [ ]  The owner has done a [full checklist review](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) of the code + tests

Internal review:

- [ ] Two approvals by internal reviewers
