### PR TITLE
N-01 Typographical Errors

### DIFF
--- a/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol
+++ b/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol
@@ -68,7 +68,7 @@ contract RoosterAMOStrategy is InitializableAbstractStrategy {
     IMaverickV2LiquidityManager public immutable liquidityManager;
     /// @notice the Maverick V2 poolLens
     ///
-    /// @dev only used to provider the pool's current sqrtPrice
+    /// @dev only used to provide the pool's current sqrtPrice
     IMaverickV2PoolLens public immutable poolLens;
     /// @notice the Maverick V2 position
     ///
@@ -265,7 +265,7 @@ contract RoosterAMOStrategy is InitializableAbstractStrategy {
 
     /**
      * @notice Set allowed pool weth share interval. After the rebalance happens
-     * the share of WETH token in the ticker needs to be withing the specifications
+     * the share of WETH token in the ticker needs to be within the specifications
      * of the interval.
      *
      * @param _allowedWethShareStart Start of WETH share interval expressed as 18 decimal amount
@@ -969,7 +969,7 @@ contract RoosterAMOStrategy is InitializableAbstractStrategy {
      * keep rebalancing the pool in both directions making the protocol lose a tiny amount of
      * funds each time.
      *
-     * Protocol must be at least SOLVENCY_THRESHOLD (99,8 %) backed in order for the rebalances to
+     * Protocol must be at least SOLVENCY_THRESHOLD (99.8%) backed in order for the rebalances to
      * function.
      */
     function _solvencyAssert() internal view {
@@ -984,7 +984,7 @@ contract RoosterAMOStrategy is InitializableAbstractStrategy {
     }
 
     /**
-     * @dev Collect stkAave, convert it to AAVE send to Vault.
+     * @dev Collect Rooster reward token, and send it to the harvesterAddress
      */
     function collectRewardTokens()
         external
@@ -1107,27 +1107,31 @@ contract RoosterAMOStrategy is InitializableAbstractStrategy {
     /***************************************
             Hidden functions
     ****************************************/
-    /// @inheritdoc InitializableAbstractStrategy
+    /**
+     * @dev Unsupported
+     */
     function setPTokenAddress(address, address) external pure override {
         // The pool tokens can never change.
         revert("Unsupported method");
     }
 
-    /// @inheritdoc InitializableAbstractStrategy
+    /**
+     * @dev Unsupported
+     */
     function removePToken(uint256) external pure override {
         // The pool tokens can never change.
         revert("Unsupported method");
     }
 
     /**
-     * @dev Not supported
+     * @dev Unsupported
      */
     function _abstractSetPToken(address, address) internal pure override {
         revert("Unsupported method");
     }
 
     /**
-     * @dev Approve the spending of all assets
+     * @dev Unsupported
      */
     function safeApproveAllTokens() external pure override {
         // all the amounts are approved at the time required


### PR DESCRIPTION
**OpenZeppelin issue:** 
The following typographical errors and minor formatting issues were found in the RoosterAMOStrategy contract:

[Line 71](https://github.com/OriginProtocol/origin-dollar/blob/2d02162bce99874ef6e0778e94527e375c4ec532/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol#L71): "provider" should be "provide"
[Line 268](https://github.com/OriginProtocol/origin-dollar/blob/2d02162bce99874ef6e0778e94527e375c4ec532/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol#L268): "withing" should be "within"
[Line 971](https://github.com/OriginProtocol/origin-dollar/blob/2d02162bce99874ef6e0778e94527e375c4ec532/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol#L971): "99,8 %" should be "99.8 %"
[Line 986](https://github.com/OriginProtocol/origin-dollar/blob/2d02162bce99874ef6e0778e94527e375c4ec532/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol#L986): "Collect stkAave, convert it to AAVE send to Vault" should be "Collect Rooster reward tokens"
[Line 1129](https://github.com/OriginProtocol/origin-dollar/blob/2d02162bce99874ef6e0778e94527e375c4ec532/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol#L1129): "Approve all tokens" revert message should be updated to "Unsupported" for accuracy
Consider fixing these instances to improve the clarity and consistency of the codebase.