### PR TITLE
SuperOETH Harvester

### DIFF
--- a/contracts/contracts/harvest/OETHHarvesterSimple.sol
+++ b/contracts/contracts/harvest/OETHHarvesterSimple.sol
@@ -88,6 +88,7 @@ contract OETHHarvesterSimple is Initializable, Strategizable {
 
         // Store locally for some gas savings
         address _strategist = strategistAddr;
+        address _dripper = dripper;
 
         // Harvest rewards
         IStrategy(_strategy).collectRewardTokens();
@@ -104,7 +105,7 @@ contract OETHHarvesterSimple is Initializable, Strategizable {
             if (balance > 0) {
                 // Determine receiver
                 address receiver = token == wrappedNativeToken
-                    ? dripper
+                    ? _dripper
                     : _strategist;
                 require(receiver != address(0), "Invalid receiver");
 

--- a/contracts/contracts/harvest/OETHHarvesterSimple.sol
+++ b/contracts/contracts/harvest/OETHHarvesterSimple.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
 import { Strategizable } from "../governance/Strategizable.sol";
@@ -16,8 +16,8 @@ contract OETHHarvesterSimple is Initializable, Strategizable {
     ////////////////////////////////////////////////////
     /// --- CONSTANTS & IMMUTABLES
     ////////////////////////////////////////////////////
-    /// @notice WETH address
-    address public immutable WETH;
+    /// @notice wrapped native token address (WETH or wS)
+    address public immutable wrappedNativeToken;
 
     ////////////////////////////////////////////////////
     /// --- STORAGE
@@ -46,8 +46,8 @@ contract OETHHarvesterSimple is Initializable, Strategizable {
     ////////////////////////////////////////////////////
     /// --- CONSTRUCTOR
     ////////////////////////////////////////////////////
-    constructor(address _WETH) {
-        WETH = _WETH;
+    constructor(address _wrappedNativeToken) {
+        wrappedNativeToken = _wrappedNativeToken;
     }
 
     /// @notice Initialize the contract
@@ -82,9 +82,12 @@ contract OETHHarvesterSimple is Initializable, Strategizable {
     }
 
     /// @notice Internal logic to harvest rewards from a strategy
-    function _harvestAndTransfer(address _strategy) internal {
+    function _harvestAndTransfer(address _strategy) internal virtual {
         // Ensure strategy is supported
         require(supportedStrategies[_strategy], "Strategy not supported");
+
+        // Store locally for some gas savings
+        address _strategist = strategistAddr;
 
         // Harvest rewards
         IStrategy(_strategy).collectRewardTokens();
@@ -100,10 +103,12 @@ contract OETHHarvesterSimple is Initializable, Strategizable {
             uint256 balance = IERC20(token).balanceOf(address(this));
             if (balance > 0) {
                 // Determine receiver
-                address receiver = token == WETH ? dripper : strategistAddr;
+                address receiver = token == wrappedNativeToken
+                    ? dripper
+                    : _strategist;
                 require(receiver != address(0), "Invalid receiver");
 
-                // Transfer to strategist
+                // Transfer to the Strategist or the Dripper
                 IERC20(token).safeTransfer(receiver, balance);
                 emit Harvested(_strategy, token, balance, receiver);
             }

--- a/contracts/contracts/harvest/SuperOETHHarvester.sol
+++ b/contracts/contracts/harvest/SuperOETHHarvester.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import { OETHHarvesterSimple, IERC20, IStrategy, SafeERC20 } from "./OETHHarvesterSimple.sol";
+
+contract SuperOETHHarvester is OETHHarvesterSimple {
+    using SafeERC20 for IERC20;
+
+    constructor(address _wrappedNativeToken)
+        OETHHarvesterSimple(_wrappedNativeToken)
+    {}
+
+    /// @inheritdoc OETHHarvesterSimple
+    function _harvestAndTransfer(address _strategy) internal virtual override {
+        // Ensure strategy is supported
+        require(supportedStrategies[_strategy], "Strategy not supported");
+
+        address receiver = strategistAddr;
+        require(receiver != address(0), "Invalid receiver");
+
+        // Harvest rewards
+        IStrategy(_strategy).collectRewardTokens();
+
+        // Cache reward tokens
+        address[] memory rewardTokens = IStrategy(_strategy)
+            .getRewardTokenAddresses();
+
+        uint256 len = rewardTokens.length;
+        for (uint256 i = 0; i < len; i++) {
+            // Cache balance
+            address token = rewardTokens[i];
+            uint256 balance = IERC20(token).balanceOf(address(this));
+            if (balance > 0) {
+                // Transfer everything to the strategist
+                IERC20(token).safeTransfer(receiver, balance);
+                emit Harvested(_strategy, token, balance, receiver);
+            }
+        }
+    }
+}

--- a/contracts/contracts/proxies/BaseProxies.sol
+++ b/contracts/contracts/proxies/BaseProxies.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import { InitializeGovernedUpgradeabilityProxy } from "./InitializeGovernedUpgradeabilityProxy.sol";
+
+/**
+ * @notice BridgedBaseWOETHProxy delegates calls to BridgedWOETH implementation
+ */
+contract BridgedBaseWOETHProxy is InitializeGovernedUpgradeabilityProxy {
+
+}
+
+/**
+ * @notice OETHBaseVaultProxy delegates calls to OETHBaseVault implementation
+ */
+contract OETHBaseVaultProxy is InitializeGovernedUpgradeabilityProxy {
+
+}
+
+/**
+ * @notice OETHBaseProxy delegates calls to OETH implementation
+ */
+contract OETHBaseProxy is InitializeGovernedUpgradeabilityProxy {
+
+}
+
+/**
+ * @notice WOETHBaseProxy delegates calls to WOETH implementation
+ */
+contract WOETHBaseProxy is InitializeGovernedUpgradeabilityProxy {
+
+}
+
+/**
+ * @notice OETHBaseDripperProxy delegates calls to a FixedRateDripper implementation
+ */
+contract OETHBaseDripperProxy is InitializeGovernedUpgradeabilityProxy {
+
+}
+
+/**
+ * @notice AerodromeAMOStrategyProxy delegates calls to AerodromeAMOStrategy implementation
+ */
+contract AerodromeAMOStrategyProxy is InitializeGovernedUpgradeabilityProxy {
+
+}
+
+/**
+ * @notice BridgedWOETHStrategyProxy delegates calls to BridgedWOETHStrategy implementation
+ */
+contract BridgedWOETHStrategyProxy is InitializeGovernedUpgradeabilityProxy {
+
+}
+
+/**
+ * @notice OETHBaseHarvesterProxy delegates calls to a SuperOETHHarvester implementation
+ */
+contract OETHBaseHarvesterProxy is InitializeGovernedUpgradeabilityProxy {
+
+}
+
+/**
+ * @notice OETHBaseCurveAMOProxy delegates calls to a OETHBaseCurveAMO implementation
+ */
+contract OETHBaseCurveAMOProxy is InitializeGovernedUpgradeabilityProxy {
+
+}

--- a/contracts/contracts/proxies/Proxies.sol
+++ b/contracts/contracts/proxies/Proxies.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 
 import { InitializeGovernedUpgradeabilityProxy } from "./InitializeGovernedUpgradeabilityProxy.sol";
@@ -272,65 +272,9 @@ contract LidoWithdrawalStrategyProxy is InitializeGovernedUpgradeabilityProxy {
 }
 
 /**
- * @notice BridgedBaseWOETHProxy delegates calls to BridgedWOETH implementation
- */
-contract BridgedBaseWOETHProxy is InitializeGovernedUpgradeabilityProxy {
-
-}
-
-/**
- * @notice OETHBaseVaultProxy delegates calls to OETHBaseVault implementation
- */
-contract OETHBaseVaultProxy is InitializeGovernedUpgradeabilityProxy {
-
-}
-
-/**
- * @notice OETHBaseProxy delegates calls to OETH implementation
- */
-contract OETHBaseProxy is InitializeGovernedUpgradeabilityProxy {
-
-}
-
-/**
- * @notice WOETHBaseProxy delegates calls to WOETH implementation
- */
-contract WOETHBaseProxy is InitializeGovernedUpgradeabilityProxy {
-
-}
-
-/**
- * @notice OETHBaseDripperProxy delegates calls to a OETHDripper implementation
- */
-contract OETHBaseDripperProxy is InitializeGovernedUpgradeabilityProxy {
-
-}
-
-/**
- * @notice AerodromeAMOStrategyProxy delegates calls to AerodromeAMOStrategy implementation
- */
-contract AerodromeAMOStrategyProxy is InitializeGovernedUpgradeabilityProxy {
-
-}
-
-/**
- * @notice BridgedWOETHStrategyProxy delegates calls to BridgedWOETHStrategy implementation
- */
-contract BridgedWOETHStrategyProxy is InitializeGovernedUpgradeabilityProxy {
-
-}
-
-/**
  * @notice MetaMorphoStrategyProxy delegates calls to a Generalized4626Strategy implementation
  */
 contract MetaMorphoStrategyProxy is InitializeGovernedUpgradeabilityProxy {
-
-}
-
-/**
- * @notice OETHBaseHarvesterProxy delegates calls to a OETHBaseHarvester implementation
- */
-contract OETHBaseHarvesterProxy is InitializeGovernedUpgradeabilityProxy {
 
 }
 
@@ -370,13 +314,6 @@ contract CurvePoolBoosterProxy is InitializeGovernedUpgradeabilityProxy {
  * @notice OETHFixedRateDripperProxy delegates calls to a OETHFixedRateDripper implementation
  */
 contract OETHFixedRateDripperProxy is InitializeGovernedUpgradeabilityProxy {
-
-}
-
-/**
- * @notice OETHBaseCurveAMOProxy delegates calls to a OETHBaseCurveAMO implementation
- */
-contract OETHBaseCurveAMOProxy is InitializeGovernedUpgradeabilityProxy {
 
 }
 

--- a/contracts/contracts/proxies/SonicProxies.sol
+++ b/contracts/contracts/proxies/SonicProxies.sol
@@ -39,7 +39,7 @@ contract SonicStakingStrategyProxy is InitializeGovernedUpgradeabilityProxy {
 }
 
 /**
- * @notice OSonicHarvesterProxy delegates calls to a OSonicHarvester implementation
+ * @notice OSonicHarvesterProxy delegates calls to a OETHHarvesterSimple implementation
  */
 contract OSonicHarvesterProxy is InitializeGovernedUpgradeabilityProxy {
 

--- a/contracts/deploy/base/026_harvester_v2.js
+++ b/contracts/deploy/base/026_harvester_v2.js
@@ -1,0 +1,73 @@
+const addresses = require("../../utils/addresses");
+const { deployWithConfirmation } = require("../../utils/deploy");
+const { deployOnBase } = require("../../utils/deploy-l2");
+
+module.exports = deployOnBase(
+  {
+    deployName: "026_harvester_v2",
+  },
+  async ({ ethers }) => {
+    const cHarvesterProxy = await ethers.getContract("OETHBaseHarvesterProxy");
+    const cAMOStrategyProxy = await ethers.getContract(
+      "AerodromeAMOStrategyProxy"
+    );
+    const cCurveAMOStrategyProxy = await ethers.getContract(
+      "OETHBaseCurveAMOProxy"
+    );
+    const cCurveAMOStrategy = await ethers.getContractAt(
+      "BaseCurveAMOStrategy",
+      cCurveAMOStrategyProxy.address
+    );
+
+    const dHarvester = await deployWithConfirmation("SuperOETHHarvester", [
+      addresses.base.WETH,
+    ]);
+    console.log("SuperOETHHarvester deployed at", dHarvester.address);
+
+    const cHarvester = await ethers.getContractAt(
+      "SuperOETHHarvester",
+      cHarvesterProxy.address
+    );
+
+    const cDripperProxy = await ethers.getContract("OETHBaseDripperProxy");
+
+    return {
+      actions: [
+        {
+          // Upgrade the harvester
+          contract: cHarvesterProxy,
+          signature: "upgradeTo(address)",
+          args: [dHarvester.address],
+        },
+        {
+          // Upgrade the harvester
+          contract: cHarvester,
+          signature: "initialize(address,address,address)",
+          args: [
+            addresses.base.timelock,
+            addresses.multichainStrategist,
+            cDripperProxy.address,
+          ],
+        },
+        {
+          // Mark Aerodome AMO strategy as supported
+          contract: cHarvester,
+          signature: "setSupportedStrategy(address,bool)",
+          args: [cAMOStrategyProxy.address, true],
+        },
+        {
+          // Mark Curve AMO strategy as supported
+          contract: cHarvester,
+          signature: "setSupportedStrategy(address,bool)",
+          args: [cCurveAMOStrategyProxy.address, true],
+        },
+        {
+          // Set the harvester address on the Curve AMO strategy
+          contract: cCurveAMOStrategy,
+          signature: "setHarvesterAddress(address)",
+          args: [cHarvesterProxy.address],
+        },
+      ],
+    };
+  }
+);

--- a/contracts/deploy/sonic/009_harvester.js
+++ b/contracts/deploy/sonic/009_harvester.js
@@ -1,0 +1,57 @@
+const addresses = require("../../utils/addresses.js");
+const { deployOnSonic } = require("../../utils/deploy-l2.js");
+const {
+  deployWithConfirmation,
+  withConfirmation,
+} = require("../../utils/deploy.js");
+
+module.exports = deployOnSonic(
+  {
+    deployName: "009_harvester",
+  },
+  async ({ ethers }) => {
+    const { deployerAddr, strategistAddr } = await getNamedAccounts();
+
+    const sDeployer = await ethers.provider.getSigner(deployerAddr);
+    await deployWithConfirmation("OSonicHarvesterProxy");
+
+    await deployWithConfirmation("OETHHarvesterSimple", [addresses.sonic.wS]);
+    const dHarvester = await ethers.getContract("OETHHarvesterSimple");
+
+    const cHarvesterProxy = await ethers.getContract("OSonicHarvesterProxy");
+    const cHarvester = await ethers.getContractAt(
+      "OETHHarvesterSimple",
+      cHarvesterProxy.address
+    );
+
+    const cDripperProxy = await ethers.getContract("OSonicDripperProxy");
+
+    // const cStakingStrategyProxy = await ethers.getContract("SonicStakingStrategyProxy");
+
+    const initSonicStakingStrategy = cHarvester.interface.encodeFunctionData(
+      "initialize(address,address,address)",
+      [addresses.sonic.timelock, strategistAddr, cDripperProxy.address]
+    );
+
+    // prettier-ignore
+    await withConfirmation(
+      cHarvesterProxy
+        .connect(sDeployer)["initialize(address,address,bytes)"](
+          dHarvester.address,
+          addresses.sonic.timelock,
+          initSonicStakingStrategy
+        )
+    );
+
+    return {
+      actions: [
+        // TODO: Enable for Curve AMO after it has been deployed
+        // {
+        //   contract: cHarvesterProxy,
+        //   signature: "setSupportedStrategy(address,bool)",
+        //   args: [cStakingStrategyProxy.address, true],
+        // },
+      ],
+    };
+  }
+);

--- a/contracts/test/_fixture-base.js
+++ b/contracts/test/_fixture-base.js
@@ -79,7 +79,7 @@ const defaultBaseFixture = deployments.createFixture(async () => {
     // Harvester
     const harvesterProxy = await ethers.getContract("OETHBaseHarvesterProxy");
     harvester = await ethers.getContractAt(
-      "OETHBaseHarvester",
+      "SuperOETHHarvester",
       harvesterProxy.address
     );
 


### PR DESCRIPTION
## Code Changes
- Adds a new `SuperOETHHarvester` that inherits from `OETHHarvesterSimple`. 
  - Only change is the recipient of reward tokens being the guardian always
- Moving forward, all supercharged LSTs (a.k.a Super OETH/OUSD) to use `SuperOETHHarvester` and all native LST OTokens (OETH) to use `OETHHarvesterSimple`
- Rename `weth` in `OETHHarvesterSimple` to `wrappedNativeToken` to avoid confusions when using for wS on Sonic
- Move Base proxies to a separate file
- `OETHBaseHarvester` is no longer used (I'm splitting up the swap functions to a Safe module in a different branch to help with our operations better)
- **NOTE**: Storage slot changes from the existing `OETHBaseHarvester`, however the deployment file calls `initialize` and that should reset the slots