### PR TITLE
L-01 _checkForExpectedPoolPrice Returns Incorrect WETH Share When Pool Is Out of Bounds

### DIFF
--- a/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol
+++ b/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol
@@ -577,8 +577,7 @@ contract RoosterAMOStrategy is InitializableAbstractStrategy {
                 revert OutsideExpectedTickRange();
             }
             
-            if (_currentPrice <= sqrtPriceTickLower) return (false, 0);
-            else return (false, 1e18);
+            return (false, _currentPrice <= sqrtPriceTickLower ? 0 : 1e18);
         }
 
         // 18 decimal number expressed WETH tick share

--- a/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol
+++ b/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol
@@ -576,7 +576,9 @@ contract RoosterAMOStrategy is InitializableAbstractStrategy {
             if (_throwException) {
                 revert OutsideExpectedTickRange();
             }
-            return (false, 0);
+            
+            if (_currentPrice <= sqrtPriceTickLower) return (false, 0);
+            else return (false, 1e18);
         }
 
         // 18 decimal number expressed WETH tick share


### PR DESCRIPTION
**OpenZeppeling audit issue:** 
The _checkForExpectedPoolPrice function checks whether the Maverick pool's current price is within a preconfigured tick range and returns the corresponding WETH share held by the strategy. While the price check itself functions correctly, the returned wethSharePct is inaccurate when the pool price is outside the expected range.

Specifically, the function [returns a WETH share of 0](https://github.com/OriginProtocol/origin-dollar/blob/2d02162bce99874ef6e0778e94527e375c4ec532/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol#L572-L580) in all out-of-bounds cases. While this is correct when the price is at or below the lower tick (where the position is 100% OETH), it is incorrect when the price is at or above the upper tick boundary. In that scenario, the position is entirely in WETH, and the WETH share should be 1e18.

Although the current implementation [does not rely on the returned WETH share value of 0](https://github.com/OriginProtocol/origin-dollar/blob/2d02162bce99874ef6e0778e94527e375c4ec532/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol#L339), this behavior introduces a latent risk. Because the contract is upgradeable, future versions of the strategy may assume wethSharePct is accurate and make faulty decisions based on it.

Consider updating the logic to return the correct WETH share based on whether the price is below the lower tick (0) or above the upper tick (1e18). This change would make the strategy more robust and reduce the risk of incorrect assumptions in future upgrades or extensions.