### PR TITLE
add task to upload contracts to tenderly

### DIFF
--- a/contracts/dev.env
+++ b/contracts/dev.env
@@ -73,3 +73,6 @@ VALIDATOR_MASTER_ENCRYPTED_PRIVATE_KEY=
 
 # Beaconcha.in API key can be obtained by creating an account
 BEACONCHAIN_API_KEY=
+
+# Tenderly access token required to upload newly deployed and verified contracts to Tenderly
+TENDERLY_ACCESS_TOKEN=

--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -392,7 +392,7 @@ module.exports = {
       holesky: process.env.ETHERSCAN_API_KEY,
       base: process.env.BASESCAN_API_KEY,
       sonic: process.env.SONICSCAN_API_KEY,
-      plume: 'empty', // this works for: npx hardhat verify...
+      plume: "empty", // this works for: npx hardhat verify...
     },
     customChains: [
       {

--- a/contracts/tasks/tasks.js
+++ b/contracts/tasks/tasks.js
@@ -103,6 +103,8 @@ const {
   resolveNativeStakingStrategyProxy,
   snapValidators,
 } = require("./validator");
+
+const { tenderlySync } = require("./tenderly");
 const { setDefaultValidator, snapSonicStaking } = require("../utils/sonic");
 const {
   undelegateValidator,
@@ -1829,3 +1831,11 @@ task("lzSetConfig")
   .setAction(async (taskArgs) => {
     await lzSetConfig(taskArgs, hre);
   });
+
+subtask(
+  "tenderlySync",
+  "Fetches all contracts from deployment descriptors and uploads them to Tenderly if they are not there yet."
+).setAction(tenderlySync);
+task("tenderlySync").setAction(async (_, __, runSuper) => {
+  return runSuper();
+});

--- a/contracts/tasks/tenderly.js
+++ b/contracts/tasks/tenderly.js
@@ -1,0 +1,113 @@
+const fetch = require("node-fetch");
+
+async function tenderlySync(taskArguments, hre) {
+  const allDeployments = await hre.deployments.all();
+  const deployedContracts = Object.entries(allDeployments).map(
+    ([name, deployment]) => ({
+      name,
+      address: deployment.address,
+    })
+  );
+  const chainId = parseInt(
+    (await hre.network.provider.send("eth_chainId")).toString()
+  );
+  const allTenderlyContracts = await fetchAllContractsFromTenderly(chainId);
+
+  for (let i = 0; i < deployedContracts.length; i++) {
+    let presentInTenderly = false;
+    const deployedContract = deployedContracts[i];
+    for (let j = 0; j < allTenderlyContracts.length; j++) {
+      if (
+        deployedContract.address.toLowerCase() ==
+        allTenderlyContracts[j].toLowerCase()
+      ) {
+        presentInTenderly = true;
+      }
+    }
+
+    if (presentInTenderly) {
+      console.log(
+        `✓ contract ${deployedContract.name}[${deployedContract.address}] already detected by Tenderly`
+      );
+      continue;
+    }
+
+    await uploadContractToTenderly(
+      deployedContract.address,
+      deployedContract.name,
+      chainId
+    );
+    console.log(
+      `✅ contract ${deployedContract.name}[${deployedContract.address}] added to Tenderly`
+    );
+  }
+}
+
+async function uploadContractToTenderly(address, name, networkId) {
+  if (!process.env.TENDERLY_ACCESS_TOKEN) {
+    throw new Error("TENDERLY_ACCESS_TOKEN env var missing");
+  }
+
+  const baseUrl = `https://api.tenderly.co/api/v1/account/origin-protocol/project/origin/address`;
+
+  const payload = {
+    network_id: `${networkId}`,
+    address: address,
+    display_name: name,
+  };
+
+  const response = await fetch(baseUrl, {
+    method: "POST",
+    headers: {
+      "X-Access-Key": `${process.env.TENDERLY_ACCESS_TOKEN}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `API request failed with status ${
+        response.status
+      }: ${await response.text()}`
+    );
+  }
+
+  const data = await response.json();
+  return data;
+}
+
+async function fetchAllContractsFromTenderly() {
+  if (!process.env.TENDERLY_ACCESS_TOKEN) {
+    throw new Error("TENDERLY_ACCESS_TOKEN env var missing");
+  }
+
+  const baseUrl = `https://api.tenderly.co/api/v1/account/origin-protocol/project/origin/contracts?accountType=contract`;
+
+  let url = baseUrl;
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      "X-Access-Key": `${process.env.TENDERLY_ACCESS_TOKEN}`,
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `API request failed with status ${
+        response.status
+      }: ${await response.text()}`
+    );
+  }
+
+  const data = await response.json();
+
+  // return the array of contract addresses
+  return data.map((contractData) => contractData.contract.address);
+}
+
+module.exports = {
+  tenderlySync,
+};


### PR DESCRIPTION
Adds a Tenderly task that is relatively easy to run which checks all of the deployed contracts that are present in the deploy descriptors and uploads them to Tenderly if they are not present there yet. 

Example output: 
<img width="1015" height="1083" alt="Screenshot 2025-07-22 at 01 27 49" src="https://github.com/user-attachments/assets/4c6459fb-c9ba-4dd2-aba7-1af017082357" />


