### PR TITLE
Fix failing fork test on base

### DIFF
--- a/contracts/test/strategies/base/bridged-woeth-strategy.base.fork-test.js
+++ b/contracts/test/strategies/base/bridged-woeth-strategy.base.fork-test.js
@@ -18,6 +18,7 @@ describe("Base Fork Test: Bridged WOETH Strategy", function () {
     const { woeth, oethb, oethbVault, weth, woethStrategy, governor } = fixture;
 
     await oethbVault.rebase();
+    await woethStrategy.updateWOETHOraclePrice();
 
     const supplyBefore = await oethb.totalSupply();
     const userOETHbBalanceBefore = await oethb.balanceOf(governor.address);

--- a/contracts/test/strategies/base/bridged-woeth-strategy.plume.fork-test.js
+++ b/contracts/test/strategies/base/bridged-woeth-strategy.plume.fork-test.js
@@ -18,6 +18,7 @@ describe("Plume Fork Test: Bridged WOETH Strategy", function () {
     const { woeth, oethp, oethpVault, weth, woethStrategy, governor } = fixture;
 
     await oethpVault.rebase();
+    await woethStrategy.updateWOETHOraclePrice();
 
     const supplyBefore = await oethp.totalSupply();
     const userOETHpBalanceBefore = await oethp.balanceOf(governor.address);


### PR DESCRIPTION
The BridgedWoethStrategy can mid-deposit update the WOETH oracle price. Such update caused the fork tests to fail, since the checkBalance would report a higher number (due to the oracle updating) then expected 