### PR TITLE
Remove pool boosters from Pool Booster Factory SwapxSingle

### DIFF
--- a/contracts/deploy/sonic/017_remove_pool_booster.js
+++ b/contracts/deploy/sonic/017_remove_pool_booster.js
@@ -9,7 +9,7 @@ module.exports = deployOnSonic(
     );
 
     return {
-      name: "Remove 3 pool booster from Pool Booster Factory SwapxSingle",
+      name: "Remove 2 pool boosters from Pool Booster Factory SwapxSingle",
       actions: [
         {
           // Protocol: THC
@@ -17,13 +17,6 @@ module.exports = deployOnSonic(
           contract: cPoolBoosterFactorySwapxSingle,
           signature: "removePoolBooster(address)",
           args: ["0xcAc8E01CeeC490F82276A350f395Ab12F089BBe5"],
-        },
-        {
-          // Protocol: GEMSx
-          // GEMsx/OS SwapX Pool booster
-          contract: cPoolBoosterFactorySwapxSingle,
-          signature: "removePoolBooster(address)",
-          args: ["0x1ea8Db4053f806636250bb2BFa6B1E0c4923c209"],
         },
         {
           // Protocol: SWAPx

--- a/contracts/deploy/sonic/017_remove_pool_booster.js
+++ b/contracts/deploy/sonic/017_remove_pool_booster.js
@@ -1,0 +1,38 @@
+const { deployOnSonic } = require("../../utils/deploy-l2");
+module.exports = deployOnSonic(
+  {
+    deployName: "017_remove_pool_booster",
+  },
+  async ({ ethers }) => {
+    const cPoolBoosterFactorySwapxSingle = await ethers.getContract(
+      "PoolBoosterFactorySwapxSingle"
+    );
+
+    return {
+      name: "Remove 3 pool booster from Pool Booster Factory SwapxSingle",
+      actions: [
+        {
+          // Protocol: THC
+          // THC/OS SwapX Pool booster
+          contract: cPoolBoosterFactorySwapxSingle,
+          signature: "removePoolBooster(address)",
+          args: ["0xcAc8E01CeeC490F82276A350f395Ab12F089BBe5"],
+        },
+        {
+          // Protocol: GEMSx
+          // GEMsx/OS SwapX Pool booster
+          contract: cPoolBoosterFactorySwapxSingle,
+          signature: "removePoolBooster(address)",
+          args: ["0x1ea8Db4053f806636250bb2BFa6B1E0c4923c209"],
+        },
+        {
+          // Protocol: SWAPx
+          // SWPx/OS SwapX Pool booster
+          contract: cPoolBoosterFactorySwapxSingle,
+          signature: "removePoolBooster(address)",
+          args: ["0x46b210Dd7217A37357bF076AA78e09330a974e33"],
+        },
+      ],
+    };
+  }
+);

--- a/contracts/deployments/sonic/operations/017_remove_pool_booster.execute.json
+++ b/contracts/deployments/sonic/operations/017_remove_pool_booster.execute.json
@@ -1,0 +1,52 @@
+{
+  "version": "1.0",
+  "chainId": "146",
+  "createdAt": 1743758906,
+  "meta": {
+    "name": "Transaction Batch",
+    "description": "",
+    "txBuilderVersion": "1.16.1",
+    "createdFromSafeAddress": "0xAdDEA7933Db7d83855786EB43a238111C69B00b6",
+    "createdFromOwnerAddress": ""
+  },
+  "transactions": [
+    {
+      "to": "0x31a91336414d3B955E494E7d485a6B06b55FC8fB",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "type": "address[]",
+            "name": "targets"
+          },
+          {
+            "type": "uint256[]",
+            "name": "values"
+          },
+          {
+            "type": "bytes[]",
+            "name": "payloads"
+          },
+          {
+            "type": "bytes32",
+            "name": "predecessor"
+          },
+          {
+            "type": "bytes32",
+            "name": "salt"
+          }
+        ],
+        "name": "executeBatch",
+        "payable": true
+      },
+      "contractInputsValues": {
+        "targets": "[\"0x2d7C5a0a60a874A48bd538322f758EF43fa32953\",\"0x2d7C5a0a60a874A48bd538322f758EF43fa32953\",\"0x2d7C5a0a60a874A48bd538322f758EF43fa32953\"]",
+        "values": "[\"0\",\"0\",\"0\"]",
+        "payloads": "[\"0xe24abe63000000000000000000000000cac8e01ceec490f82276a350f395ab12f089bbe5\",\"0xe24abe630000000000000000000000001ea8db4053f806636250bb2bfa6b1e0c4923c209\",\"0xe24abe6300000000000000000000000046b210dd7217a37357bf076aa78e09330a974e33\"]",
+        "predecessor": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "salt": "0x66b3522af37e151651a189e9434194cb55c85f7b1f9619d3be4e2b86735dcd90"
+      }
+    }
+  ]
+}

--- a/contracts/deployments/sonic/operations/017_remove_pool_booster.execute.json
+++ b/contracts/deployments/sonic/operations/017_remove_pool_booster.execute.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "chainId": "146",
-  "createdAt": 1743758906,
+  "createdAt": 1743760364,
   "meta": {
     "name": "Transaction Batch",
     "description": "",
@@ -41,11 +41,11 @@
         "payable": true
       },
       "contractInputsValues": {
-        "targets": "[\"0x2d7C5a0a60a874A48bd538322f758EF43fa32953\",\"0x2d7C5a0a60a874A48bd538322f758EF43fa32953\",\"0x2d7C5a0a60a874A48bd538322f758EF43fa32953\"]",
-        "values": "[\"0\",\"0\",\"0\"]",
-        "payloads": "[\"0xe24abe63000000000000000000000000cac8e01ceec490f82276a350f395ab12f089bbe5\",\"0xe24abe630000000000000000000000001ea8db4053f806636250bb2bfa6b1e0c4923c209\",\"0xe24abe6300000000000000000000000046b210dd7217a37357bf076aa78e09330a974e33\"]",
+        "targets": "[\"0x2d7C5a0a60a874A48bd538322f758EF43fa32953\",\"0x2d7C5a0a60a874A48bd538322f758EF43fa32953\"]",
+        "values": "[\"0\",\"0\"]",
+        "payloads": "[\"0xe24abe63000000000000000000000000cac8e01ceec490f82276a350f395ab12f089bbe5\",\"0xe24abe6300000000000000000000000046b210dd7217a37357bf076aa78e09330a974e33\"]",
         "predecessor": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "salt": "0x66b3522af37e151651a189e9434194cb55c85f7b1f9619d3be4e2b86735dcd90"
+        "salt": "0xe42e202da15d5769c936edc982b90233f7610575d3b7459c7f0f3e05adc74c04"
       }
     }
   ]

--- a/contracts/deployments/sonic/operations/017_remove_pool_booster.schedule.json
+++ b/contracts/deployments/sonic/operations/017_remove_pool_booster.schedule.json
@@ -1,0 +1,57 @@
+{
+  "version": "1.0",
+  "chainId": "146",
+  "createdAt": 1743758906,
+  "meta": {
+    "name": "Transaction Batch",
+    "description": "",
+    "txBuilderVersion": "1.16.1",
+    "createdFromSafeAddress": "0xAdDEA7933Db7d83855786EB43a238111C69B00b6",
+    "createdFromOwnerAddress": ""
+  },
+  "transactions": [
+    {
+      "to": "0x31a91336414d3B955E494E7d485a6B06b55FC8fB",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "type": "address[]",
+            "name": "targets"
+          },
+          {
+            "type": "uint256[]",
+            "name": "values"
+          },
+          {
+            "type": "bytes[]",
+            "name": "payloads"
+          },
+          {
+            "type": "bytes32",
+            "name": "predecessor"
+          },
+          {
+            "type": "bytes32",
+            "name": "salt"
+          },
+          {
+            "type": "uint256",
+            "name": "delay"
+          }
+        ],
+        "name": "scheduleBatch",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "targets": "[\"0x2d7C5a0a60a874A48bd538322f758EF43fa32953\",\"0x2d7C5a0a60a874A48bd538322f758EF43fa32953\",\"0x2d7C5a0a60a874A48bd538322f758EF43fa32953\"]",
+        "values": "[\"0\",\"0\",\"0\"]",
+        "payloads": "[\"0xe24abe63000000000000000000000000cac8e01ceec490f82276a350f395ab12f089bbe5\",\"0xe24abe630000000000000000000000001ea8db4053f806636250bb2bfa6b1e0c4923c209\",\"0xe24abe6300000000000000000000000046b210dd7217a37357bf076aa78e09330a974e33\"]",
+        "predecessor": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "salt": "0x66b3522af37e151651a189e9434194cb55c85f7b1f9619d3be4e2b86735dcd90",
+        "delay": "86400"
+      }
+    }
+  ]
+}

--- a/contracts/deployments/sonic/operations/017_remove_pool_booster.schedule.json
+++ b/contracts/deployments/sonic/operations/017_remove_pool_booster.schedule.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "chainId": "146",
-  "createdAt": 1743758906,
+  "createdAt": 1743760364,
   "meta": {
     "name": "Transaction Batch",
     "description": "",
@@ -45,11 +45,11 @@
         "payable": false
       },
       "contractInputsValues": {
-        "targets": "[\"0x2d7C5a0a60a874A48bd538322f758EF43fa32953\",\"0x2d7C5a0a60a874A48bd538322f758EF43fa32953\",\"0x2d7C5a0a60a874A48bd538322f758EF43fa32953\"]",
-        "values": "[\"0\",\"0\",\"0\"]",
-        "payloads": "[\"0xe24abe63000000000000000000000000cac8e01ceec490f82276a350f395ab12f089bbe5\",\"0xe24abe630000000000000000000000001ea8db4053f806636250bb2bfa6b1e0c4923c209\",\"0xe24abe6300000000000000000000000046b210dd7217a37357bf076aa78e09330a974e33\"]",
+        "targets": "[\"0x2d7C5a0a60a874A48bd538322f758EF43fa32953\",\"0x2d7C5a0a60a874A48bd538322f758EF43fa32953\"]",
+        "values": "[\"0\",\"0\"]",
+        "payloads": "[\"0xe24abe63000000000000000000000000cac8e01ceec490f82276a350f395ab12f089bbe5\",\"0xe24abe6300000000000000000000000046b210dd7217a37357bf076aa78e09330a974e33\"]",
         "predecessor": "0x0000000000000000000000000000000000000000000000000000000000000000",
-        "salt": "0x66b3522af37e151651a189e9434194cb55c85f7b1f9619d3be4e2b86735dcd90",
+        "salt": "0xe42e202da15d5769c936edc982b90233f7610575d3b7459c7f0f3e05adc74c04",
         "delay": "86400"
       }
     }


### PR DESCRIPTION
## Description
This PR doesn't aim to be merged, this is only for governance purpose.

Remove following pool booster from the SwapXSingle factory:
- THC/OS -> 0xcAc8E01CeeC490F82276A350f395Ab12F089BBe5
- SWPx/OS -> 0x46b210Dd7217A37357bF076AA78e09330a974e33


## Deploy checklist

Two reviewers complete the following checklist:

```
- [ ] Governance proposal matches the deploy script
- [ ] Smoke tests pass after fork test execution of the governance proposal
```

