### PR TITLE
N-08 Lack of Security Contact

### DIFF
--- a/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol
+++ b/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 /**
  * @title Rooster AMO strategy
  * @author Origin Protocol Inc
+ * @custom:security-contact security@originprotocol.com
  */
 import { Math as MathRooster } from "../../../lib/rooster/v2-common/libraries/Math.sol";
 import { Math as Math_v5 } from "../../../lib/rooster/openzeppelin-custom/contracts/utils/math/Math.sol";


### PR DESCRIPTION
**OpenZeppelin issue:** 
Providing a specific security contact (such as an email or ENS name) within a smart contract significantly simplifies the process for individuals to communicate if they identify a vulnerability in the code. This practice is quite beneficial as it permits the code owners to dictate the communication channel for vulnerability disclosure, eliminating the risk of miscommunication or failure to report due to a lack of knowledge on how to do so. In addition, if the contract incorporates third-party libraries and a bug surfaces in those, it becomes easier for their maintainers to contact the appropriate person about the problem and provide mitigation instructions.

The [RoosterAMOStrategy contract](https://github.com/OriginProtocol/origin-dollar/blob/2d02162bce99874ef6e0778e94527e375c4ec532/contracts/contracts/strategies/plume/RoosterAMOStrategy.sol) does not have a security contact.

Consider adding a NatSpec comment containing a security contact above each contract definition. Using the @custom:security-contact convention is recommended as it has been adopted by the [OpenZeppelin Wizard](https://wizard.openzeppelin.com/) and the [ethereum-lists](https://github.com/ethereum-lists/contracts#tracking-new-deployments)