### PR TITLE
[Base] Add deployment file to set performance fee to 20%

### DIFF
--- a/contracts/deploy/base/032_vault_perf_fee.js
+++ b/contracts/deploy/base/032_vault_perf_fee.js
@@ -1,0 +1,25 @@
+const { deployOnBase } = require("../../utils/deploy-l2.js");
+
+module.exports = deployOnBase(
+  {
+    deployName: "032_vault_perf_fee",
+  },
+  async () => {
+    const cOETHBaseVaultProxy = await ethers.getContract("OETHBaseVaultProxy");
+    const cOETHBaseVault = await ethers.getContractAt(
+      "IVault",
+      cOETHBaseVaultProxy.address
+    );
+
+    return {
+      name: "Enable Buyback Operator",
+      actions: [
+        {
+          contract: cOETHBaseVault,
+          signature: "setTrusteeFeeBps(uint256)",
+          args: [2000], // 20%
+        },
+      ],
+    };
+  }
+);

--- a/contracts/deployments/base/.migrations.json
+++ b/contracts/deployments/base/.migrations.json
@@ -28,5 +28,6 @@
   "027_base_curve_amo_upgrade": 1743570593,
   "028_vault_woeth_upgrade": 1744987946,
   "030_claimbribes_safe_module": 1746891767,
-  "031_enable_buyback_operator": 1749060898
+  "031_enable_buyback_operator": 1749060898,
+  "032_vault_perf_fee": 1749471718
 }

--- a/contracts/deployments/base/operations/032_vault_perf_fee.execute.json
+++ b/contracts/deployments/base/operations/032_vault_perf_fee.execute.json
@@ -1,0 +1,52 @@
+{
+  "version": "1.0",
+  "chainId": "8453",
+  "createdAt": 1749471718,
+  "meta": {
+    "name": "Transaction Batch",
+    "description": "",
+    "txBuilderVersion": "1.16.1",
+    "createdFromSafeAddress": "0x92A19381444A001d62cE67BaFF066fA1111d7202",
+    "createdFromOwnerAddress": ""
+  },
+  "transactions": [
+    {
+      "to": "0xf817cb3092179083c48c014688D98B72fB61464f",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "type": "address[]",
+            "name": "targets"
+          },
+          {
+            "type": "uint256[]",
+            "name": "values"
+          },
+          {
+            "type": "bytes[]",
+            "name": "payloads"
+          },
+          {
+            "type": "bytes32",
+            "name": "predecessor"
+          },
+          {
+            "type": "bytes32",
+            "name": "salt"
+          }
+        ],
+        "name": "executeBatch",
+        "payable": true
+      },
+      "contractInputsValues": {
+        "targets": "[\"0x98a0CbeF61bD2D21435f433bE4CD42B56B38CC93\"]",
+        "values": "[\"0\"]",
+        "payloads": "[\"0x0acbda7500000000000000000000000000000000000000000000000000000000000007d0\"]",
+        "predecessor": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "salt": "0xb5fa5dc2a99672adab74672b11e878976d79a0bb0474ae805d5d989d552943e3"
+      }
+    }
+  ]
+}

--- a/contracts/deployments/base/operations/032_vault_perf_fee.schedule.json
+++ b/contracts/deployments/base/operations/032_vault_perf_fee.schedule.json
@@ -1,0 +1,57 @@
+{
+  "version": "1.0",
+  "chainId": "8453",
+  "createdAt": 1749471718,
+  "meta": {
+    "name": "Transaction Batch",
+    "description": "",
+    "txBuilderVersion": "1.16.1",
+    "createdFromSafeAddress": "0x92A19381444A001d62cE67BaFF066fA1111d7202",
+    "createdFromOwnerAddress": ""
+  },
+  "transactions": [
+    {
+      "to": "0xf817cb3092179083c48c014688D98B72fB61464f",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "type": "address[]",
+            "name": "targets"
+          },
+          {
+            "type": "uint256[]",
+            "name": "values"
+          },
+          {
+            "type": "bytes[]",
+            "name": "payloads"
+          },
+          {
+            "type": "bytes32",
+            "name": "predecessor"
+          },
+          {
+            "type": "bytes32",
+            "name": "salt"
+          },
+          {
+            "type": "uint256",
+            "name": "delay"
+          }
+        ],
+        "name": "scheduleBatch",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "targets": "[\"0x98a0CbeF61bD2D21435f433bE4CD42B56B38CC93\"]",
+        "values": "[\"0\"]",
+        "payloads": "[\"0x0acbda7500000000000000000000000000000000000000000000000000000000000007d0\"]",
+        "predecessor": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "salt": "0xb5fa5dc2a99672adab74672b11e878976d79a0bb0474ae805d5d989d552943e3",
+        "delay": "172800"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Governance
- 5/8 needs to schedule and execute the action to change the performance fee to 20% (current value is 0%)

## Deploy checklist

Two reviewers complete the following checklist:

```
- [ ] Governance proposal matches the deploy script
- [ ] Smoke tests pass after fork test execution of the governance proposal
```

