### PR TITLE
Deploy Sonic 021 - support new Sonic validator

### DIFF
--- a/contracts/deploy/sonic/021_add_validator.js
+++ b/contracts/deploy/sonic/021_add_validator.js
@@ -1,0 +1,43 @@
+const { deployOnSonic } = require("../../utils/deploy-l2.js");
+const addresses = require("../../utils/addresses.js");
+
+module.exports = deployOnSonic(
+  {
+    deployName: "021_add_validator",
+    forceSkip: false,
+  },
+  async ({ ethers }) => {
+    const cOSonicVaultProxy = await ethers.getContract("OSonicVaultProxy");
+    const cOSonicVault = await ethers.getContractAt(
+      "IVault",
+      cOSonicVaultProxy.address
+    );
+
+    // Staking Strategy
+    const cSonicStakingStrategyProxy = await ethers.getContract(
+      "SonicStakingStrategyProxy"
+    );
+    const cSonicStakingStrategy = await ethers.getContractAt(
+      "SonicStakingStrategy",
+      cSonicStakingStrategyProxy.address
+    );
+
+    return {
+      name: "Config Sonic Staking Strategy",
+      actions: [
+        // 1. Add support for new validator
+        {
+          contract: cSonicStakingStrategy,
+          signature: "supportValidator(uint256)",
+          args: [45],
+        },
+        // 2. Remove default strategy for wS
+        {
+          contract: cOSonicVault,
+          signature: "setAssetDefaultStrategy(address,address)",
+          args: [addresses.sonic.wS, addresses.zero],
+        },
+      ],
+    };
+  }
+);

--- a/contracts/deployments/sonic/.migrations.json
+++ b/contracts/deployments/sonic/.migrations.json
@@ -18,5 +18,6 @@
   "018_merkl_pool_booster": 1744620502,
   "014_wrapped_sonic": 1744749364,
   "019_os_vault_based_dripper": 1744752764,
-  "020_enable_buyback_operator": 1749060854
+  "020_enable_buyback_operator": 1749060854,
+  "021_add_validator": 1750336746
 }

--- a/contracts/deployments/sonic/operations/021_add_validator.execute.json
+++ b/contracts/deployments/sonic/operations/021_add_validator.execute.json
@@ -1,0 +1,52 @@
+{
+  "version": "1.0",
+  "chainId": "146",
+  "createdAt": 1750336746,
+  "meta": {
+    "name": "Transaction Batch",
+    "description": "",
+    "txBuilderVersion": "1.16.1",
+    "createdFromSafeAddress": "0xAdDEA7933Db7d83855786EB43a238111C69B00b6",
+    "createdFromOwnerAddress": ""
+  },
+  "transactions": [
+    {
+      "to": "0x31a91336414d3B955E494E7d485a6B06b55FC8fB",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "type": "address[]",
+            "name": "targets"
+          },
+          {
+            "type": "uint256[]",
+            "name": "values"
+          },
+          {
+            "type": "bytes[]",
+            "name": "payloads"
+          },
+          {
+            "type": "bytes32",
+            "name": "predecessor"
+          },
+          {
+            "type": "bytes32",
+            "name": "salt"
+          }
+        ],
+        "name": "executeBatch",
+        "payable": true
+      },
+      "contractInputsValues": {
+        "targets": "[\"0x596B0401479f6DfE1cAF8c12838311FeE742B95c\",\"0xa3c0eCA00D2B76b4d1F170b0AB3FdeA16C180186\"]",
+        "values": "[\"0\",\"0\"]",
+        "payloads": "[\"0x84bcbb4e000000000000000000000000000000000000000000000000000000000000002d\",\"0xbc90106b000000000000000000000000039e2fb66102314ce7b64ce5ce3e5183bc94ad380000000000000000000000000000000000000000000000000000000000000000\"]",
+        "predecessor": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "salt": "0x2dad2e3c6f78aed64919aec88bd85087dde5c909ebe37315f68490e5ef62caee"
+      }
+    }
+  ]
+}

--- a/contracts/deployments/sonic/operations/021_add_validator.schedule.json
+++ b/contracts/deployments/sonic/operations/021_add_validator.schedule.json
@@ -1,0 +1,57 @@
+{
+  "version": "1.0",
+  "chainId": "146",
+  "createdAt": 1750336746,
+  "meta": {
+    "name": "Transaction Batch",
+    "description": "",
+    "txBuilderVersion": "1.16.1",
+    "createdFromSafeAddress": "0xAdDEA7933Db7d83855786EB43a238111C69B00b6",
+    "createdFromOwnerAddress": ""
+  },
+  "transactions": [
+    {
+      "to": "0x31a91336414d3B955E494E7d485a6B06b55FC8fB",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "type": "address[]",
+            "name": "targets"
+          },
+          {
+            "type": "uint256[]",
+            "name": "values"
+          },
+          {
+            "type": "bytes[]",
+            "name": "payloads"
+          },
+          {
+            "type": "bytes32",
+            "name": "predecessor"
+          },
+          {
+            "type": "bytes32",
+            "name": "salt"
+          },
+          {
+            "type": "uint256",
+            "name": "delay"
+          }
+        ],
+        "name": "scheduleBatch",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "targets": "[\"0x596B0401479f6DfE1cAF8c12838311FeE742B95c\",\"0xa3c0eCA00D2B76b4d1F170b0AB3FdeA16C180186\"]",
+        "values": "[\"0\",\"0\"]",
+        "payloads": "[\"0x84bcbb4e000000000000000000000000000000000000000000000000000000000000002d\",\"0xbc90106b000000000000000000000000039e2fb66102314ce7b64ce5ce3e5183bc94ad380000000000000000000000000000000000000000000000000000000000000000\"]",
+        "predecessor": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "salt": "0x2dad2e3c6f78aed64919aec88bd85087dde5c909ebe37315f68490e5ef62caee",
+        "delay": "86400"
+      }
+    }
+  ]
+}

--- a/contracts/test/behaviour/sfcStakingStrategy.js
+++ b/contracts/test/behaviour/sfcStakingStrategy.js
@@ -49,7 +49,7 @@ const shouldBehaveLikeASFCStakingStrategy = (context) => {
       );
 
       expect(await sonicStakingStrategy.supportedValidatorsLength()).to.equal(
-        4,
+        testValidatorIds.length,
         "Incorrect Supported validators length"
       );
 

--- a/contracts/test/strategies/sonic/sonicStaking.sonic.fork-test.js
+++ b/contracts/test/strategies/sonic/sonicStaking.sonic.fork-test.js
@@ -18,7 +18,7 @@ describe("Sonic Fork Test: Sonic Staking Strategy", function () {
       addresses: addresses.sonic,
       sfc: await ethers.getContractAt("ISFC", addresses.sonic.SFC),
       // see validators here: https://explorer.soniclabs.com/staking
-      testValidatorIds: [15, 16, 17, 18],
+      testValidatorIds: [15, 16, 17, 18, 45],
       unsupportedValidators: [1, 2, 3],
     };
   });

--- a/contracts/test/vault/vault.sonic.fork-test.js
+++ b/contracts/test/vault/vault.sonic.fork-test.js
@@ -119,7 +119,7 @@ describe("ForkTest: Sonic Vault", function () {
       expect(balanceDiff).to.approxEqualTolerance(parseUnits("1000"), 1);
     });
 
-    it("should automatically deposit to staking strategy", async () => {
+    it.skip("should automatically deposit to staking strategy", async () => {
       const { oSonicVault, nick, wS, sonicStakingStrategy } = fixture;
 
       // Clear any wS out of the Vault first


### PR DESCRIPTION
## Config Changes

* Add support for Sonic validator 45
* Remove the default strategy for wS from the OS Vault

## Deployment

Deployment script is `contracts/deploy/sonic/021_add_validator.js`

* No contracts are deployed
* There are two governance actions in the Timelock

```
yarn run deploy:sonic
```

## Deploy checklist

Two reviewers complete the following checklist:

```
- [ ] All deployed contracts are listed in the deploy PR's description
- [ ] Deployed contract's verified code (and all dependencies) match the code in master
- [ ] Contract constructors have correct arguments
- [ ] The transactions that interacted with the newly deployed contract match the deploy script.
- [ ] Governance proposal matches the deploy script
- [ ] Smoke tests pass after fork test execution of the governance proposal
```

