### PR TITLE
Add withdrawSSV to Native Staking Strategy

### DIFF
--- a/contracts/contracts/strategies/NativeStaking/ValidatorRegistrator.sol
+++ b/contracts/contracts/strategies/NativeStaking/ValidatorRegistrator.sol
@@ -347,6 +347,19 @@ abstract contract ValidatorRegistrator is Governable, Pausable {
         );
     }
 
+    /// @notice Withdraws excess SSV Tokens from the SSV Network contract which was used to pay the SSV Operators.
+    /// @dev A SSV cluster is defined by the SSVOwnerAddress and the set of operatorIds.
+    /// @param operatorIds The operator IDs of the SSV Cluster
+    /// @param ssvAmount The amount of SSV tokens to be deposited to the SSV cluster
+    /// @param cluster The SSV cluster details including the validator count and SSV balance
+    function withdrawSSV(
+        uint64[] memory operatorIds,
+        uint256 ssvAmount,
+        Cluster memory cluster
+    ) external onlyGovernor {
+        ISSVNetwork(SSV_NETWORK).withdraw(operatorIds, ssvAmount, cluster);
+    }
+
     /***************************************
                  Abstract
     ****************************************/

--- a/contracts/deploy/mainnet/139_remove_1st_native_ssv_staking.js
+++ b/contracts/deploy/mainnet/139_remove_1st_native_ssv_staking.js
@@ -1,0 +1,74 @@
+const { deploymentWithGovernanceProposal } = require("../../utils/deploy");
+const addresses = require("../../utils/addresses");
+
+module.exports = deploymentWithGovernanceProposal(
+  {
+    deployName: "139_remove_1st_native_ssv_staking",
+    forceDeploy: false,
+    //forceSkip: true,
+    reduceQueueTime: true,
+    deployerIsProposer: false,
+    // proposalId: "",
+  },
+  async ({ deployWithConfirmation, ethers }) => {
+    // Current contracts
+    const cVaultProxy = await ethers.getContract("OETHVaultProxy");
+    const cVaultAdmin = await ethers.getContractAt(
+      "OETHVaultAdmin",
+      cVaultProxy.address
+    );
+
+    // Deployer Actions
+    // ----------------
+
+    // 1. Fetch the first native strategy proxy
+    const cNativeStakingStrategyProxy = await ethers.getContract(
+      "NativeStakingSSVStrategyProxy"
+    );
+
+    const cFeeAccumulatorProxy = await ethers.getContract(
+      "NativeStakingFeeAccumulatorProxy"
+    );
+
+    // 2. Deploy the new Native Staking Strategy implementation
+    const dNativeStakingStrategyImpl = await deployWithConfirmation(
+      "NativeStakingSSVStrategy",
+      [
+        [addresses.zero, cVaultProxy.address], //_baseConfig
+        addresses.mainnet.WETH, // wethAddress
+        addresses.mainnet.SSV, // ssvToken
+        addresses.mainnet.SSVNetwork, // ssvNetwork
+        500, // maxValidators
+        cFeeAccumulatorProxy.address, // feeAccumulator
+        addresses.mainnet.beaconChainDepositContract, // beacon chain deposit contract
+      ]
+    );
+
+    // Governance Actions
+    // ----------------
+    return {
+      name: `Deploy a third OETH Native Staking Strategy.`,
+      actions: [
+        // 1. Remove strategy from vault
+        {
+          contract: cVaultAdmin,
+          signature: "removeStrategy(address)",
+          args: [cNativeStakingStrategyProxy.address],
+        },
+        // 2. Upgrade the Native Staking Strategy Strategy
+        {
+          contract: cNativeStakingStrategyProxy,
+          signature: "upgradeTo(address)",
+          args: [dNativeStakingStrategyImpl.address],
+        },
+        // 3. Transfer governance to the Guardian
+        {
+          contract: cNativeStakingStrategyProxy,
+          signature: "transferGovernance(address)",
+          args: [addresses.multichainStrategist],
+        },
+        // The Guardian can then retrieve the SSV left in the cluster by calling claimGovernance, withdrawSSV and transferToken
+      ],
+    };
+  }
+);

--- a/contracts/scripts/defender-actions/doAccounting.js
+++ b/contracts/scripts/defender-actions/doAccounting.js
@@ -24,7 +24,7 @@ const handler = async (event) => {
   const networkName = network.chainId === 1 ? "mainnet" : "holesky";
   log(`Network: ${networkName} with chain id (${network.chainId})`);
 
-  await doAccounting("NativeStakingSSVStrategyProxy", networkName, signer);
+  // await doAccounting("NativeStakingSSVStrategyProxy", networkName, signer);
   await doAccounting("NativeStakingSSVStrategy2Proxy", networkName, signer);
   await doAccounting("NativeStakingSSVStrategy3Proxy", networkName, signer);
 };

--- a/contracts/scripts/defender-actions/harvest.js
+++ b/contracts/scripts/defender-actions/harvest.js
@@ -44,7 +44,7 @@ const handler = async (event) => {
   const strategiesToHarvest = [convexAMOProxyAddress];
 
   const nativeStakingStrategies = [
-    addresses[networkName].NativeStakingSSVStrategyProxy,
+    // addresses[networkName].NativeStakingSSVStrategyProxy,
     addresses[networkName].NativeStakingSSVStrategy2Proxy,
     addresses[networkName].NativeStakingSSVStrategy3Proxy,
   ];

--- a/contracts/tasks/ssv.js
+++ b/contracts/tasks/ssv.js
@@ -72,11 +72,47 @@ const depositSSV = async ({ amount, index, operatorids }) => {
       strategy.address
     } with operator IDs ${operatorIds}`
   );
-  log(`Cluster: ${JSON.stringify(clusterInfo.snapshot)}`);
+  log(`Cluster: ${JSON.stringify(clusterInfo.cluster)}`);
   const tx = await strategy
     .connect(signer)
     .depositSSV(operatorIds, amountBN, clusterInfo.cluster);
   await logTxDetails(tx, "depositSSV");
+};
+
+const withdrawSSV = async ({ amount, index, operatorids }) => {
+  const amountBN = parseUnits(amount.toString(), 18);
+  log(`Splitting operator IDs ${operatorids}`);
+  const operatorIds = operatorids.split(",").map((id) => parseInt(id));
+
+  const signer = await getSigner();
+
+  const strategy = await resolveNativeStakingStrategyProxy(index);
+
+  const { chainId } = await ethers.provider.getNetwork();
+  const network = networkMap[chainId];
+  const ssvNetworkAddress = addresses[network].SSVNetwork;
+  const ssvNetwork = await resolveContract(ssvNetworkAddress, "ISSVNetwork");
+
+  // Cluster details
+  const clusterInfo = await getClusterInfo({
+    chainId,
+    ssvNetwork: ssvNetwork.address,
+    operatorids,
+    ownerAddress: strategy.address,
+  });
+
+  log(
+    `About to withdraw ${formatUnits(
+      amountBN
+    )} SSV tokens from the SSV Network for native staking strategy ${
+      strategy.address
+    } with operator IDs ${operatorIds}`
+  );
+  log(`Cluster: ${JSON.stringify(clusterInfo.cluster)}`);
+  const tx = await strategy
+    .connect(signer)
+    .withdrawSSV(operatorIds, amountBN, clusterInfo.cluster);
+  await logTxDetails(tx, "withdrawSSV");
 };
 
 const calcDepositRoot = async ({ index, pubkey, sig }, hre) => {
@@ -120,6 +156,7 @@ const calcDepositRoot = async ({ index, pubkey, sig }, hre) => {
 module.exports = {
   printClusterInfo,
   depositSSV,
+  withdrawSSV,
   calcDepositRoot,
   removeValidator,
 };

--- a/contracts/tasks/tasks.js
+++ b/contracts/tasks/tasks.js
@@ -68,6 +68,7 @@ const {
 const {
   calcDepositRoot,
   depositSSV,
+  withdrawSSV,
   printClusterInfo,
   removeValidator,
 } = require("./ssv");
@@ -87,6 +88,7 @@ const {
   getRewardTokenAddresses,
   setRewardTokenAddresses,
   checkBalance,
+  transferToken,
 } = require("./strategy");
 const {
   validatorOperationsConfig,
@@ -112,20 +114,6 @@ const { deployForceEtherSender, forceSend } = require("./simulation");
 const { sleep } = require("../utils/time");
 
 const { lzBridgeToken, lzSetConfig } = require("./layerzero");
-
-// can not import from utils/deploy since that imports hardhat globally
-const withConfirmation = async (deployOrTransactionPromise) => {
-  const hre = require("hardhat");
-
-  const result = await deployOrTransactionPromise;
-  const receipt = await hre.ethers.provider.waitForTransaction(
-    result.receipt ? result.receipt.transactionHash : result.hash,
-    3
-  );
-
-  result.receipt = receipt;
-  return result;
-};
 
 const log = require("../utils/logger")("tasks");
 
@@ -942,6 +930,7 @@ task(
     undefined,
     types.string
   )
+  .addParam("governor", "Address of the new governor", undefined, types.string)
   .setAction(transferGovernance);
 
 task(
@@ -955,6 +944,22 @@ task(
     types.string
   )
   .setAction(claimGovernance);
+
+task("transferToken", "Transfer tokens in a contract to the governor")
+  .addParam(
+    "proxy",
+    "Name of the proxy contract or contract name if no proxy. eg OETHVaultProxy or OETHZapper",
+    undefined,
+    types.string
+  )
+  .addParam("symbol", "Symbol of the token", undefined, types.string)
+  .addOptionalParam(
+    "amount",
+    "The amount of tokens to transfer. (default: balance)",
+    undefined,
+    types.float
+  )
+  .setAction(transferToken);
 
 // Strategy
 
@@ -1070,6 +1075,28 @@ task("depositSSV").setAction(async (_, __, runSuper) => {
   return runSuper();
 });
 
+subtask(
+  "withdrawSSV",
+  "Withdraw SSV tokens from an SSV Cluster to the native staking strategy"
+)
+  .addParam("amount", "Amount of SSV tokens", undefined, types.float)
+  .addOptionalParam(
+    "index",
+    "The number of the Native Staking Contract deployed.",
+    undefined,
+    types.int
+  )
+  .addParam(
+    "operatorids",
+    "Comma separated operator ids. E.g. 342,343,344,345",
+    undefined,
+    types.string
+  )
+  .setAction(withdrawSSV);
+task("withdrawSSV").setAction(async (_, __, runSuper) => {
+  return runSuper();
+});
+
 /**
  * The native staking proxy needs to be deployed via the defender relayer because the SSV network
  * grants the SSV rewards to the deployer of the contract. And we want the Defender Relayer to be
@@ -1103,49 +1130,6 @@ subtask(
 task("deployNativeStakingProxy").setAction(async (_, __, runSuper) => {
   return runSuper();
 });
-
-/**
- * Governance of the SSV strategy proxy needs to be transferred to the deployer address so that
- * the deployer is able to initialize the proxy
- */
-subtask(
-  "transferGovernanceNativeStakingProxy",
-  "Transfer governance of the proxy from the Defender Relayer"
-)
-  .addParam(
-    "deployer",
-    "Address of the deployer of NativeStakingSSVStrategy implementation",
-    undefined,
-    types.string
-  )
-  .addOptionalParam(
-    "index",
-    "The number of the Native Staking Contract deployed.",
-    undefined,
-    types.int
-  )
-  .setAction(async ({ deployer, index }) => {
-    const signer = await getSigner();
-
-    const nativeStakingProxy = await ethers.getContract(
-      `NativeStakingSSVStrategy${index}Proxy`
-    );
-    const oldGovernor = await nativeStakingProxy.governor();
-    log(
-      `About to transfer governance of NativeStakingSSVStrategy${index}Proxy (${nativeStakingProxy.address}) from ${oldGovernor} to ${deployer}`
-    );
-    await withConfirmation(
-      nativeStakingProxy.connect(signer).transferGovernance(deployer)
-    );
-    log(
-      `Transferred governance of NativeStakingSSVStrategy${index}Proxy from ${oldGovernor} to ${deployer}`
-    );
-  });
-task("transferGovernanceNativeStakingProxy").setAction(
-  async (_, __, runSuper) => {
-    return runSuper();
-  }
-);
 
 // Validator Operations
 

--- a/contracts/test/_fixture.js
+++ b/contracts/test/_fixture.js
@@ -1854,11 +1854,7 @@ async function nativeStakingSSVStrategyFixture() {
   });
 
   if (isFork) {
-    const { oethVault, weth, nativeStakingSSVStrategy, ssv, timelock } =
-      fixture;
-    await oethVault
-      .connect(timelock)
-      .setAssetDefaultStrategy(weth.address, nativeStakingSSVStrategy.address);
+    const { nativeStakingSSVStrategy, ssv } = fixture;
 
     // The Defender Relayer
     fixture.validatorRegistrator = await impersonateAndFund(

--- a/contracts/test/strategies/curve-amo-ousd.mainnet.fork-test.js
+++ b/contracts/test/strategies/curve-amo-ousd.mainnet.fork-test.js
@@ -216,7 +216,7 @@ describe("Curve AMO OUSD strategy", function () {
       const user = defaultDepositor;
       const attackerusdcBalanceBefore = await usdc.balanceOf(user.address);
       const attackerOusdBalanceBefore = await ousd.balanceOf(user.address);
-      const attackerusdcAmount = usdcUnits("1500000"); // 1.5M usdc
+      const attackerusdcAmount = usdcUnits("900000"); // 900k usdc
       const depositusdcAmount = usdcUnits("10000"); // 10k usdc
 
       const dataBeforeAttack = await snapData();

--- a/contracts/test/strategies/nativeSsvStaking.mainnet.fork-test.js
+++ b/contracts/test/strategies/nativeSsvStaking.mainnet.fork-test.js
@@ -8,7 +8,7 @@ const loadFixture = createFixtureLoader(nativeStakingSSVStrategyFixture);
 const { shouldBehaveLikeAnSsvStrategy } = require("../behaviour/ssvStrategy");
 const { resolveContract } = require("../../utils/resolvers");
 
-describe("ForkTest: First Native SSV Staking Strategy", function () {
+describe.skip("ForkTest: First Native SSV Staking Strategy", function () {
   this.timeout(0);
 
   let fixture;


### PR DESCRIPTION
## Changes

* Adds `withdrawSSV` to Native Staking Strategy so the left over SSV in the cluster can be claimed by the strategy.

## Deployment

The `contracts/deploy/mainnet/139_remove_1st_native_ssv_staking.js` deploy script deploys a new `NativeStakingSSVStrategy` contract and creates a governance proposal to:
 
1. Remove the first native staking strategy from OETH Vault
2. Upgrade the Native Staking Strategy Strategy
3. Transfer governance to the 2.8 Guardian multisig

The 2/8 Guardian can then

1. Claim the governance of the first native staking strategy
2. withdraw the SSV from the first SSV cluster
3. transfer the SSV to the 2/8 Guardian multisig

## Testing

Start a local forked node
```
yarn run node
```

Use hardhat tasks to test the governance changes.
```
export IMPERSONATE=0x35918cDE7233F2dD33fA41ae3Cb6aE0e42E0e69F
FORK=true npx hardhat transferGovernance --proxy NativeStakingSSVStrategyProxy --governor 0x4FF1b9D9ba8558F5EAfCec096318eA0d8b541971 --network localhost

export IMPERSONATE=0x4FF1b9D9ba8558F5EAfCec096318eA0d8b541971
FORK=true npx hardhat claimGovernance --proxy NativeStakingSSVStrategyProxy --network localhost

# Need to leave 1.6 SSV which is the min liquidation collateral
FORK=true npx hardhat withdrawSSV --amount 275.287 --operatorids 342,343,344,345 --network localhost

FORK=true npx hardhat transferToken --symbol SSV --proxy NativeStakingSSVStrategyProxy --network localhost
```

## Code Change Checklist

To be completed before internal review begins:

- [ ]  The contract code is complete
- [ ]  Executable deployment file
- [ ]  Fork tests that test after the deployment file runs
- [ ]  Unit tests *if needed
- [ ]  The owner has done a [full checklist review](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) of the code + tests

Internal review:

- [ ] Two approvals by internal reviewers



