### PR TITLE
Protect deposits to SwapX AMO

### DIFF
--- a/contracts/contracts/strategies/sonic/SonicSwapXAMOStrategy.sol
+++ b/contracts/contracts/strategies/sonic/SonicSwapXAMOStrategy.sol
@@ -49,7 +49,7 @@ contract SonicSwapXAMOStrategy is InitializableAbstractStrategy {
     /// eg 0.01e18 or 1e16 is 1% which is 100 basis points.
     /// This is the amount below and above peg so a 50 basis point deviation (0.005e18)
     /// allows a price range from 0.995 to 1.005.
-    uint256 maxDepeg;
+    uint256 public maxDepeg;
 
     event SwapOTokensToPool(
         uint256 osMinted,
@@ -62,6 +62,7 @@ contract SonicSwapXAMOStrategy is InitializableAbstractStrategy {
         uint256 lpTokens,
         uint256 osBurnt
     );
+    event MaxDepegUpdated(uint256 maxDepeg);
 
     /**
      * @dev Verifies that the caller is the Strategist of the Vault.
@@ -765,6 +766,21 @@ contract SonicSwapXAMOStrategy is InitializableAbstractStrategy {
         ) {
             revert("Protocol insolvent");
         }
+    }
+
+    /***************************************
+                    Setters
+    ****************************************/
+
+    /**
+     * @notice Set the maximum deviation from the OS/wS peg (1e18) before deposits are reverted.
+     * @param _maxDepeg the OS/wS price from peg (1e18) in 18 decimals.
+     * eg 0.01e18 or 1e16 is 1% which is 100 basis points.
+     */
+    function setMaxDepeg(uint256 _maxDepeg) external onlyGovernor {
+        maxDepeg = _maxDepeg;
+
+        emit MaxDepegUpdated(_maxDepeg);
     }
 
     /***************************************

--- a/contracts/contracts/strategies/sonic/SonicSwapXAMOStrategy.sol
+++ b/contracts/contracts/strategies/sonic/SonicSwapXAMOStrategy.sol
@@ -79,11 +79,22 @@ contract SonicSwapXAMOStrategy is InitializableAbstractStrategy {
         _;
     }
 
+    /**
+     * @dev Checks the pool is balanced enough to allow deposits.
+     */
     modifier nearBalancedPool() {
-        // Get the OS/wS price from the pool. That's the amount of OS received for 1 wS.
+        // OS/wS price = wS / OS
+        // Get the OS/wS price for selling 1 OS for wS
+        // As OS is 1, the wS amount is the OS/wS price
         uint256 sellPrice = IPair(pool).getAmountOut(1e18, os);
-        uint256 buyPrice = 1e36 / IPair(pool).getAmountOut(1e18, ws);
+
+        // Get the amount of OS received from selling 1 wS. This is buying OS.
+        uint256 osAmount = IPair(pool).getAmountOut(1e18, ws);
+        // Convert to a OS/wS price = wS / OS
+        uint256 buyPrice = 1e36 / osAmount;
+
         uint256 pegPrice = 1e18;
+
         require(
             sellPrice >= pegPrice - maxDepeg && buyPrice <= pegPrice + maxDepeg,
             "price out of range"

--- a/contracts/contracts/strategies/sonic/SonicSwapXAMOStrategy.sol
+++ b/contracts/contracts/strategies/sonic/SonicSwapXAMOStrategy.sol
@@ -44,9 +44,11 @@ contract SonicSwapXAMOStrategy is InitializableAbstractStrategy {
     /// @notice Address of the SwapX Gauge contract.
     address public immutable gauge;
 
-    /// @notice The max amount the OS/wS price can deviate from peg (1e18) before deposits are reverted scaled to 18 decimals.
+    /// @notice The max amount the OS/wS price can deviate from peg (1e18)
+    /// before deposits are reverted scaled to 18 decimals.
     /// eg 0.01e18 or 1e16 is 1% which is 100 basis points.
-    /// This is the amount below and above peg so a 50 basis point deviation (0.005e18) allows a price range from 0.995 to 1.005.
+    /// This is the amount below and above peg so a 50 basis point deviation (0.005e18)
+    /// allows a price range from 0.995 to 1.005.
     uint256 maxDepeg;
 
     event SwapOTokensToPool(

--- a/contracts/contracts/strategies/sonic/SonicSwapXAMOStrategy.sol
+++ b/contracts/contracts/strategies/sonic/SonicSwapXAMOStrategy.sol
@@ -44,8 +44,9 @@ contract SonicSwapXAMOStrategy is InitializableAbstractStrategy {
     /// @notice Address of the SwapX Gauge contract.
     address public immutable gauge;
 
-    /// @notice The max amount the OS/wS price can deviate from peg (1e18) before deposits are reverted.
-    /// This is a min and max so a 50 basis point deviation (0.005e18) allows a price range from 0.995 to 1.005.
+    /// @notice The max amount the OS/wS price can deviate from peg (1e18) before deposits are reverted scaled to 18 decimals.
+    /// eg 0.01e18 or 1e16 is 1% which is 100 basis points.
+    /// This is the amount below and above peg so a 50 basis point deviation (0.005e18) allows a price range from 0.995 to 1.005.
     uint256 maxDepeg;
 
     event SwapOTokensToPool(
@@ -225,6 +226,7 @@ contract SonicSwapXAMOStrategy is InitializableAbstractStrategy {
      * mint the pool's LP token and deposit in the gauge.
      * @dev This tx must be wrapped by the VaultValueChecker.
      * To minimize loses, the pool should be rebalanced before depositing.
+     * The pool's OS/wS price must be within the maxDepeg range.
      * @param _asset Address of Wrapped S (wS) token.
      * @param _wsAmount Amount of Wrapped S (wS) tokens to deposit.
      */
@@ -254,6 +256,7 @@ contract SonicSwapXAMOStrategy is InitializableAbstractStrategy {
      * mint the pool's LP token and deposit in the gauge.
      * @dev This tx must be wrapped by the VaultValueChecker.
      * To minimize loses, the pool should be rebalanced before depositing.
+     * The pool's OS/wS price must be within the maxDepeg range.
      */
     function depositAll()
         external
@@ -306,8 +309,6 @@ contract SonicSwapXAMOStrategy is InitializableAbstractStrategy {
     /**
      * @notice Withdraw wS and OS from the SwapX pool, burn the OS,
      * and transfer the wS to the recipient.
-     * @dev This tx must be wrapped by the VaultValueChecker.
-     * To minimize loses, the pool should be rebalanced before the withdraw.
      * @param _recipient Address of the Vault.
      * @param _asset Address of the Wrapped S (wS) contract.
      * @param _wsAmount Amount of Wrapped S (wS) to withdraw.
@@ -356,9 +357,7 @@ contract SonicSwapXAMOStrategy is InitializableAbstractStrategy {
      * remove all wS and OS from the SwapX pool,
      * burn all the OS tokens,
      * and transfer all the wS to the Vault contract.
-     * @dev This tx must be wrapped by the VaultValueChecker.
-     * To minimize loses, the pool should be rebalanced before the withdraw.
-     * There is no solvency check here as withdrawAll can be called to
+     * @dev There is no solvency check here as withdrawAll can be called to
      * quickly secure assets to the Vault in emergencies.
      */
     function withdrawAll()

--- a/contracts/contracts/strategies/sonic/SonicSwapXAMOStrategy.sol
+++ b/contracts/contracts/strategies/sonic/SonicSwapXAMOStrategy.sol
@@ -459,7 +459,7 @@ contract SonicSwapXAMOStrategy is InitializableAbstractStrategy {
 
         // 1. Mint OS so it can be swapped into the pool
 
-        // There shouldn't be any OS in the strategy but just in case
+        // There can be OS in the strategy from skimming the pool
         uint256 osInStrategy = IERC20(os).balanceOf(address(this));
         require(_osAmount >= osInStrategy, "Too much OS in strategy");
         uint256 osToMint = _osAmount - osInStrategy;

--- a/contracts/deploy/deployActions.js
+++ b/contracts/deploy/deployActions.js
@@ -12,6 +12,7 @@ const {
 } = require("../test/helpers.js");
 const { deployWithConfirmation, withConfirmation } = require("../utils/deploy");
 const { metapoolLPCRVPid } = require("../utils/constants");
+const { parseUnits } = require("ethers/lib/utils.js");
 
 const log = require("../utils/logger")("deploy:core");
 
@@ -1347,9 +1348,10 @@ const deploySonicSwapXAMOStrategyImplementation = async () => {
     cSonicSwapXAMOStrategyProxy.address
   );
   // Initialize Sonic Curve AMO Strategy implementation
+  const depositPriceRange = parseUnits("0.01", 18); // 1% or 100 basis points
   const initData = cSonicSwapXAMOStrategy.interface.encodeFunctionData(
-    "initialize(address[])",
-    [[addresses.sonic.SWPx]]
+    "initialize(address[],uint256)",
+    [[addresses.sonic.SWPx], depositPriceRange]
   );
   await withConfirmation(
     // prettier-ignore


### PR DESCRIPTION
## Changes

* Check the SwapX pool is not too imbalanced before depositing to the SwapX AMO strategy. This uses the `maxDepeg` config on the strategy that is be max deviation from peg the OS/wS price is allowed.