### PR TITLE
N-02 Overly Restrictive Validation

### DIFF
--- a/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol
+++ b/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol
@@ -108,8 +108,8 @@ contract RoosterAMOStrategy is InitializableAbstractStrategy {
     uint256 public immutable sqrtPriceAtParity;
     /// @notice The tick where the strategy deploys the liquidity to
     int32 public constant TICK_NUMBER = -1;
-    /// @notice Minimum liquidity required to continue with the action
-    /// e.g. deposit, add liquidity, burn OETH
+    /// @notice Minimum liquidity that must be exceeded to continue with the action
+    /// e.g. deposit, add liquidity
     uint256 public constant ACTION_THRESHOLD = 1e12;
     /// @notice Maverick pool static liquidity bin type
     uint8 public constant MAV_STATIC_BIN_KIND = 0;
@@ -527,8 +527,8 @@ contract RoosterAMOStrategy is InitializableAbstractStrategy {
             addParam
         );
 
-        require(_maxWETH > WETHRequired, "More WETH required than specified");
-        require(_maxOETH > OETHRequired, "More OETH required than specified");
+        require(_maxWETH >= WETHRequired, "More WETH required than specified");
+        require(_maxOETH >= OETHRequired, "More OETH required than specified");
 
         // organize values to be used by manager
         addParams[0] = addParam;


### PR DESCRIPTION
**OpenZeppelin issue:** 
Throughout the codebase, there are several validation issues that can be corrected:

The NatSpec comment for ACTION_THRESHOLD describes it as the "Minimum liquidity required to continue," which implies the value [1e12 is an inclusive lower bound](https://github.com/OriginProtocol/origin-dollar/blob/2d02162bce99874ef6e0778e94527e375c4ec532/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol#L111-L113) for an action to proceed. However, within the _burnOethOnTheContract function, this threshold [must be exceeded](https://github.com/OriginProtocol/origin-dollar/blob/2d02162bce99874ef6e0778e94527e375c4ec532/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol#L827-L829), making the threshold an exclusive boundary and contradicting the NatSpec comment. Consider updating the NatSpec comment to clarify that the amount must be "greater than" the threshold to align with the code's logic.
The validation checks in _getAddLiquidityParams use a [strict greater-than (>) comparison](https://github.com/OriginProtocol/origin-dollar/blob/2d02162bce99874ef6e0778e94527e375c4ec532/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol#L530-L531) to ensure the calculated required token amounts are less than the maximum available balances. This logic is overly restrictive and will incorrectly cause the transaction to revert in valid scenarios where the required amount is exactly equal to the contract's available balance. To fix this and allow the strategy to correctly deploy its full token balance when necessary, consider changing the comparison operators from > to >=.
Consider fixing these issues to ensure the validations are correctly aligned with intended behavior