### PR TITLE
L-03 Incomplete Docstrings

### DIFF
--- a/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol
+++ b/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol
@@ -547,10 +547,10 @@ contract RoosterAMOStrategy is InitializableAbstractStrategy {
      *      position in the pool or not. The function returns _wethSharePct
      *      as a gas optimization measure.
      * @param _throwException  when set to true the function throws an exception
-     *        when pool's price is not within expected range.
+     *                         when pool's price is not within expected range.
      * @return _isExpectedRange  Bool expressing price is within expected range
      * @return _wethSharePct  Share of WETH owned by this strategy contract in the
-     *         configured ticker.
+     *                        configured ticker.
      */
     function _checkForExpectedPoolPrice(bool _throwException)
         internal
@@ -1086,7 +1086,7 @@ contract RoosterAMOStrategy is InitializableAbstractStrategy {
     /**
      * @notice Tick dominance   denominated in 1e18
      * @return _tickDominance   The share of liquidity in TICK_NUMBER tick owned
-     * by the strategy contract denominated in 1e18
+     *                          by the strategy contract denominated in 1e18
      */
     function tickDominance() public view returns (uint256 _tickDominance) {
         IMaverickV2Pool.TickState memory tickState = mPool.getTick(TICK_NUMBER);


### PR DESCRIPTION
**OpenZeppelin audit issue:** 
Within RoosterAMOStrategy.sol, multiple instances of incomplete docstrings were identified:

The return value is not documented in the [supportsAsset](https://github.com/OriginProtocol/origin-dollar/blob/2d02162bce99874ef6e0778e94527e375c4ec532/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol#L391-L393) function.
The return value is not documented in the [tickDominance](https://github.com/OriginProtocol/origin-dollar/blob/2d02162bce99874ef6e0778e94527e375c4ec532/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol#L1088-L1104) function.
Consider thoroughly documenting all functions and events (including their parameters and return values) that are part of the contract's public API. When writing docstrings, consider following the [Ethereum Natural Specification Format](https://solidity.readthedocs.io/en/latest/natspec-format.html) (NatSpec)