### PR TITLE
Yield forwarding template

### DIFF
--- a/contracts/deployments/sonic/operations/yield_forward_template.execute.json
+++ b/contracts/deployments/sonic/operations/yield_forward_template.execute.json
@@ -1,0 +1,52 @@
+{
+  "version": "1.0",
+  "chainId": "146",
+  "createdAt": 1738873151,
+  "meta": {
+    "name": "Transaction Batch",
+    "description": "",
+    "txBuilderVersion": "1.16.1",
+    "createdFromSafeAddress": "0xAdDEA7933Db7d83855786EB43a238111C69B00b6",
+    "createdFromOwnerAddress": ""
+  },
+  "transactions": [
+    {
+      "to": "0x31a91336414d3B955E494E7d485a6B06b55FC8fB",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "type": "address[]",
+            "name": "targets"
+          },
+          {
+            "type": "uint256[]",
+            "name": "values"
+          },
+          {
+            "type": "bytes[]",
+            "name": "payloads"
+          },
+          {
+            "type": "bytes32",
+            "name": "predecessor"
+          },
+          {
+            "type": "bytes32",
+            "name": "salt"
+          }
+        ],
+        "name": "executeBatch",
+        "payable": true
+      },
+      "contractInputsValues": {
+        "targets": "[\"0xb1e25689D55734FD3ffFc939c4C3Eb52DFf8A794\"]",
+        "values": "[\"0\"]",
+        "payloads": "[\"0x9d01fc72000000000000000000000000[FROM_ADDRESS_WITHOUT_0x]000000000000000000000000[TO_ADDRESS_WITHOUT_0x]\"]",
+        "predecessor": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "salt": "0xcff5f83cedb9dc69e608bd518db9ef0bfad4aa4897d21364f01388fce8ac9f51"
+      }
+    }
+  ]
+}

--- a/contracts/deployments/sonic/operations/yield_forward_template.schedule.json
+++ b/contracts/deployments/sonic/operations/yield_forward_template.schedule.json
@@ -1,0 +1,57 @@
+{
+  "version": "1.0",
+  "chainId": "146",
+  "createdAt": 1738873151,
+  "meta": {
+    "name": "Transaction Batch",
+    "description": "",
+    "txBuilderVersion": "1.16.1",
+    "createdFromSafeAddress": "0xAdDEA7933Db7d83855786EB43a238111C69B00b6",
+    "createdFromOwnerAddress": ""
+  },
+  "transactions": [
+    {
+      "to": "0x31a91336414d3B955E494E7d485a6B06b55FC8fB",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "type": "address[]",
+            "name": "targets"
+          },
+          {
+            "type": "uint256[]",
+            "name": "values"
+          },
+          {
+            "type": "bytes[]",
+            "name": "payloads"
+          },
+          {
+            "type": "bytes32",
+            "name": "predecessor"
+          },
+          {
+            "type": "bytes32",
+            "name": "salt"
+          },
+          {
+            "type": "uint256",
+            "name": "delay"
+          }
+        ],
+        "name": "scheduleBatch",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "targets": "[\"0xb1e25689D55734FD3ffFc939c4C3Eb52DFf8A794\"]",
+        "values": "[\"0\"]",
+        "payloads": "[\"0x9d01fc72000000000000000000000000[FROM_ADDRESS_WITHOUT_0x]000000000000000000000000[TO_ADDRESS_WITHOUT_0x]\"]",
+        "predecessor": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "salt": "0xcff5f83cedb9dc69e608bd518db9ef0bfad4aa4897d21364f01388fce8ac9f51",
+        "delay": "86400"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
We don't need to clutter our deployments folder with extra entries every time we want to create a yield forwarding action. This PR adds a template where from & to addresses need to be added in order to schedule and execute a yield forwarding transaction. 