### PR TITLE
[Base][Automation] Add defender action to automate claiming bribes

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -349,6 +349,7 @@ npx hardhat setActionVars --id 12c153c8-c5ca-420b-9696-e80c827996d1
 npx hardhat setActionVars --id 6e4f764d-4126-45a5-b7d9-1ab90cd3ffd6
 npx hardhat setActionVars --id 84988850-6816-4074-8e7b-c11cb2b32e7e
 npx hardhat setActionVars --id f92ea662-fc34-433b-8beb-b34e9ab74685
+npx hardhat setActionVars --id b1d831f1-29d4-4943-bb2e-8e625b76e82c
 
 # The Defender autotask client uses generic env var names so we'll set them first from the values in the .env file
 export API_KEY=${DEFENDER_TEAM_KEY}
@@ -363,6 +364,7 @@ npx defender-autotask update-code e2929f53-db56-49b2-b054-35f7df7fc4fb ./dist/do
 npx defender-autotask update-code 6e4f764d-4126-45a5-b7d9-1ab90cd3ffd6 ./dist/harvest
 npx defender-autotask update-code 84988850-6816-4074-8e7b-c11cb2b32e7e ./dist/sonicRequestWithdrawal
 npx defender-autotask update-code f92ea662-fc34-433b-8beb-b34e9ab74685 ./dist/sonicClaimWithdrawals
+npx defender-autotask update-code b1d831f1-29d4-4943-bb2e-8e625b76e82c ./dist/claimBribes
 ```
 
 `rollup` and `defender-autotask-client` can be installed globally to avoid the `npx` prefix.

--- a/contracts/scripts/defender-actions/claimBribes.js
+++ b/contracts/scripts/defender-actions/claimBribes.js
@@ -1,0 +1,79 @@
+const { ethers } = require("ethers");
+
+const {
+  DefenderRelaySigner,
+  DefenderRelayProvider,
+} = require("@openzeppelin/defender-relay-client/lib/ethers");
+
+// const addresses = require("../../utils/addresses");
+const { logTxDetails } = require("../../utils/txLogger");
+const log = require("../../utils/logger")("action:claimBribes");
+
+// Claim Bribes module for Coinbase AERO Locker Safe
+const COINBASE_AERO_LOCKER_MODULE =
+  "0x60D3D6eC213d84DEa193dbd79673340061178893";
+
+const MODULE_ABI = [
+  "function getNFTIdsLength() external view returns (uint256)",
+  "function fetchNFTIds() external",
+  "function removeAllNFTIds() external",
+  "function claimBribes(uint256 nftIndexStart, uint256 nftIndexEnd, bool silent) external",
+];
+
+const handler = async (event) => {
+  const provider = new DefenderRelayProvider(event);
+  const signer = new DefenderRelaySigner(event, provider, { speed: "fastest" });
+
+  const network = await provider.getNetwork();
+  if (network.chainId != 8453) {
+    throw new Error("Only supported on Base");
+  }
+
+  const aeroLockerModule = new ethers.Contract(
+    COINBASE_AERO_LOCKER_MODULE,
+    MODULE_ABI,
+    signer
+  );
+
+  log(`Claiming bribes from Coinbase AERO Locker Safe`);
+  await manageNFTsOnModule(aeroLockerModule, signer);
+  await claimBribesFromModule(aeroLockerModule, signer);
+};
+
+async function manageNFTsOnModule(module, signer) {
+  // Remove all NFTs from the module
+  let tx = await module.connect(signer).removeAllNFTIds({
+    gasLimit: 8000000,
+  });
+  logTxDetails(tx, `removeAllNFTIds`);
+
+  // Fetch all NFTs from the veNFT contract
+  tx = await module.connect(signer).fetchNFTIds({
+    gasLimit: 16000000,
+  });
+  logTxDetails(tx, `fetchNFTIds`);
+}
+
+async function claimBribesFromModule(module, signer) {
+  const nftIdsLength = (
+    await module.connect(signer).getNFTIdsLength()
+  ).toNumber();
+  const batchSize = 100;
+  const batchCount = Math.ceil(nftIdsLength / batchSize);
+
+  log(`Found ${nftIdsLength} NFTs on the module`);
+  log(`Claiming bribes in ${batchCount} batches of ${batchSize}`);
+
+  for (let i = 0; i < batchCount; i++) {
+    const start = i * batchSize;
+    const end = Math.min(start + batchSize, nftIdsLength);
+
+    const tx = await module.connect(signer).claimBribes(start, end, true);
+    await logTxDetails(
+      tx,
+      `claimBribes (batch ${i + 1} of ${batchCount})`
+    );
+  }
+}
+
+module.exports = { handler };

--- a/contracts/scripts/defender-actions/claimBribes.js
+++ b/contracts/scripts/defender-actions/claimBribes.js
@@ -69,10 +69,7 @@ async function claimBribesFromModule(module, signer) {
     const end = Math.min(start + batchSize, nftIdsLength);
 
     const tx = await module.connect(signer).claimBribes(start, end, true);
-    await logTxDetails(
-      tx,
-      `claimBribes (batch ${i + 1} of ${batchCount})`
-    );
+    await logTxDetails(tx, `claimBribes (batch ${i + 1} of ${batchCount})`);
   }
 }
 

--- a/contracts/scripts/defender-actions/rollup.config.cjs
+++ b/contracts/scripts/defender-actions/rollup.config.cjs
@@ -104,4 +104,13 @@ module.exports = [
       format: "cjs",
     },
   },
+  {
+    ...commonConfig,
+    input: "claimBribes.js",
+    output: {
+      file: "dist/claimBribes/index.js",
+      inlineDynamicImports: true,
+      format: "cjs",
+    },
+  },
 ];


### PR DESCRIPTION
## Code Change
- Adds a Defender Action script to manage NFTs and claim bribes from the Aero Locker safe. 
- The module was updated in #2553 and deployed with #2554
