### PR TITLE
Remove OUSD Aave Strategy

### DIFF
--- a/contracts/deploy/mainnet/124_remove_ousd_aave_strat.js
+++ b/contracts/deploy/mainnet/124_remove_ousd_aave_strat.js
@@ -5,6 +5,9 @@ module.exports = deploymentWithGovernanceProposal(
   {
     deployName: "124_remove_ousd_aave_strat",
     forceDeploy: false,
+    reduceQueueTime: true,
+    proposalId:
+      "17220948252813776682241285028495841512040920149452955785735049769329911757024",
   },
   async () => {
     const cVaultAdmin = await ethers.getContractAt(

--- a/contracts/deploy/mainnet/124_remove_ousd_aave_strat.js
+++ b/contracts/deploy/mainnet/124_remove_ousd_aave_strat.js
@@ -1,0 +1,36 @@
+const addresses = require("../../utils/addresses");
+const { deploymentWithGovernanceProposal } = require("../../utils/deploy");
+
+module.exports = deploymentWithGovernanceProposal(
+  {
+    deployName: "124_remove_ousd_aave_strat",
+    forceDeploy: false,
+  },
+  async () => {
+    const cVaultAdmin = await ethers.getContractAt(
+      "VaultAdmin",
+      addresses.mainnet.VaultProxy
+    );
+
+    const cAaveStrategyProxy = await ethers.getContract("AaveStrategyProxy");
+    const cMorphoGauntletPrimeUSDTProxy = await ethers.getContract(
+      "MorphoGauntletPrimeUSDTStrategyProxy"
+    );
+
+    return {
+      name: "Remove OUSD Aave Strategy",
+      actions: [
+        {
+          contract: cVaultAdmin,
+          signature: "setAssetDefaultStrategy(address,address)",
+          args: [addresses.mainnet.USDT, cMorphoGauntletPrimeUSDTProxy.address],
+        },
+        {
+          contract: cVaultAdmin,
+          signature: "removeStrategy(address)",
+          args: [cAaveStrategyProxy.address],
+        },
+      ],
+    };
+  }
+);

--- a/contracts/deploy/mainnet/124_remove_ousd_aave_strat.js
+++ b/contracts/deploy/mainnet/124_remove_ousd_aave_strat.js
@@ -7,7 +7,7 @@ module.exports = deploymentWithGovernanceProposal(
     forceDeploy: false,
     reduceQueueTime: true,
     proposalId:
-      "17220948252813776682241285028495841512040920149452955785735049769329911757024",
+      "88299129181157806559379214304016095228552624275043325103321115382026366391938",
   },
   async () => {
     const cVaultAdmin = await ethers.getContractAt(
@@ -18,6 +18,12 @@ module.exports = deploymentWithGovernanceProposal(
     const cAaveStrategyProxy = await ethers.getContract("AaveStrategyProxy");
     const cMorphoGauntletPrimeUSDTProxy = await ethers.getContract(
       "MorphoGauntletPrimeUSDTStrategyProxy"
+    );
+
+    const cHarvesterProxy = await ethers.getContract("HarvesterProxy");
+    const cHarvester = await ethers.getContractAt(
+      "Harvester",
+      cHarvesterProxy.address
     );
 
     return {
@@ -32,6 +38,11 @@ module.exports = deploymentWithGovernanceProposal(
           contract: cVaultAdmin,
           signature: "removeStrategy(address)",
           args: [cAaveStrategyProxy.address],
+        },
+        {
+          contract: cHarvester,
+          signature: "setSupportedStrategy(address,bool)",
+          args: [cAaveStrategyProxy.address, false],
         },
       ],
     };

--- a/contracts/deployments/mainnet/.migrations.json
+++ b/contracts/deployments/mainnet/.migrations.json
@@ -111,5 +111,6 @@
   "120_remove_ousd_amo": 1737992146,
   "121_pool_booster_curve": 1737965774,
   "122_delegate_yield_curve_pool": 1739200325,
-  "123_simple_harvester_v2": 1739168735
+  "123_simple_harvester_v2": 1739168735,
+  "124_remove_ousd_aave_strat": 1739880781
 }

--- a/contracts/scripts/defender-actions/harvest.js
+++ b/contracts/scripts/defender-actions/harvest.js
@@ -16,7 +16,8 @@ const labelsSSV = {
   [addresses.mainnet.NativeStakingSSVStrategyProxy]: "Staking Strategy 1",
   [addresses.mainnet.NativeStakingSSVStrategy2Proxy]: "Staking Strategy 2",
   [addresses.mainnet.NativeStakingSSVStrategy3Proxy]: "Staking Strategy 3",
-  [addresses.holesky.NativeStakingSSVStrategyProxy]: "Staking Strategy 1 Holesky",
+  [addresses.holesky.NativeStakingSSVStrategyProxy]:
+    "Staking Strategy 1 Holesky",
 };
 
 // Entrypoint for the Defender Action

--- a/contracts/test/_fund.js
+++ b/contracts/test/_fund.js
@@ -44,9 +44,9 @@ const balancesContractSlotCache = {
 const findBalancesSlot = async (tokenAddress) => {
   tokenAddress = tokenAddress.toLowerCase();
   if (balancesContractSlotCache[tokenAddress]) {
-    console.log(
-      `Found balance slot ${balancesContractSlotCache[tokenAddress]} for ${tokenAddress} in cache`
-    );
+    // console.log(
+    //   `Found balance slot ${balancesContractSlotCache[tokenAddress]} for ${tokenAddress} in cache`
+    // );
     return balancesContractSlotCache[tokenAddress];
   }
 

--- a/contracts/test/strategies/3pool-standalone.js
+++ b/contracts/test/strategies/3pool-standalone.js
@@ -5,7 +5,7 @@ const { BigNumber } = require("ethers");
 const { createFixtureLoader, threepoolFixture } = require("../_fixture");
 const { units } = require("../helpers");
 
-describe("3Pool Strategy Standalone", function () {
+describe.skip("3Pool Strategy Standalone", function () {
   let governor,
     threePool,
     threePoolToken,

--- a/contracts/test/strategies/3pool.js
+++ b/contracts/test/strategies/3pool.js
@@ -10,7 +10,7 @@ const {
   isFork,
 } = require("../helpers");
 
-describe("3Pool Strategy", function () {
+describe.skip("3Pool Strategy", function () {
   if (isFork) {
     this.timeout(0);
   }

--- a/contracts/test/strategies/aave.js
+++ b/contracts/test/strategies/aave.js
@@ -13,7 +13,7 @@ const { shouldBehaveLikeGovernable } = require("../behaviour/governable");
 const { shouldBehaveLikeHarvestable } = require("../behaviour/harvestable");
 const { shouldBehaveLikeStrategy } = require("../behaviour/strategy");
 
-describe("Aave Strategy", function () {
+describe.skip("Aave Strategy", function () {
   if (isFork) {
     this.timeout(0);
   }

--- a/contracts/test/strategies/aave.mainnet.fork-test.js
+++ b/contracts/test/strategies/aave.mainnet.fork-test.js
@@ -10,7 +10,7 @@ const {
 const { createFixtureLoader, aaveFixture } = require("../_fixture");
 const { impersonateAndFund } = require("../../utils/signers");
 
-describe("ForkTest: Aave Strategy", function () {
+describe.skip("ForkTest: Aave Strategy", function () {
   this.timeout(0);
 
   // Retry up to 3 times on CI

--- a/contracts/test/vault/oeth-vault.mainnet.fork-test.js
+++ b/contracts/test/vault/oeth-vault.mainnet.fork-test.js
@@ -6,9 +6,6 @@ const { createFixtureLoader, oethDefaultFixture } = require("../_fixture");
 const { isCI, oethUnits, advanceTime } = require("../helpers");
 const { impersonateAndFund } = require("../../utils/signers");
 const { logTxDetails } = require("../../utils/txLogger");
-const {
-  shouldHaveRewardTokensConfigured,
-} = require("../behaviour/reward-tokens.fork");
 
 const log = require("../../utils/logger")("test:fork:oeth:vault");
 
@@ -396,29 +393,30 @@ describe("ForkTest: OETH Vault", function () {
     });
   });
 
-  shouldHaveRewardTokensConfigured(() => ({
-    vault: fixture.oethVault,
-    harvester: fixture.oethHarvester,
-    ignoreTokens: [fixture.weth.address.toLowerCase()],
-    expectedConfigs: {
-      [fixture.cvx.address]: {
-        allowedSlippageBps: 300,
-        harvestRewardBps: 200,
-        swapPlatformAddr: "0xB576491F1E6e5E62f1d8F26062Ee822B40B0E0d4",
-        doSwapRewardToken: true,
-        swapPlatform: 3,
-        liquidationLimit: oethUnits("2500"),
-        curvePoolIndices: [1, 0],
-      },
-      [fixture.crv.address]: {
-        allowedSlippageBps: 300,
-        harvestRewardBps: 200,
-        swapPlatformAddr: "0x4eBdF703948ddCEA3B11f675B4D1Fba9d2414A14",
-        doSwapRewardToken: true,
-        swapPlatform: 3,
-        liquidationLimit: oethUnits("4000"),
-        curvePoolIndices: [2, 1],
-      },
-    },
-  }));
+  // We have migrated to simplified Harvester and this is no longer relevant
+  // shouldHaveRewardTokensConfigured(() => ({
+  //   vault: fixture.oethVault,
+  //   harvester: fixture.oethHarvester,
+  //   ignoreTokens: [fixture.weth.address.toLowerCase()],
+  //   expectedConfigs: {
+  //     [fixture.cvx.address]: {
+  //       allowedSlippageBps: 300,
+  //       harvestRewardBps: 200,
+  //       swapPlatformAddr: "0xB576491F1E6e5E62f1d8F26062Ee822B40B0E0d4",
+  //       doSwapRewardToken: true,
+  //       swapPlatform: 3,
+  //       liquidationLimit: oethUnits("2500"),
+  //       curvePoolIndices: [1, 0],
+  //     },
+  //     [fixture.crv.address]: {
+  //       allowedSlippageBps: 300,
+  //       harvestRewardBps: 200,
+  //       swapPlatformAddr: "0x4eBdF703948ddCEA3B11f675B4D1Fba9d2414A14",
+  //       doSwapRewardToken: true,
+  //       swapPlatform: 3,
+  //       liquidationLimit: oethUnits("4000"),
+  //       curvePoolIndices: [2, 1],
+  //     },
+  //   },
+  // }));
 });

--- a/contracts/test/vault/vault.mainnet.fork-test.js
+++ b/contracts/test/vault/vault.mainnet.fork-test.js
@@ -181,66 +181,61 @@ describe("ForkTest: Vault", function () {
     });
 
     it("should withdraw from and deposit to strategy", async () => {
-      const { vault, josh, usdc, dai, aaveStrategy } = fixture;
-      await vault.connect(josh).mint(usdc.address, usdcUnits("90"), 0);
-      await vault.connect(josh).mint(dai.address, daiUnits("50"), 0);
+      const { vault, josh, usdt, morphoGauntletPrimeUSDTStrategy } = fixture;
+      await vault.connect(josh).mint(usdt.address, usdtUnits("90"), 0);
       const strategistSigner = await impersonateAndFund(
         await vault.strategistAddr()
       );
 
-      let daiBalanceDiff, usdcBalanceDiff, daiStratDiff, usdcStratDiff;
+      let usdtBalanceDiff, usdtStratDiff;
 
-      [daiBalanceDiff, usdcBalanceDiff] = await differenceInErc20TokenBalances(
-        [vault.address, vault.address],
-        [dai, usdc],
+      [usdtBalanceDiff] = await differenceInErc20TokenBalances(
+        [vault.address],
+        [usdt],
         async () => {
-          [daiStratDiff, usdcStratDiff] = await differenceInStrategyBalance(
-            [dai.address, usdc.address],
-            [aaveStrategy, aaveStrategy],
+          [usdtStratDiff] = await differenceInStrategyBalance(
+            [usdt.address],
+            [morphoGauntletPrimeUSDTStrategy],
             async () => {
               await vault
                 .connect(strategistSigner)
                 .depositToStrategy(
-                  aaveStrategy.address,
-                  [dai.address, usdc.address],
-                  [daiUnits("50"), usdcUnits("90")]
+                  morphoGauntletPrimeUSDTStrategy.address,
+                  [usdt.address],
+                  [usdtUnits("90")]
                 );
             }
           );
         }
       );
 
-      expect(daiBalanceDiff).to.equal(daiUnits("-50"));
-      expect(usdcBalanceDiff).to.approxEqualTolerance(usdcUnits("-90"), 1);
+      expect(usdtBalanceDiff).to.equal(usdtUnits("-90"));
 
-      expect(daiStratDiff).gte(daiUnits("49.95"));
-      expect(usdcStratDiff).gte(usdcUnits("89.91"));
+      expect(usdtStratDiff).gte(usdtUnits("89.91"));
 
-      [daiBalanceDiff, usdcBalanceDiff] = await differenceInErc20TokenBalances(
-        [vault.address, vault.address],
-        [dai, usdc],
+      [usdtBalanceDiff] = await differenceInErc20TokenBalances(
+        [vault.address],
+        [usdt],
         async () => {
-          [daiStratDiff, usdcStratDiff] = await differenceInStrategyBalance(
-            [dai.address, usdc.address],
-            [aaveStrategy, aaveStrategy],
+          [usdtStratDiff] = await differenceInStrategyBalance(
+            [usdt.address],
+            [morphoGauntletPrimeUSDTStrategy],
             async () => {
               await vault
                 .connect(strategistSigner)
                 .withdrawFromStrategy(
-                  aaveStrategy.address,
-                  [dai.address, usdc.address],
-                  [daiUnits("50"), usdcUnits("90")]
+                  morphoGauntletPrimeUSDTStrategy.address,
+                  [usdt.address],
+                  [usdtUnits("90")]
                 );
             }
           );
         }
       );
 
-      expect(daiBalanceDiff).to.approxEqualTolerance(daiUnits("50"), 1);
-      expect(usdcBalanceDiff).to.approxEqualTolerance(usdcUnits("90"), 1);
+      expect(usdtBalanceDiff).to.equal(usdtUnits("90"));
 
-      expect(daiStratDiff).approxEqualTolerance(daiUnits("-50"));
-      expect(usdcStratDiff).approxEqualTolerance(usdcUnits("-90"));
+      expect(usdtStratDiff).to.equal(usdtUnits("-90"));
     });
 
     it("Should have vault buffer disabled", async () => {
@@ -342,7 +337,6 @@ describe("ForkTest: Vault", function () {
 
       const knownStrategies = [
         // Update this every time a new strategy is added. Below are mainnet addresses
-        "0x5e3646A1Db86993f73E6b74A57D8640B69F7e259", // Aave
         "0x79F2188EF9350A1dC11A062cca0abE90684b0197", // MorphoAaveStrategy
         "0x6b69B755C629590eD59618A2712d8a2957CA98FC", // Maker DSR Strategy
         "0x603CDEAEC82A60E3C4A10dA6ab546459E5f64Fa0", // Meta Morpho USDC

--- a/contracts/test/vault/vault.mainnet.fork-test.js
+++ b/contracts/test/vault/vault.mainnet.fork-test.js
@@ -232,7 +232,7 @@ describe("ForkTest: Vault", function () {
 
       expect(usdtBalanceDiff).to.equal(usdtUnits("90"));
 
-      expect(usdtStratDiff).to.gte(usdtUnits("-89.91"));
+      expect(usdtStratDiff).to.lte(usdtUnits("-89.91"));
     });
 
     it("Should have vault buffer disabled", async () => {

--- a/contracts/test/vault/vault.mainnet.fork-test.js
+++ b/contracts/test/vault/vault.mainnet.fork-test.js
@@ -13,9 +13,6 @@ const {
   isCI,
 } = require("./../helpers");
 const { impersonateAndFund } = require("../../utils/signers");
-const {
-  shouldHaveRewardTokensConfigured,
-} = require("../behaviour/reward-tokens.fork");
 
 const log = require("../../utils/logger")("test:fork:ousd:vault");
 
@@ -235,7 +232,7 @@ describe("ForkTest: Vault", function () {
 
       expect(usdtBalanceDiff).to.equal(usdtUnits("90"));
 
-      expect(usdtStratDiff).to.equal(usdtUnits("-90"));
+      expect(usdtStratDiff).to.gte(usdtUnits("-89.91"));
     });
 
     it("Should have vault buffer disabled", async () => {
@@ -362,21 +359,16 @@ describe("ForkTest: Vault", function () {
     it("Should have correct default strategy set for USDT", async () => {
       const { vault, usdt } = fixture;
 
-      // aave and compound
       expect([
-        "0x5e3646A1Db86993f73E6b74A57D8640B69F7e259",
-        "0x9c459eeb3FA179a40329b81C1635525e9A0Ef094",
         "0x79F2188EF9350A1dC11A062cca0abE90684b0197", // MorphoAave
+        "0xe3ae7c80a1b02ccd3fb0227773553aeb14e32f26", // Morpho Gauntlet Prime USDT
       ]).to.include(await vault.assetDefaultStrategies(usdt.address));
     });
 
     it("Should have correct default strategy set for USDC", async () => {
       const { vault, usdc } = fixture;
 
-      // aave and compound
       expect([
-        "0x5e3646A1Db86993f73E6b74A57D8640B69F7e259",
-        "0x9c459eeb3FA179a40329b81C1635525e9A0Ef094",
         "0x79F2188EF9350A1dC11A062cca0abE90684b0197", // MorphoAave
         "0x603CDEAEC82A60E3C4A10dA6ab546459E5f64Fa0", // Meta Morpho USDC
       ]).to.include(await vault.assetDefaultStrategies(usdc.address));
@@ -385,10 +377,7 @@ describe("ForkTest: Vault", function () {
     it("Should have correct default strategy set for DAI", async () => {
       const { vault, dai } = fixture;
 
-      // aave and compound
       expect([
-        "0x5e3646A1Db86993f73E6b74A57D8640B69F7e259",
-        "0x9c459eeb3FA179a40329b81C1635525e9A0Ef094",
         "0x79F2188EF9350A1dC11A062cca0abE90684b0197", // MorphoAave
         "0x6b69B755C629590eD59618A2712d8a2957CA98FC", // Maker DSR
       ]).to.include(await vault.assetDefaultStrategies(dai.address));
@@ -400,40 +389,41 @@ describe("ForkTest: Vault", function () {
     });
   });
 
-  shouldHaveRewardTokensConfigured(() => ({
-    vault: fixture.vault,
-    harvester: fixture.harvester,
-    expectedConfigs: {
-      [fixture.aave.address]: {
-        allowedSlippageBps: 300,
-        harvestRewardBps: 100,
-        swapPlatformAddr: "0xE592427A0AEce92De3Edee1F18E0157C05861564",
-        doSwapRewardToken: true,
-        swapPlatform: 1,
-        liquidationLimit: 0,
-        uniswapV3Path:
-          "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9002710c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20001f4dac17f958d2ee523a2206206994597c13d831ec7",
-      },
-      [fixture.cvx.address]: {
-        allowedSlippageBps: 300,
-        harvestRewardBps: 100,
-        swapPlatformAddr: "0xE592427A0AEce92De3Edee1F18E0157C05861564",
-        doSwapRewardToken: true,
-        swapPlatform: 1,
-        liquidationLimit: ousdUnits("2500"),
-        uniswapV3Path:
-          "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b002710c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20001f4dac17f958d2ee523a2206206994597c13d831ec7",
-      },
-      [fixture.crv.address]: {
-        allowedSlippageBps: 300,
-        harvestRewardBps: 200,
-        swapPlatformAddr: "0xE592427A0AEce92De3Edee1F18E0157C05861564",
-        doSwapRewardToken: true,
-        swapPlatform: 1,
-        liquidationLimit: ousdUnits("4000"),
-        uniswapV3Path:
-          "0xd533a949740bb3306d119cc777fa900ba034cd52000bb8c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20001f4dac17f958d2ee523a2206206994597c13d831ec7",
-      },
-    },
-  }));
+  // We no longer have any strategies that harvest these reward tokens
+  // shouldHaveRewardTokensConfigured(() => ({
+  //   vault: fixture.vault,
+  //   harvester: fixture.harvester,
+  //   expectedConfigs: {
+  //     [fixture.aave.address]: {
+  //       allowedSlippageBps: 300,
+  //       harvestRewardBps: 100,
+  //       swapPlatformAddr: "0xE592427A0AEce92De3Edee1F18E0157C05861564",
+  //       doSwapRewardToken: true,
+  //       swapPlatform: 1,
+  //       liquidationLimit: 0,
+  //       uniswapV3Path:
+  //         "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9002710c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20001f4dac17f958d2ee523a2206206994597c13d831ec7",
+  //     },
+  //     [fixture.cvx.address]: {
+  //       allowedSlippageBps: 300,
+  //       harvestRewardBps: 100,
+  //       swapPlatformAddr: "0xE592427A0AEce92De3Edee1F18E0157C05861564",
+  //       doSwapRewardToken: true,
+  //       swapPlatform: 1,
+  //       liquidationLimit: ousdUnits("2500"),
+  //       uniswapV3Path:
+  //         "0x4e3fbd56cd56c3e72c1403e103b45db9da5b9d2b002710c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20001f4dac17f958d2ee523a2206206994597c13d831ec7",
+  //     },
+  //     [fixture.crv.address]: {
+  //       allowedSlippageBps: 300,
+  //       harvestRewardBps: 200,
+  //       swapPlatformAddr: "0xE592427A0AEce92De3Edee1F18E0157C05861564",
+  //       doSwapRewardToken: true,
+  //       swapPlatform: 1,
+  //       liquidationLimit: ousdUnits("4000"),
+  //       uniswapV3Path:
+  //         "0xd533a949740bb3306d119cc777fa900ba034cd52000bb8c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20001f4dac17f958d2ee523a2206206994597c13d831ec7",
+  //     },
+  //   },
+  // }));
 });


### PR DESCRIPTION
## Governance

Proposal: [88299129181157806559379214304016095228552624275043325103321115382026366391938](https://app.originprotocol.com/#/more/1:0x1d3fbd4d129ddd2372ea85c5fa00b2682081c9ec:88299129181157806559379214304016095228552624275043325103321115382026366391938)

### Actions:
- Set Gauntlet Prime USDT as the default USDT strategy
- Remove vanilla Aave Strategy
- Mark strategy as not supported on Harvester

## Deploy checklist

Two reviewers complete the following checklist:

```
- [ ] Governance proposal matches the deploy script
- [ ] Smoke tests pass after fork test execution of the governance proposal
```

