### PR TITLE
[Deploy-138] Deprecate buyback

### DIFF
--- a/contracts/deploy/mainnet/138_buyback_deprecation.js
+++ b/contracts/deploy/mainnet/138_buyback_deprecation.js
@@ -8,8 +8,7 @@ module.exports = deploymentWithGovernanceProposal(
     // forceSkip: true,
     // reduceQueueTime: true,
     deployerIsProposer: false,
-    proposalId:
-      "82684779292823865624163305100894964251242260336820147312852506014889047275271",
+    proposalId: "",
   },
   async () => {
     const cLegacyBuyback = await ethers.getContractAt(
@@ -52,8 +51,7 @@ module.exports = deploymentWithGovernanceProposal(
       name: `Update fee recipient and change ownership of buyback contracts
 
 - Sets the trustee address to the multichain Guardian for OUSD and OETH vaults
-- Changes the governor of existing buyback contracts to the multichain Guardian to enable updated buyback operations
-- Transfers leftover OGV from one of the legacy buyback contracts to the multichain Guardian`,
+- Changes the governor of existing and legacy buyback contracts to the multichain Guardian to enable updated buyback operations`,
       actions: [
         {
           // Send all OUSD fees to the Multichain Strategist
@@ -87,12 +85,6 @@ module.exports = deploymentWithGovernanceProposal(
           contract: cLegacyBuyback,
           signature: "transferGovernance(address)",
           args: [addresses.multichainStrategist],
-        },
-        // Drain OGV from Legacy Buyback contract
-        {
-          contract: cLegacyBuyback,
-          signature: "transferToken(address,uint256)",
-          args: [addresses.mainnet.OGV, ogvInLegacyBuyback],
         },
       ],
     };

--- a/contracts/deploy/mainnet/138_buyback_deprecation.js
+++ b/contracts/deploy/mainnet/138_buyback_deprecation.js
@@ -47,7 +47,11 @@ module.exports = deploymentWithGovernanceProposal(
     );
 
     return {
-      name: "Deprecate Buyback",
+      name: `Update fee recipient and change ownership of buyback contracts
+
+- Sets the trustee address to the multichain Guardian for OUSD and OETH vaults
+- Changes the governor of existing buyback contracts to the multichain Guardian to enable updated buyback operations
+- Transfers leftover OGV from one of the legacy buyback contracts to the multichain Guardian`,
       actions: [
         {
           // Send all OUSD fees to the Multichain Strategist

--- a/contracts/deploy/mainnet/138_buyback_deprecation.js
+++ b/contracts/deploy/mainnet/138_buyback_deprecation.js
@@ -8,7 +8,8 @@ module.exports = deploymentWithGovernanceProposal(
     // forceSkip: true,
     // reduceQueueTime: true,
     deployerIsProposer: false,
-    proposalId: "",
+    proposalId:
+      "95818130106833559554842628131764707258168638288997879437261600658785882386480",
   },
   async () => {
     const cLegacyBuyback = await ethers.getContractAt(

--- a/contracts/deploy/mainnet/138_buyback_deprecation.js
+++ b/contracts/deploy/mainnet/138_buyback_deprecation.js
@@ -57,13 +57,13 @@ module.exports = deploymentWithGovernanceProposal(
           // Send all OUSD fees to the Multichain Strategist
           contract: cOUSDVault,
           signature: "setTrusteeAddress(address)",
-          args: [addresses.multichainStrategist],
+          args: [addresses.multichainBuybackOperator],
         },
         {
           // Send all OETH fees to the Multichain Strategist
           contract: cOETHVault,
           signature: "setTrusteeAddress(address)",
-          args: [addresses.multichainStrategist],
+          args: [addresses.multichainBuybackOperator],
         },
         // Transfer governance from all buyback contracts to the Multichain Strategist
         {

--- a/contracts/deploy/mainnet/138_buyback_deprecation.js
+++ b/contracts/deploy/mainnet/138_buyback_deprecation.js
@@ -8,6 +8,8 @@ module.exports = deploymentWithGovernanceProposal(
     // forceSkip: true,
     // reduceQueueTime: true,
     deployerIsProposer: false,
+    proposalId:
+      "82684779292823865624163305100894964251242260336820147312852506014889047275271",
   },
   async () => {
     const cLegacyBuyback = await ethers.getContractAt(

--- a/contracts/deploy/mainnet/138_buyback_deprecation.js
+++ b/contracts/deploy/mainnet/138_buyback_deprecation.js
@@ -1,0 +1,94 @@
+const addresses = require("../../utils/addresses");
+const { deploymentWithGovernanceProposal } = require("../../utils/deploy");
+
+module.exports = deploymentWithGovernanceProposal(
+  {
+    deployName: "138_buyback_deprecation",
+    forceDeploy: false,
+    // forceSkip: true,
+    // reduceQueueTime: true,
+    deployerIsProposer: false,
+  },
+  async () => {
+    const cLegacyBuyback = await ethers.getContractAt(
+      "OUSDBuyback",
+      "0x77314eb392b2be47c014cde0706908b3307ad6a9"
+    );
+    const ogv = await ethers.getContractAt("IERC20", addresses.mainnet.OGV);
+    const ogvInLegacyBuyback = await ogv.balanceOf(cLegacyBuyback.address);
+
+    console.log("OGV in Legacy Buyback:", ogvInLegacyBuyback.toString());
+
+    const cOUSDBuybackProxy = await ethers.getContract("BuybackProxy");
+    const cOUSDBuyback = await ethers.getContractAt(
+      "OUSDBuyback",
+      cOUSDBuybackProxy.address
+    );
+    const cOETHBuybackProxy = await ethers.getContract("OETHBuybackProxy");
+    const cOETHBuyback = await ethers.getContractAt(
+      "OETHBuyback",
+      cOETHBuybackProxy.address
+    );
+    const cARMBuybackProxy = await ethers.getContract("ARMBuybackProxy");
+    const cARMBuyback = await ethers.getContractAt(
+      "ARMBuyback",
+      cARMBuybackProxy.address
+    );
+
+    const cOUSDVaultProxy = await ethers.getContract("VaultProxy");
+    const cOUSDVault = await ethers.getContractAt(
+      "IVault",
+      cOUSDVaultProxy.address
+    );
+    const cOETHVaultProxy = await ethers.getContract("OETHVaultProxy");
+    const cOETHVault = await ethers.getContractAt(
+      "IVault",
+      cOETHVaultProxy.address
+    );
+
+    return {
+      name: "Deprecate Buyback",
+      actions: [
+        {
+          // Send all OUSD fees to the Multichain Strategist
+          contract: cOUSDVault,
+          signature: "setTrusteeAddress(address)",
+          args: [addresses.multichainStrategist],
+        },
+        {
+          // Send all OETH fees to the Multichain Strategist
+          contract: cOETHVault,
+          signature: "setTrusteeAddress(address)",
+          args: [addresses.multichainStrategist],
+        },
+        // Transfer governance from all buyback contracts to the Multichain Strategist
+        {
+          contract: cOUSDBuyback,
+          signature: "transferGovernance(address)",
+          args: [addresses.multichainStrategist],
+        },
+        {
+          contract: cOETHBuyback,
+          signature: "transferGovernance(address)",
+          args: [addresses.multichainStrategist],
+        },
+        {
+          contract: cARMBuyback,
+          signature: "transferGovernance(address)",
+          args: [addresses.multichainStrategist],
+        },
+        {
+          contract: cLegacyBuyback,
+          signature: "transferGovernance(address)",
+          args: [addresses.multichainStrategist],
+        },
+        // Drain OGV from Legacy Buyback contract
+        {
+          contract: cLegacyBuyback,
+          signature: "transferToken(address,uint256)",
+          args: [addresses.mainnet.OGV, ogvInLegacyBuyback],
+        },
+      ],
+    };
+  }
+);

--- a/contracts/deployments/mainnet/.migrations.json
+++ b/contracts/deployments/mainnet/.migrations.json
@@ -33,5 +33,6 @@
   "134_vault_woeth_upgrade": 1745347199,
   "135_vault_wousd_upgrade": 1745403755,
   "136_upgrade_morpho_strategies": 1746506903,
-  "137_oeth_weth_curve_amo": 1746523151
+  "137_oeth_weth_curve_amo": 1746523151,
+  "138_buyback_deprecation": 1748836826
 }

--- a/contracts/utils/addresses.js
+++ b/contracts/utils/addresses.js
@@ -6,6 +6,8 @@ addresses.dead = "0x0000000000000000000000000000000000000001";
 addresses.ETH = "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE";
 addresses.createX = "0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed";
 addresses.multichainStrategist = "0x4FF1b9D9ba8558F5EAfCec096318eA0d8b541971";
+addresses.multichainBuybackOperator =
+  "0xBB077E716A5f1F1B63ed5244eBFf5214E50fec8c";
 addresses.votemarket = "0x8c2c5A295450DDFf4CB360cA73FCCC12243D14D9";
 
 addresses.mainnet = {};


### PR DESCRIPTION
## Quick Overview
- Related snapshot proposal [is here](https://snapshot.box/#/s:origingov.eth/proposal/0x46acad07ab3f5cbdddf2bcbc6ad60def3375b99b6500e294b69e5d415a4151eb)
- This sets the trustee address to be the multichain guardian on both OUSD and OETH Vaults
- Also, changes the governor of the existing buyback contracts to the multichain guardian
   - This is needed because we can't call `transferToken` in the proposal without leaving some dust (since proposal can take up to 5 days). Making the 2/8 as governor will make it easier for us to drain it once this proposal has passed. 
- Transfer some leftover OGV from one of the legacy buyback contracts to the guardian

## Governance Proposal
- Proposal ID: [95818130106833559554842628131764707258168638288997879437261600658785882386480](https://app.originprotocol.com/#/ogn/governance/1:0x1d3fbd4d129ddd2372ea85c5fa00b2682081c9ec:95818130106833559554842628131764707258168638288997879437261600658785882386480)
- [Propose Tx](https://etherscan.io/tx/0x00488f870647123dbaaf178a94fe16f16aa713e5a5bca0974575357a00c0dd96)
## Deploy checklist

Two reviewers complete the following checklist:

```
- [ ] Governance proposal matches the deploy script
- [ ] Smoke tests pass after fork test execution of the governance proposal
```

