### PR TITLE
Add storage layout assertion for proxies

### DIFF
--- a/contracts/hardhat.config.js
+++ b/contracts/hardhat.config.js
@@ -235,6 +235,11 @@ module.exports = {
     mainnet: {
       url: `${process.env.PROVIDER_URL}`,
       accounts: defaultAccounts,
+      verify: {
+        etherscan: {
+          apiKey: process.env.ETHERSCAN_API_KEY,
+        },
+      },
     },
     holesky: {
       url: holeskyProviderUrl,
@@ -252,6 +257,12 @@ module.exports = {
       // Fails if gas limit is anything less than 20M on Arbitrum One
       gas: 20000000,
       // initialBaseFeePerGas: 0,
+      verify: {
+        etherscan: {
+          apiKey: process.env.ARBISCAN_API_KEY,
+          apiUrl: "https://api.arbiscan.io",
+        },
+      },
     },
     base: {
       url: baseProviderUrl,
@@ -260,6 +271,12 @@ module.exports = {
       tags: ["base"],
       live: true,
       saveDeployments: true,
+      verify: {
+        etherscan: {
+          apiKey: process.env.BASESCAN_API_KEY,
+          apiUrl: "https://api.basescan.org",
+        },
+      },
     },
     sonic: {
       url: sonicProviderUrl,
@@ -268,6 +285,12 @@ module.exports = {
       tags: ["sonic"],
       live: true,
       saveDeployments: true,
+      verify: {
+        etherscan: {
+          apiKey: process.env.SONICSCAN_API_KEY,
+          apiUrl: "https://api.sonicscan.org",
+        },
+      },
     },
     plume: {
       url: plumeProviderUrl,
@@ -276,6 +299,12 @@ module.exports = {
       tags: ["plume"],
       live: true,
       saveDeployments: true,
+      verify: {
+        etherscan: {
+          apiKey: "",
+          apiUrl: "https://explorer.plume.org",
+        },
+      },
     },
   },
   mocha: {
@@ -384,50 +413,6 @@ module.exports = {
   contractSizer: {
     alphaSort: true,
     runOnCompile: process.env.CONTRACT_SIZE ? true : false,
-  },
-  etherscan: {
-    apiKey: {
-      mainnet: process.env.ETHERSCAN_API_KEY,
-      arbitrumOne: process.env.ARBISCAN_API_KEY,
-      holesky: process.env.ETHERSCAN_API_KEY,
-      base: process.env.BASESCAN_API_KEY,
-      sonic: process.env.SONICSCAN_API_KEY,
-      plume: 'empty', // this works for: npx hardhat verify...
-    },
-    customChains: [
-      {
-        network: "holesky",
-        chainId: 17000,
-        urls: {
-          apiURL: "https://api-holesky.etherscan.io/api",
-          browserURL: "https://holesky.etherscan.io",
-        },
-      },
-      {
-        network: "base",
-        chainId: 8453,
-        urls: {
-          apiURL: "https://api.basescan.org/api",
-          browserURL: "https://basescan.org",
-        },
-      },
-      {
-        network: "sonic",
-        chainId: 146,
-        urls: {
-          apiURL: "https://api.sonicscan.org/api",
-          browserURL: "https://sonicscan.org",
-        },
-      },
-      {
-        network: "plume",
-        chainId: 98866,
-        urls: {
-          apiURL: "https://explorer.plume.org/api",
-          browserURL: "https://explorer.plume.org",
-        },
-      },
-    ],
   },
   gasReporter: {
     enabled: process.env.REPORT_GAS ? true : false,

--- a/contracts/storageLayout/arbitrumOne/BridgedWOETHProxy-impl.json
+++ b/contracts/storageLayout/arbitrumOne/BridgedWOETHProxy-impl.json
@@ -1,0 +1,187 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "_roles",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_mapping(t_bytes32,t_struct(RoleData)5668_storage)",
+      "contract": "AccessControl",
+      "src": "@openzeppelin/contracts/access/AccessControl.sol:55"
+    },
+    {
+      "label": "_roleMembers",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_mapping(t_bytes32,t_struct(AddressSet)8931_storage)",
+      "contract": "AccessControlEnumerable",
+      "src": "@openzeppelin/contracts/access/AccessControlEnumerable.sol:16"
+    },
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "2",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "2",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "3",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_balances",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:36"
+    },
+    {
+      "label": "_allowances",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:38"
+    },
+    {
+      "label": "_totalSupply",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_uint256",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:40"
+    },
+    {
+      "label": "_name",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_string_storage",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:42"
+    },
+    {
+      "label": "_symbol",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_string_storage",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:43"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_bytes32)dyn_storage": {
+      "label": "bytes32[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_bytes32": {
+      "label": "bytes32",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_bool)": {
+      "label": "mapping(address => bool)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+      "label": "mapping(address => mapping(address => uint256))",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_uint256)": {
+      "label": "mapping(address => uint256)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_bytes32,t_struct(AddressSet)8931_storage)": {
+      "label": "mapping(bytes32 => struct EnumerableSet.AddressSet)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_bytes32,t_struct(RoleData)5668_storage)": {
+      "label": "mapping(bytes32 => struct AccessControl.RoleData)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_bytes32,t_uint256)": {
+      "label": "mapping(bytes32 => uint256)",
+      "numberOfBytes": "32"
+    },
+    "t_string_storage": {
+      "label": "string",
+      "numberOfBytes": "32"
+    },
+    "t_struct(AddressSet)8931_storage": {
+      "label": "struct EnumerableSet.AddressSet",
+      "members": [
+        {
+          "label": "_inner",
+          "type": "t_struct(Set)8630_storage",
+          "offset": 0,
+          "slot": "0"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(RoleData)5668_storage": {
+      "label": "struct AccessControl.RoleData",
+      "members": [
+        {
+          "label": "members",
+          "type": "t_mapping(t_address,t_bool)",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "adminRole",
+          "type": "t_bytes32",
+          "offset": 0,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(Set)8630_storage": {
+      "label": "struct EnumerableSet.Set",
+      "members": [
+        {
+          "label": "_values",
+          "type": "t_array(t_bytes32)dyn_storage",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "_indexes",
+          "type": "t_mapping(t_bytes32,t_uint256)",
+          "offset": 0,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/base/AerodromeAMOStrategyProxy-impl.json
+++ b/contracts/storageLayout/base/AerodromeAMOStrategyProxy-impl.json
@@ -1,0 +1,179 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "tokenId",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_uint256",
+      "contract": "AerodromeAMOStrategy",
+      "src": "contracts/strategies/aerodrome/AerodromeAMOStrategy.sol:45"
+    },
+    {
+      "label": "underlyingAssets",
+      "offset": 0,
+      "slot": "158",
+      "type": "t_uint256",
+      "contract": "AerodromeAMOStrategy",
+      "src": "contracts/strategies/aerodrome/AerodromeAMOStrategy.sol:48"
+    },
+    {
+      "label": "allowedWethShareStart",
+      "offset": 0,
+      "slot": "159",
+      "type": "t_uint256",
+      "contract": "AerodromeAMOStrategy",
+      "src": "contracts/strategies/aerodrome/AerodromeAMOStrategy.sol:51"
+    },
+    {
+      "label": "allowedWethShareEnd",
+      "offset": 0,
+      "slot": "160",
+      "type": "t_uint256",
+      "contract": "AerodromeAMOStrategy",
+      "src": "contracts/strategies/aerodrome/AerodromeAMOStrategy.sol:54"
+    },
+    {
+      "label": "__reserved",
+      "offset": 0,
+      "slot": "161",
+      "type": "t_array(t_int256)46_storage",
+      "contract": "AerodromeAMOStrategy",
+      "src": "contracts/strategies/aerodrome/AerodromeAMOStrategy.sol:56"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)46_storage": {
+      "label": "int256[46]",
+      "numberOfBytes": "1472"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/base/BridgedBaseWOETHProxy-impl.json
+++ b/contracts/storageLayout/base/BridgedBaseWOETHProxy-impl.json
@@ -1,0 +1,187 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "_roles",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_mapping(t_bytes32,t_struct(RoleData)5668_storage)",
+      "contract": "AccessControl",
+      "src": "@openzeppelin/contracts/access/AccessControl.sol:55"
+    },
+    {
+      "label": "_roleMembers",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_mapping(t_bytes32,t_struct(AddressSet)8931_storage)",
+      "contract": "AccessControlEnumerable",
+      "src": "@openzeppelin/contracts/access/AccessControlEnumerable.sol:16"
+    },
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "2",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "2",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "3",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_balances",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:36"
+    },
+    {
+      "label": "_allowances",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:38"
+    },
+    {
+      "label": "_totalSupply",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_uint256",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:40"
+    },
+    {
+      "label": "_name",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_string_storage",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:42"
+    },
+    {
+      "label": "_symbol",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_string_storage",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:43"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_bytes32)dyn_storage": {
+      "label": "bytes32[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_bytes32": {
+      "label": "bytes32",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_bool)": {
+      "label": "mapping(address => bool)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+      "label": "mapping(address => mapping(address => uint256))",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_uint256)": {
+      "label": "mapping(address => uint256)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_bytes32,t_struct(AddressSet)8931_storage)": {
+      "label": "mapping(bytes32 => struct EnumerableSet.AddressSet)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_bytes32,t_struct(RoleData)5668_storage)": {
+      "label": "mapping(bytes32 => struct AccessControl.RoleData)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_bytes32,t_uint256)": {
+      "label": "mapping(bytes32 => uint256)",
+      "numberOfBytes": "32"
+    },
+    "t_string_storage": {
+      "label": "string",
+      "numberOfBytes": "32"
+    },
+    "t_struct(AddressSet)8931_storage": {
+      "label": "struct EnumerableSet.AddressSet",
+      "members": [
+        {
+          "label": "_inner",
+          "type": "t_struct(Set)8630_storage",
+          "offset": 0,
+          "slot": "0"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(RoleData)5668_storage": {
+      "label": "struct AccessControl.RoleData",
+      "members": [
+        {
+          "label": "members",
+          "type": "t_mapping(t_address,t_bool)",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "adminRole",
+          "type": "t_bytes32",
+          "offset": 0,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(Set)8630_storage": {
+      "label": "struct EnumerableSet.Set",
+      "members": [
+        {
+          "label": "_values",
+          "type": "t_array(t_bytes32)dyn_storage",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "_indexes",
+          "type": "t_mapping(t_bytes32,t_uint256)",
+          "offset": 0,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/base/BridgedWOETHStrategyProxy-impl.json
+++ b/contracts/storageLayout/base/BridgedWOETHStrategyProxy-impl.json
@@ -1,0 +1,155 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "lastOraclePrice",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_uint128",
+      "contract": "BridgedWOETHStrategy",
+      "src": "contracts/strategies/BridgedWOETHStrategy.sol:27"
+    },
+    {
+      "label": "maxPriceDiffBps",
+      "offset": 16,
+      "slot": "157",
+      "type": "t_uint128",
+      "contract": "BridgedWOETHStrategy",
+      "src": "contracts/strategies/BridgedWOETHStrategy.sol:28"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_uint128": {
+      "label": "uint128",
+      "numberOfBytes": "16"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/base/OETHBaseCurveAMOProxy-impl.json
+++ b/contracts/storageLayout/base/OETHBaseCurveAMOProxy-impl.json
@@ -1,0 +1,143 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "maxSlippage",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_uint256",
+      "contract": "BaseCurveAMOStrategy",
+      "src": "contracts/strategies/BaseCurveAMOStrategy.sol:69"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/base/OETHBaseDripperProxy-impl.json
+++ b/contracts/storageLayout/base/OETHBaseDripperProxy-impl.json
@@ -1,0 +1,53 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "dripDuration",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_uint256",
+      "contract": "Dripper",
+      "src": "contracts/harvest/Dripper.sol:57"
+    },
+    {
+      "label": "drip",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_struct(Drip)13710_storage",
+      "contract": "Dripper",
+      "src": "contracts/harvest/Dripper.sol:58"
+    }
+  ],
+  "types": {
+    "t_struct(Drip)13710_storage": {
+      "label": "struct Dripper.Drip",
+      "members": [
+        {
+          "label": "lastCollect",
+          "type": "t_uint64",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "perSecond",
+          "type": "t_uint192",
+          "offset": 8,
+          "slot": "0"
+        }
+      ],
+      "numberOfBytes": "32"
+    },
+    "t_uint192": {
+      "label": "uint192",
+      "numberOfBytes": "24"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    },
+    "t_uint64": {
+      "label": "uint64",
+      "numberOfBytes": "8"
+    }
+  }
+}

--- a/contracts/storageLayout/base/OETHBaseHarvesterProxy-impl.json
+++ b/contracts/storageLayout/base/OETHBaseHarvesterProxy-impl.json
@@ -1,0 +1,95 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "strategistAddr",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "Strategizable",
+      "src": "contracts/governance/Strategizable.sol:10"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Strategizable",
+      "src": "contracts/governance/Strategizable.sol:13"
+    },
+    {
+      "label": "dripper",
+      "offset": 0,
+      "slot": "102",
+      "type": "t_address",
+      "contract": "OETHHarvesterSimple",
+      "src": "contracts/harvest/OETHHarvesterSimple.sol:26"
+    },
+    {
+      "label": "supportedStrategies",
+      "offset": 0,
+      "slot": "103",
+      "type": "t_mapping(t_address,t_bool)",
+      "contract": "OETHHarvesterSimple",
+      "src": "contracts/harvest/OETHHarvesterSimple.sol:29"
+    },
+    {
+      "label": "___gap",
+      "offset": 0,
+      "slot": "104",
+      "type": "t_array(t_uint256)48_storage",
+      "contract": "OETHHarvesterSimple",
+      "src": "contracts/harvest/OETHHarvesterSimple.sol:32"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_uint256)48_storage": {
+      "label": "uint256[48]",
+      "numberOfBytes": "1536"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_mapping(t_address,t_bool)": {
+      "label": "mapping(address => bool)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/base/OETHBaseProxy-impl.json
+++ b/contracts/storageLayout/base/OETHBaseProxy-impl.json
@@ -1,0 +1,162 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "_gap",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_array(t_uint256)154_storage",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:69"
+    },
+    {
+      "label": "totalSupply",
+      "offset": 0,
+      "slot": "154",
+      "type": "t_uint256",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:72"
+    },
+    {
+      "label": "allowances",
+      "offset": 0,
+      "slot": "155",
+      "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:73"
+    },
+    {
+      "label": "vaultAddress",
+      "offset": 0,
+      "slot": "156",
+      "type": "t_address",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:76"
+    },
+    {
+      "label": "creditBalances",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:77"
+    },
+    {
+      "label": "rebasingCredits_",
+      "offset": 0,
+      "slot": "158",
+      "type": "t_uint256",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:79"
+    },
+    {
+      "label": "rebasingCreditsPerToken_",
+      "offset": 0,
+      "slot": "159",
+      "type": "t_uint256",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:80"
+    },
+    {
+      "label": "nonRebasingSupply",
+      "offset": 0,
+      "slot": "160",
+      "type": "t_uint256",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:82"
+    },
+    {
+      "label": "alternativeCreditsPerToken",
+      "offset": 0,
+      "slot": "161",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:83"
+    },
+    {
+      "label": "rebaseState",
+      "offset": 0,
+      "slot": "162",
+      "type": "t_mapping(t_address,t_enum(RebaseOptions)47335)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:85"
+    },
+    {
+      "label": "__deprecated_isUpgraded",
+      "offset": 0,
+      "slot": "163",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:86"
+    },
+    {
+      "label": "yieldTo",
+      "offset": 0,
+      "slot": "164",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:91"
+    },
+    {
+      "label": "yieldFrom",
+      "offset": 0,
+      "slot": "165",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:96"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "166",
+      "type": "t_array(t_uint256)34_storage",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:99"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_uint256)154_storage": {
+      "label": "uint256[154]",
+      "numberOfBytes": "4928"
+    },
+    "t_array(t_uint256)34_storage": {
+      "label": "uint256[34]",
+      "numberOfBytes": "1088"
+    },
+    "t_enum(RebaseOptions)47335": {
+      "label": "enum OUSD.RebaseOptions",
+      "members": [
+        "NotSet",
+        "StdNonRebasing",
+        "StdRebasing",
+        "YieldDelegationSource",
+        "YieldDelegationTarget"
+      ],
+      "numberOfBytes": "1"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_enum(RebaseOptions)47335)": {
+      "label": "mapping(address => enum OUSD.RebaseOptions)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+      "label": "mapping(address => mapping(address => uint256))",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_uint256)": {
+      "label": "mapping(address => uint256)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/base/OETHBaseVaultProxy-impl.json
+++ b/contracts/storageLayout/base/OETHBaseVaultProxy-impl.json
@@ -1,0 +1,531 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "assets",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_mapping(t_address,t_struct(Asset)57206_storage)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:99"
+    },
+    {
+      "label": "allAssets",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:101"
+    },
+    {
+      "label": "strategies",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_struct(Strategy)57221_storage)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:109"
+    },
+    {
+      "label": "allStrategies",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:111"
+    },
+    {
+      "label": "priceProvider",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:114"
+    },
+    {
+      "label": "rebasePaused",
+      "offset": 20,
+      "slot": "55",
+      "type": "t_bool",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:116"
+    },
+    {
+      "label": "capitalPaused",
+      "offset": 21,
+      "slot": "55",
+      "type": "t_bool",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:119"
+    },
+    {
+      "label": "redeemFeeBps",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:121"
+    },
+    {
+      "label": "vaultBuffer",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:123"
+    },
+    {
+      "label": "autoAllocateThreshold",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:125"
+    },
+    {
+      "label": "rebaseThreshold",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:127"
+    },
+    {
+      "label": "oUSD",
+      "offset": 0,
+      "slot": "60",
+      "type": "t_contract(OUSD)48948",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:130"
+    },
+    {
+      "label": "_deprecated_rebaseHooksAddr",
+      "offset": 0,
+      "slot": "61",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:138"
+    },
+    {
+      "label": "_deprecated_uniswapAddr",
+      "offset": 0,
+      "slot": "62",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:141"
+    },
+    {
+      "label": "strategistAddr",
+      "offset": 0,
+      "slot": "63",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:144"
+    },
+    {
+      "label": "assetDefaultStrategies",
+      "offset": 0,
+      "slot": "64",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:148"
+    },
+    {
+      "label": "maxSupplyDiff",
+      "offset": 0,
+      "slot": "65",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:151"
+    },
+    {
+      "label": "trusteeAddress",
+      "offset": 0,
+      "slot": "66",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:154"
+    },
+    {
+      "label": "trusteeFeeBps",
+      "offset": 0,
+      "slot": "67",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:157"
+    },
+    {
+      "label": "_deprecated_swapTokens",
+      "offset": 0,
+      "slot": "68",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:160"
+    },
+    {
+      "label": "ousdMetaStrategy",
+      "offset": 0,
+      "slot": "69",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:166"
+    },
+    {
+      "label": "netOusdMintedForStrategy",
+      "offset": 0,
+      "slot": "70",
+      "type": "t_int256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:169"
+    },
+    {
+      "label": "netOusdMintForStrategyThreshold",
+      "offset": 0,
+      "slot": "71",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:172"
+    },
+    {
+      "label": "swapConfig",
+      "offset": 0,
+      "slot": "72",
+      "type": "t_struct(SwapConfig)57323_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:186"
+    },
+    {
+      "label": "isMintWhitelistedStrategy",
+      "offset": 0,
+      "slot": "73",
+      "type": "t_mapping(t_address,t_bool)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:190"
+    },
+    {
+      "label": "dripper",
+      "offset": 0,
+      "slot": "74",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:194"
+    },
+    {
+      "label": "withdrawalQueueMetadata",
+      "offset": 0,
+      "slot": "75",
+      "type": "t_struct(WithdrawalQueueMetadata)57350_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:214"
+    },
+    {
+      "label": "withdrawalRequests",
+      "offset": 0,
+      "slot": "77",
+      "type": "t_mapping(t_uint256,t_struct(WithdrawalRequest)57365_storage)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:228"
+    },
+    {
+      "label": "withdrawalClaimDelay",
+      "offset": 0,
+      "slot": "78",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:233"
+    },
+    {
+      "label": "lastRebase",
+      "offset": 0,
+      "slot": "79",
+      "type": "t_uint64",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:236"
+    },
+    {
+      "label": "dripDuration",
+      "offset": 8,
+      "slot": "79",
+      "type": "t_uint64",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:239"
+    },
+    {
+      "label": "rebasePerSecondMax",
+      "offset": 16,
+      "slot": "79",
+      "type": "t_uint64",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:244"
+    },
+    {
+      "label": "rebasePerSecondTarget",
+      "offset": 24,
+      "slot": "79",
+      "type": "t_uint64",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:247"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "80",
+      "type": "t_array(t_uint256)43_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:254"
+    },
+    {
+      "label": "wethAssetIndex",
+      "offset": 0,
+      "slot": "123",
+      "type": "t_uint256",
+      "contract": "OETHVaultCore",
+      "src": "contracts/vault/OETHVaultCore.sol:22"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "124",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "OETHVaultCore",
+      "src": "contracts/vault/OETHVaultCore.sol:25"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_uint256)43_storage": {
+      "label": "uint256[43]",
+      "numberOfBytes": "1376"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_contract(OUSD)48948": {
+      "label": "contract OUSD",
+      "numberOfBytes": "20"
+    },
+    "t_enum(UnitConversion)57196": {
+      "label": "enum VaultStorage.UnitConversion",
+      "members": [
+        "DECIMALS",
+        "GETEXCHANGERATE"
+      ],
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_bool)": {
+      "label": "mapping(address => bool)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_struct(Asset)57206_storage)": {
+      "label": "mapping(address => struct VaultStorage.Asset)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_struct(Strategy)57221_storage)": {
+      "label": "mapping(address => struct VaultStorage.Strategy)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_uint256,t_struct(WithdrawalRequest)57365_storage)": {
+      "label": "mapping(uint256 => struct VaultStorage.WithdrawalRequest)",
+      "numberOfBytes": "32"
+    },
+    "t_struct(Asset)57206_storage": {
+      "label": "struct VaultStorage.Asset",
+      "members": [
+        {
+          "label": "isSupported",
+          "type": "t_bool",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "unitConversion",
+          "type": "t_enum(UnitConversion)57196",
+          "offset": 1,
+          "slot": "0"
+        },
+        {
+          "label": "decimals",
+          "type": "t_uint8",
+          "offset": 2,
+          "slot": "0"
+        },
+        {
+          "label": "allowedOracleSlippageBps",
+          "type": "t_uint16",
+          "offset": 3,
+          "slot": "0"
+        }
+      ],
+      "numberOfBytes": "32"
+    },
+    "t_struct(Strategy)57221_storage": {
+      "label": "struct VaultStorage.Strategy",
+      "members": [
+        {
+          "label": "isSupported",
+          "type": "t_bool",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "_deprecated",
+          "type": "t_uint256",
+          "offset": 0,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(SwapConfig)57323_storage": {
+      "label": "struct VaultStorage.SwapConfig",
+      "members": [
+        {
+          "label": "swapper",
+          "type": "t_address",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "allowedUndervalueBps",
+          "type": "t_uint16",
+          "offset": 20,
+          "slot": "0"
+        }
+      ],
+      "numberOfBytes": "32"
+    },
+    "t_struct(WithdrawalQueueMetadata)57350_storage": {
+      "label": "struct VaultStorage.WithdrawalQueueMetadata",
+      "members": [
+        {
+          "label": "queued",
+          "type": "t_uint128",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "claimable",
+          "type": "t_uint128",
+          "offset": 16,
+          "slot": "0"
+        },
+        {
+          "label": "claimed",
+          "type": "t_uint128",
+          "offset": 0,
+          "slot": "1"
+        },
+        {
+          "label": "nextWithdrawalIndex",
+          "type": "t_uint128",
+          "offset": 16,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(WithdrawalRequest)57365_storage": {
+      "label": "struct VaultStorage.WithdrawalRequest",
+      "members": [
+        {
+          "label": "withdrawer",
+          "type": "t_address",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "claimed",
+          "type": "t_bool",
+          "offset": 20,
+          "slot": "0"
+        },
+        {
+          "label": "timestamp",
+          "type": "t_uint40",
+          "offset": 21,
+          "slot": "0"
+        },
+        {
+          "label": "amount",
+          "type": "t_uint128",
+          "offset": 0,
+          "slot": "1"
+        },
+        {
+          "label": "queued",
+          "type": "t_uint128",
+          "offset": 16,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_uint128": {
+      "label": "uint128",
+      "numberOfBytes": "16"
+    },
+    "t_uint16": {
+      "label": "uint16",
+      "numberOfBytes": "2"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    },
+    "t_uint40": {
+      "label": "uint40",
+      "numberOfBytes": "5"
+    },
+    "t_uint64": {
+      "label": "uint64",
+      "numberOfBytes": "8"
+    },
+    "t_uint8": {
+      "label": "uint8",
+      "numberOfBytes": "1"
+    }
+  }
+}

--- a/contracts/storageLayout/base/WOETHBaseProxy-impl.json
+++ b/contracts/storageLayout/base/WOETHBaseProxy-impl.json
@@ -1,0 +1,119 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "_balances",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:36"
+    },
+    {
+      "label": "_allowances",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:38"
+    },
+    {
+      "label": "_totalSupply",
+      "offset": 0,
+      "slot": "2",
+      "type": "t_uint256",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:40"
+    },
+    {
+      "label": "_name",
+      "offset": 0,
+      "slot": "3",
+      "type": "t_string_storage",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:42"
+    },
+    {
+      "label": "_symbol",
+      "offset": 0,
+      "slot": "4",
+      "type": "t_string_storage",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:43"
+    },
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "5",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "5",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "6",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "adjuster",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "WOETH",
+      "src": "contracts/token/WOETH.sol:41"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_array(t_uint256)49_storage",
+      "contract": "WOETH",
+      "src": "contracts/token/WOETH.sol:42"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_uint256)49_storage": {
+      "label": "uint256[49]",
+      "numberOfBytes": "1568"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+      "label": "mapping(address => mapping(address => uint256))",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_uint256)": {
+      "label": "mapping(address => uint256)",
+      "numberOfBytes": "32"
+    },
+    "t_string_storage": {
+      "label": "string",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/ARMBuybackProxy-impl.json
+++ b/contracts/storageLayout/mainnet/ARMBuybackProxy-impl.json
@@ -1,0 +1,151 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "strategistAddr",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "Strategizable",
+      "src": "contracts/governance/Strategizable.sol:10"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Strategizable",
+      "src": "contracts/governance/Strategizable.sol:13"
+    },
+    {
+      "label": "swapRouter",
+      "offset": 0,
+      "slot": "102",
+      "type": "t_address",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:31"
+    },
+    {
+      "label": "__deprecated_ousd",
+      "offset": 0,
+      "slot": "103",
+      "type": "t_address",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:34"
+    },
+    {
+      "label": "__deprecated_ogv",
+      "offset": 0,
+      "slot": "104",
+      "type": "t_address",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:36"
+    },
+    {
+      "label": "__deprecated_usdt",
+      "offset": 0,
+      "slot": "105",
+      "type": "t_address",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:38"
+    },
+    {
+      "label": "__deprecated_weth9",
+      "offset": 0,
+      "slot": "106",
+      "type": "t_address",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:40"
+    },
+    {
+      "label": "rewardsSource",
+      "offset": 0,
+      "slot": "107",
+      "type": "t_address",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:43"
+    },
+    {
+      "label": "treasuryManager",
+      "offset": 0,
+      "slot": "108",
+      "type": "t_address",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:46"
+    },
+    {
+      "label": "__deprecated_treasuryBps",
+      "offset": 0,
+      "slot": "109",
+      "type": "t_uint256",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:49"
+    },
+    {
+      "label": "balanceForOGN",
+      "offset": 0,
+      "slot": "110",
+      "type": "t_uint256",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:57"
+    },
+    {
+      "label": "balanceForCVX",
+      "offset": 0,
+      "slot": "111",
+      "type": "t_uint256",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:60"
+    },
+    {
+      "label": "cvxShareBps",
+      "offset": 0,
+      "slot": "112",
+      "type": "t_uint256",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:63"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/AaveStrategyProxy-impl.json
+++ b/contracts/storageLayout/mainnet/AaveStrategyProxy-impl.json
@@ -1,0 +1,159 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "incentivesController",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_contract(IAaveIncentivesController)34067",
+      "contract": "AaveStrategy",
+      "src": "contracts/strategies/AaveStrategy.sol:22"
+    },
+    {
+      "label": "stkAave",
+      "offset": 0,
+      "slot": "158",
+      "type": "t_contract(IAaveStakedToken)34104",
+      "contract": "AaveStrategy",
+      "src": "contracts/strategies/AaveStrategy.sol:23"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_contract(IAaveIncentivesController)34067": {
+      "label": "contract IAaveIncentivesController",
+      "numberOfBytes": "20"
+    },
+    "t_contract(IAaveStakedToken)34104": {
+      "label": "contract IAaveStakedToken",
+      "numberOfBytes": "20"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/BuybackProxy-impl.json
+++ b/contracts/storageLayout/mainnet/BuybackProxy-impl.json
@@ -1,0 +1,151 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "strategistAddr",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "Strategizable",
+      "src": "contracts/governance/Strategizable.sol:10"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Strategizable",
+      "src": "contracts/governance/Strategizable.sol:13"
+    },
+    {
+      "label": "swapRouter",
+      "offset": 0,
+      "slot": "102",
+      "type": "t_address",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:31"
+    },
+    {
+      "label": "__deprecated_ousd",
+      "offset": 0,
+      "slot": "103",
+      "type": "t_address",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:34"
+    },
+    {
+      "label": "__deprecated_ogv",
+      "offset": 0,
+      "slot": "104",
+      "type": "t_address",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:36"
+    },
+    {
+      "label": "__deprecated_usdt",
+      "offset": 0,
+      "slot": "105",
+      "type": "t_address",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:38"
+    },
+    {
+      "label": "__deprecated_weth9",
+      "offset": 0,
+      "slot": "106",
+      "type": "t_address",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:40"
+    },
+    {
+      "label": "rewardsSource",
+      "offset": 0,
+      "slot": "107",
+      "type": "t_address",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:43"
+    },
+    {
+      "label": "treasuryManager",
+      "offset": 0,
+      "slot": "108",
+      "type": "t_address",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:46"
+    },
+    {
+      "label": "__deprecated_treasuryBps",
+      "offset": 0,
+      "slot": "109",
+      "type": "t_uint256",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:49"
+    },
+    {
+      "label": "balanceForOGN",
+      "offset": 0,
+      "slot": "110",
+      "type": "t_uint256",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:57"
+    },
+    {
+      "label": "balanceForCVX",
+      "offset": 0,
+      "slot": "111",
+      "type": "t_uint256",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:60"
+    },
+    {
+      "label": "cvxShareBps",
+      "offset": 0,
+      "slot": "112",
+      "type": "t_uint256",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:63"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/CompoundStrategyProxy-impl.json
+++ b/contracts/storageLayout/mainnet/CompoundStrategyProxy-impl.json
@@ -1,0 +1,147 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "__reserved",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_array(t_int256)50_storage",
+      "contract": "AbstractCompoundStrategy",
+      "src": "contracts/strategies/AbstractCompoundStrategy.sol:17"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)50_storage": {
+      "label": "int256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/ConvexEthMetaStrategyProxy-impl.json
+++ b/contracts/storageLayout/mainnet/ConvexEthMetaStrategyProxy-impl.json
@@ -1,0 +1,211 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "_deprecated_cvxDepositorAddress",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_address",
+      "contract": "ConvexEthMetaStrategy",
+      "src": "contracts/strategies/ConvexEthMetaStrategy.sol:30"
+    },
+    {
+      "label": "_deprecated_cvxRewardStaker",
+      "offset": 0,
+      "slot": "158",
+      "type": "t_address",
+      "contract": "ConvexEthMetaStrategy",
+      "src": "contracts/strategies/ConvexEthMetaStrategy.sol:32"
+    },
+    {
+      "label": "_deprecated_cvxDepositorPTokenId",
+      "offset": 0,
+      "slot": "159",
+      "type": "t_uint256",
+      "contract": "ConvexEthMetaStrategy",
+      "src": "contracts/strategies/ConvexEthMetaStrategy.sol:34"
+    },
+    {
+      "label": "_deprecated_curvePool",
+      "offset": 0,
+      "slot": "160",
+      "type": "t_address",
+      "contract": "ConvexEthMetaStrategy",
+      "src": "contracts/strategies/ConvexEthMetaStrategy.sol:36"
+    },
+    {
+      "label": "_deprecated_lpToken",
+      "offset": 0,
+      "slot": "161",
+      "type": "t_address",
+      "contract": "ConvexEthMetaStrategy",
+      "src": "contracts/strategies/ConvexEthMetaStrategy.sol:38"
+    },
+    {
+      "label": "_deprecated_oeth",
+      "offset": 0,
+      "slot": "162",
+      "type": "t_address",
+      "contract": "ConvexEthMetaStrategy",
+      "src": "contracts/strategies/ConvexEthMetaStrategy.sol:40"
+    },
+    {
+      "label": "_deprecated_weth",
+      "offset": 0,
+      "slot": "163",
+      "type": "t_address",
+      "contract": "ConvexEthMetaStrategy",
+      "src": "contracts/strategies/ConvexEthMetaStrategy.sol:42"
+    },
+    {
+      "label": "_deprecated_oethCoinIndex",
+      "offset": 0,
+      "slot": "164",
+      "type": "t_uint128",
+      "contract": "ConvexEthMetaStrategy",
+      "src": "contracts/strategies/ConvexEthMetaStrategy.sol:46"
+    },
+    {
+      "label": "_deprecated_ethCoinIndex",
+      "offset": 16,
+      "slot": "164",
+      "type": "t_uint128",
+      "contract": "ConvexEthMetaStrategy",
+      "src": "contracts/strategies/ConvexEthMetaStrategy.sol:48"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_uint128": {
+      "label": "uint128",
+      "numberOfBytes": "16"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/ConvexLUSDMetaStrategyProxy-impl.json
+++ b/contracts/storageLayout/mainnet/ConvexLUSDMetaStrategyProxy-impl.json
@@ -1,0 +1,259 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "pTokenAddress",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_address",
+      "contract": "AbstractCurveStrategy",
+      "src": "contracts/strategies/AbstractCurveStrategy.sol:23"
+    },
+    {
+      "label": "__reserved",
+      "offset": 0,
+      "slot": "158",
+      "type": "t_array(t_int256)49_storage",
+      "contract": "AbstractCurveStrategy",
+      "src": "contracts/strategies/AbstractCurveStrategy.sol:25"
+    },
+    {
+      "label": "cvxDepositorAddress",
+      "offset": 0,
+      "slot": "207",
+      "type": "t_address",
+      "contract": "AbstractConvexMetaStrategy",
+      "src": "contracts/strategies/AbstractConvexMetaStrategy.sol:37"
+    },
+    {
+      "label": "cvxRewardStakerAddress",
+      "offset": 0,
+      "slot": "208",
+      "type": "t_address",
+      "contract": "AbstractConvexMetaStrategy",
+      "src": "contracts/strategies/AbstractConvexMetaStrategy.sol:38"
+    },
+    {
+      "label": "cvxDepositorPTokenId",
+      "offset": 0,
+      "slot": "209",
+      "type": "t_uint256",
+      "contract": "AbstractConvexMetaStrategy",
+      "src": "contracts/strategies/AbstractConvexMetaStrategy.sol:39"
+    },
+    {
+      "label": "metapool",
+      "offset": 0,
+      "slot": "210",
+      "type": "t_contract(ICurveMetaPool)34840",
+      "contract": "AbstractConvexMetaStrategy",
+      "src": "contracts/strategies/AbstractConvexMetaStrategy.sol:40"
+    },
+    {
+      "label": "metapoolMainToken",
+      "offset": 0,
+      "slot": "211",
+      "type": "t_contract(IERC20)4200",
+      "contract": "AbstractConvexMetaStrategy",
+      "src": "contracts/strategies/AbstractConvexMetaStrategy.sol:41"
+    },
+    {
+      "label": "metapoolLPToken",
+      "offset": 0,
+      "slot": "212",
+      "type": "t_contract(IERC20)4200",
+      "contract": "AbstractConvexMetaStrategy",
+      "src": "contracts/strategies/AbstractConvexMetaStrategy.sol:42"
+    },
+    {
+      "label": "metapoolAssets",
+      "offset": 0,
+      "slot": "213",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "AbstractConvexMetaStrategy",
+      "src": "contracts/strategies/AbstractConvexMetaStrategy.sol:44"
+    },
+    {
+      "label": "maxWithdrawalSlippage",
+      "offset": 0,
+      "slot": "214",
+      "type": "t_uint256",
+      "contract": "AbstractConvexMetaStrategy",
+      "src": "contracts/strategies/AbstractConvexMetaStrategy.sol:46"
+    },
+    {
+      "label": "crvCoinIndex",
+      "offset": 0,
+      "slot": "215",
+      "type": "t_uint128",
+      "contract": "AbstractConvexMetaStrategy",
+      "src": "contracts/strategies/AbstractConvexMetaStrategy.sol:47"
+    },
+    {
+      "label": "mainCoinIndex",
+      "offset": 16,
+      "slot": "215",
+      "type": "t_uint128",
+      "contract": "AbstractConvexMetaStrategy",
+      "src": "contracts/strategies/AbstractConvexMetaStrategy.sol:48"
+    },
+    {
+      "label": "___reserved",
+      "offset": 0,
+      "slot": "216",
+      "type": "t_array(t_int256)41_storage",
+      "contract": "AbstractConvexMetaStrategy",
+      "src": "contracts/strategies/AbstractConvexMetaStrategy.sol:50"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)41_storage": {
+      "label": "int256[41]",
+      "numberOfBytes": "1312"
+    },
+    "t_array(t_int256)49_storage": {
+      "label": "int256[49]",
+      "numberOfBytes": "1568"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_contract(ICurveMetaPool)34840": {
+      "label": "contract ICurveMetaPool",
+      "numberOfBytes": "20"
+    },
+    "t_contract(IERC20)4200": {
+      "label": "contract IERC20",
+      "numberOfBytes": "20"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_uint128": {
+      "label": "uint128",
+      "numberOfBytes": "16"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/ConvexOUSDMetaStrategyProxy-impl.json
+++ b/contracts/storageLayout/mainnet/ConvexOUSDMetaStrategyProxy-impl.json
@@ -1,0 +1,259 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "pTokenAddress",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_address",
+      "contract": "AbstractCurveStrategy",
+      "src": "contracts/strategies/AbstractCurveStrategy.sol:23"
+    },
+    {
+      "label": "__reserved",
+      "offset": 0,
+      "slot": "158",
+      "type": "t_array(t_int256)49_storage",
+      "contract": "AbstractCurveStrategy",
+      "src": "contracts/strategies/AbstractCurveStrategy.sol:25"
+    },
+    {
+      "label": "cvxDepositorAddress",
+      "offset": 0,
+      "slot": "207",
+      "type": "t_address",
+      "contract": "AbstractConvexMetaStrategy",
+      "src": "contracts/strategies/AbstractConvexMetaStrategy.sol:37"
+    },
+    {
+      "label": "cvxRewardStakerAddress",
+      "offset": 0,
+      "slot": "208",
+      "type": "t_address",
+      "contract": "AbstractConvexMetaStrategy",
+      "src": "contracts/strategies/AbstractConvexMetaStrategy.sol:38"
+    },
+    {
+      "label": "cvxDepositorPTokenId",
+      "offset": 0,
+      "slot": "209",
+      "type": "t_uint256",
+      "contract": "AbstractConvexMetaStrategy",
+      "src": "contracts/strategies/AbstractConvexMetaStrategy.sol:39"
+    },
+    {
+      "label": "metapool",
+      "offset": 0,
+      "slot": "210",
+      "type": "t_contract(ICurveMetaPool)34840",
+      "contract": "AbstractConvexMetaStrategy",
+      "src": "contracts/strategies/AbstractConvexMetaStrategy.sol:40"
+    },
+    {
+      "label": "metapoolMainToken",
+      "offset": 0,
+      "slot": "211",
+      "type": "t_contract(IERC20)4200",
+      "contract": "AbstractConvexMetaStrategy",
+      "src": "contracts/strategies/AbstractConvexMetaStrategy.sol:41"
+    },
+    {
+      "label": "metapoolLPToken",
+      "offset": 0,
+      "slot": "212",
+      "type": "t_contract(IERC20)4200",
+      "contract": "AbstractConvexMetaStrategy",
+      "src": "contracts/strategies/AbstractConvexMetaStrategy.sol:42"
+    },
+    {
+      "label": "metapoolAssets",
+      "offset": 0,
+      "slot": "213",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "AbstractConvexMetaStrategy",
+      "src": "contracts/strategies/AbstractConvexMetaStrategy.sol:44"
+    },
+    {
+      "label": "maxWithdrawalSlippage",
+      "offset": 0,
+      "slot": "214",
+      "type": "t_uint256",
+      "contract": "AbstractConvexMetaStrategy",
+      "src": "contracts/strategies/AbstractConvexMetaStrategy.sol:46"
+    },
+    {
+      "label": "crvCoinIndex",
+      "offset": 0,
+      "slot": "215",
+      "type": "t_uint128",
+      "contract": "AbstractConvexMetaStrategy",
+      "src": "contracts/strategies/AbstractConvexMetaStrategy.sol:47"
+    },
+    {
+      "label": "mainCoinIndex",
+      "offset": 16,
+      "slot": "215",
+      "type": "t_uint128",
+      "contract": "AbstractConvexMetaStrategy",
+      "src": "contracts/strategies/AbstractConvexMetaStrategy.sol:48"
+    },
+    {
+      "label": "___reserved",
+      "offset": 0,
+      "slot": "216",
+      "type": "t_array(t_int256)41_storage",
+      "contract": "AbstractConvexMetaStrategy",
+      "src": "contracts/strategies/AbstractConvexMetaStrategy.sol:50"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)41_storage": {
+      "label": "int256[41]",
+      "numberOfBytes": "1312"
+    },
+    "t_array(t_int256)49_storage": {
+      "label": "int256[49]",
+      "numberOfBytes": "1568"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_contract(ICurveMetaPool)34840": {
+      "label": "contract ICurveMetaPool",
+      "numberOfBytes": "20"
+    },
+    "t_contract(IERC20)4200": {
+      "label": "contract IERC20",
+      "numberOfBytes": "20"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_uint128": {
+      "label": "uint128",
+      "numberOfBytes": "16"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/ConvexStrategyProxy-impl.json
+++ b/contracts/storageLayout/mainnet/ConvexStrategyProxy-impl.json
@@ -1,0 +1,187 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "pTokenAddress",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_address",
+      "contract": "AbstractCurveStrategy",
+      "src": "contracts/strategies/AbstractCurveStrategy.sol:23"
+    },
+    {
+      "label": "__reserved",
+      "offset": 0,
+      "slot": "158",
+      "type": "t_array(t_int256)49_storage",
+      "contract": "AbstractCurveStrategy",
+      "src": "contracts/strategies/AbstractCurveStrategy.sol:25"
+    },
+    {
+      "label": "cvxDepositorAddress",
+      "offset": 0,
+      "slot": "207",
+      "type": "t_address",
+      "contract": "ConvexStrategy",
+      "src": "contracts/strategies/ConvexStrategy.sol:29"
+    },
+    {
+      "label": "cvxRewardStakerAddress",
+      "offset": 0,
+      "slot": "208",
+      "type": "t_address",
+      "contract": "ConvexStrategy",
+      "src": "contracts/strategies/ConvexStrategy.sol:30"
+    },
+    {
+      "label": "_deprecated_cvxRewardTokenAddress",
+      "offset": 0,
+      "slot": "209",
+      "type": "t_address",
+      "contract": "ConvexStrategy",
+      "src": "contracts/strategies/ConvexStrategy.sol:32"
+    },
+    {
+      "label": "cvxDepositorPTokenId",
+      "offset": 0,
+      "slot": "210",
+      "type": "t_uint256",
+      "contract": "ConvexStrategy",
+      "src": "contracts/strategies/ConvexStrategy.sol:33"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)49_storage": {
+      "label": "int256[49]",
+      "numberOfBytes": "1568"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/DripperProxy-impl.json
+++ b/contracts/storageLayout/mainnet/DripperProxy-impl.json
@@ -1,0 +1,53 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "dripDuration",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_uint256",
+      "contract": "Dripper",
+      "src": "contracts/harvest/Dripper.sol:57"
+    },
+    {
+      "label": "drip",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_struct(Drip)13710_storage",
+      "contract": "Dripper",
+      "src": "contracts/harvest/Dripper.sol:58"
+    }
+  ],
+  "types": {
+    "t_struct(Drip)13710_storage": {
+      "label": "struct Dripper.Drip",
+      "members": [
+        {
+          "label": "lastCollect",
+          "type": "t_uint64",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "perSecond",
+          "type": "t_uint192",
+          "offset": 8,
+          "slot": "0"
+        }
+      ],
+      "numberOfBytes": "32"
+    },
+    "t_uint192": {
+      "label": "uint192",
+      "numberOfBytes": "24"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    },
+    "t_uint64": {
+      "label": "uint64",
+      "numberOfBytes": "8"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/HarvesterProxy-impl.json
+++ b/contracts/storageLayout/mainnet/HarvesterProxy-impl.json
@@ -1,0 +1,189 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "rewardTokenConfigs",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_mapping(t_address,t_struct(RewardTokenConfig)12457_storage)",
+      "contract": "AbstractHarvester",
+      "src": "contracts/harvest/AbstractHarvester.sol:95"
+    },
+    {
+      "label": "supportedStrategies",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_mapping(t_address,t_bool)",
+      "contract": "AbstractHarvester",
+      "src": "contracts/harvest/AbstractHarvester.sol:96"
+    },
+    {
+      "label": "rewardProceedsAddress",
+      "offset": 0,
+      "slot": "2",
+      "type": "t_address",
+      "contract": "AbstractHarvester",
+      "src": "contracts/harvest/AbstractHarvester.sol:104"
+    },
+    {
+      "label": "uniswapV2Path",
+      "offset": 0,
+      "slot": "3",
+      "type": "t_mapping(t_address,t_array(t_address)dyn_storage)",
+      "contract": "AbstractHarvester",
+      "src": "contracts/harvest/AbstractHarvester.sol:115"
+    },
+    {
+      "label": "uniswapV3Path",
+      "offset": 0,
+      "slot": "4",
+      "type": "t_mapping(t_address,t_bytes_storage)",
+      "contract": "AbstractHarvester",
+      "src": "contracts/harvest/AbstractHarvester.sol:117"
+    },
+    {
+      "label": "balancerPoolId",
+      "offset": 0,
+      "slot": "5",
+      "type": "t_mapping(t_address,t_bytes32)",
+      "contract": "AbstractHarvester",
+      "src": "contracts/harvest/AbstractHarvester.sol:119"
+    },
+    {
+      "label": "curvePoolIndices",
+      "offset": 0,
+      "slot": "6",
+      "type": "t_mapping(t_address,t_struct(CurvePoolIndices)12494_storage)",
+      "contract": "AbstractHarvester",
+      "src": "contracts/harvest/AbstractHarvester.sol:127"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_bytes32": {
+      "label": "bytes32",
+      "numberOfBytes": "32"
+    },
+    "t_bytes_storage": {
+      "label": "bytes",
+      "numberOfBytes": "32"
+    },
+    "t_enum(SwapPlatform)12352": {
+      "label": "enum AbstractHarvester.SwapPlatform",
+      "members": [
+        "UniswapV2Compatible",
+        "UniswapV3",
+        "Balancer",
+        "Curve"
+      ],
+      "numberOfBytes": "1"
+    },
+    "t_mapping(t_address,t_array(t_address)dyn_storage)": {
+      "label": "mapping(address => address[])",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_bool)": {
+      "label": "mapping(address => bool)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_bytes32)": {
+      "label": "mapping(address => bytes32)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_bytes_storage)": {
+      "label": "mapping(address => bytes)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_struct(CurvePoolIndices)12494_storage)": {
+      "label": "mapping(address => struct AbstractHarvester.CurvePoolIndices)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_struct(RewardTokenConfig)12457_storage)": {
+      "label": "mapping(address => struct AbstractHarvester.RewardTokenConfig)",
+      "numberOfBytes": "32"
+    },
+    "t_struct(CurvePoolIndices)12494_storage": {
+      "label": "struct AbstractHarvester.CurvePoolIndices",
+      "members": [
+        {
+          "label": "rewardTokenIndex",
+          "type": "t_uint128",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "baseTokenIndex",
+          "type": "t_uint128",
+          "offset": 16,
+          "slot": "0"
+        }
+      ],
+      "numberOfBytes": "32"
+    },
+    "t_struct(RewardTokenConfig)12457_storage": {
+      "label": "struct AbstractHarvester.RewardTokenConfig",
+      "members": [
+        {
+          "label": "allowedSlippageBps",
+          "type": "t_uint16",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "harvestRewardBps",
+          "type": "t_uint16",
+          "offset": 2,
+          "slot": "0"
+        },
+        {
+          "label": "swapPlatformAddr",
+          "type": "t_address",
+          "offset": 4,
+          "slot": "0"
+        },
+        {
+          "label": "doSwapRewardToken",
+          "type": "t_bool",
+          "offset": 24,
+          "slot": "0"
+        },
+        {
+          "label": "swapPlatform",
+          "type": "t_enum(SwapPlatform)12352",
+          "offset": 25,
+          "slot": "0"
+        },
+        {
+          "label": "liquidationLimit",
+          "type": "t_uint256",
+          "offset": 0,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_uint128": {
+      "label": "uint128",
+      "numberOfBytes": "16"
+    },
+    "t_uint16": {
+      "label": "uint16",
+      "numberOfBytes": "2"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/MakerSSRStrategyProxy-impl.json
+++ b/contracts/storageLayout/mainnet/MakerSSRStrategyProxy-impl.json
@@ -1,0 +1,159 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "_deprecate_shareToken",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_address",
+      "contract": "Generalized4626Strategy",
+      "src": "contracts/strategies/Generalized4626Strategy.sol:15"
+    },
+    {
+      "label": "_deprecate_assetToken",
+      "offset": 0,
+      "slot": "158",
+      "type": "t_address",
+      "contract": "Generalized4626Strategy",
+      "src": "contracts/strategies/Generalized4626Strategy.sol:18"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "159",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Generalized4626Strategy",
+      "src": "contracts/strategies/Generalized4626Strategy.sol:24"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/MetaMorphoStrategyProxy-impl.json
+++ b/contracts/storageLayout/mainnet/MetaMorphoStrategyProxy-impl.json
@@ -1,0 +1,159 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "_deprecate_shareToken",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_address",
+      "contract": "Generalized4626Strategy",
+      "src": "contracts/strategies/Generalized4626Strategy.sol:15"
+    },
+    {
+      "label": "_deprecate_assetToken",
+      "offset": 0,
+      "slot": "158",
+      "type": "t_address",
+      "contract": "Generalized4626Strategy",
+      "src": "contracts/strategies/Generalized4626Strategy.sol:18"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "159",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Generalized4626Strategy",
+      "src": "contracts/strategies/Generalized4626Strategy.sol:24"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/MorphoAaveStrategyProxy-impl.json
+++ b/contracts/storageLayout/mainnet/MorphoAaveStrategyProxy-impl.json
@@ -1,0 +1,135 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/MorphoCompoundStrategyProxy-impl.json
+++ b/contracts/storageLayout/mainnet/MorphoCompoundStrategyProxy-impl.json
@@ -1,0 +1,147 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "__reserved",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_array(t_int256)50_storage",
+      "contract": "AbstractCompoundStrategy",
+      "src": "contracts/strategies/AbstractCompoundStrategy.sol:17"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)50_storage": {
+      "label": "int256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/MorphoGauntletPrimeUSDCStrategyProxy-impl.json
+++ b/contracts/storageLayout/mainnet/MorphoGauntletPrimeUSDCStrategyProxy-impl.json
@@ -1,0 +1,159 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "_deprecate_shareToken",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_address",
+      "contract": "Generalized4626Strategy",
+      "src": "contracts/strategies/Generalized4626Strategy.sol:15"
+    },
+    {
+      "label": "_deprecate_assetToken",
+      "offset": 0,
+      "slot": "158",
+      "type": "t_address",
+      "contract": "Generalized4626Strategy",
+      "src": "contracts/strategies/Generalized4626Strategy.sol:18"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "159",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Generalized4626Strategy",
+      "src": "contracts/strategies/Generalized4626Strategy.sol:24"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/MorphoGauntletPrimeUSDTStrategyProxy-impl.json
+++ b/contracts/storageLayout/mainnet/MorphoGauntletPrimeUSDTStrategyProxy-impl.json
@@ -1,0 +1,159 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "_deprecate_shareToken",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_address",
+      "contract": "Generalized4626Strategy",
+      "src": "contracts/strategies/Generalized4626Strategy.sol:15"
+    },
+    {
+      "label": "_deprecate_assetToken",
+      "offset": 0,
+      "slot": "158",
+      "type": "t_address",
+      "contract": "Generalized4626Strategy",
+      "src": "contracts/strategies/Generalized4626Strategy.sol:18"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "159",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Generalized4626Strategy",
+      "src": "contracts/strategies/Generalized4626Strategy.sol:24"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/NativeStakingFeeAccumulator2Proxy-impl.json
+++ b/contracts/storageLayout/mainnet/NativeStakingFeeAccumulator2Proxy-impl.json
@@ -1,0 +1,5 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [],
+  "types": {}
+}

--- a/contracts/storageLayout/mainnet/NativeStakingFeeAccumulator3Proxy-impl.json
+++ b/contracts/storageLayout/mainnet/NativeStakingFeeAccumulator3Proxy-impl.json
@@ -1,0 +1,5 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [],
+  "types": {}
+}

--- a/contracts/storageLayout/mainnet/NativeStakingFeeAccumulatorProxy-impl.json
+++ b/contracts/storageLayout/mainnet/NativeStakingFeeAccumulatorProxy-impl.json
@@ -1,0 +1,5 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [],
+  "types": {}
+}

--- a/contracts/storageLayout/mainnet/NativeStakingSSVStrategy2Proxy-impl.json
+++ b/contracts/storageLayout/mainnet/NativeStakingSSVStrategy2Proxy-impl.json
@@ -1,0 +1,282 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_paused",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_bool",
+      "contract": "Pausable",
+      "src": "@openzeppelin/contracts/security/Pausable.sol:28"
+    },
+    {
+      "label": "validatorRegistrator",
+      "offset": 1,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "ValidatorRegistrator",
+      "src": "contracts/strategies/NativeStaking/ValidatorRegistrator.sol:39"
+    },
+    {
+      "label": "activeDepositedValidators",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_uint256",
+      "contract": "ValidatorRegistrator",
+      "src": "contracts/strategies/NativeStaking/ValidatorRegistrator.sol:43"
+    },
+    {
+      "label": "validatorsStates",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_bytes32,t_enum(VALIDATOR_STATE)4478)",
+      "contract": "ValidatorRegistrator",
+      "src": "contracts/strategies/NativeStaking/ValidatorRegistrator.sol:45"
+    },
+    {
+      "label": "stakingMonitor",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_address",
+      "contract": "ValidatorRegistrator",
+      "src": "contracts/strategies/NativeStaking/ValidatorRegistrator.sol:47"
+    },
+    {
+      "label": "stakeETHThreshold",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_uint256",
+      "contract": "ValidatorRegistrator",
+      "src": "contracts/strategies/NativeStaking/ValidatorRegistrator.sol:50"
+    },
+    {
+      "label": "stakeETHTally",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "ValidatorRegistrator",
+      "src": "contracts/strategies/NativeStaking/ValidatorRegistrator.sol:53"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_array(t_uint256)47_storage",
+      "contract": "ValidatorRegistrator",
+      "src": "contracts/strategies/NativeStaking/ValidatorRegistrator.sol:55"
+    },
+    {
+      "label": "consensusRewards",
+      "offset": 0,
+      "slot": "104",
+      "type": "t_uint256",
+      "contract": "ValidatorAccountant",
+      "src": "contracts/strategies/NativeStaking/ValidatorAccountant.sol:17"
+    },
+    {
+      "label": "fuseIntervalStart",
+      "offset": 0,
+      "slot": "105",
+      "type": "t_uint256",
+      "contract": "ValidatorAccountant",
+      "src": "contracts/strategies/NativeStaking/ValidatorAccountant.sol:20"
+    },
+    {
+      "label": "fuseIntervalEnd",
+      "offset": 0,
+      "slot": "106",
+      "type": "t_uint256",
+      "contract": "ValidatorAccountant",
+      "src": "contracts/strategies/NativeStaking/ValidatorAccountant.sol:22"
+    },
+    {
+      "label": "lastFixAccountingBlockNumber",
+      "offset": 0,
+      "slot": "107",
+      "type": "t_uint256",
+      "contract": "ValidatorAccountant",
+      "src": "contracts/strategies/NativeStaking/ValidatorAccountant.sol:24"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "108",
+      "type": "t_array(t_uint256)49_storage",
+      "contract": "ValidatorAccountant",
+      "src": "contracts/strategies/NativeStaking/ValidatorAccountant.sol:26"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "158",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "159",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "160",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "161",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "162",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "163",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "164",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "165",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "depositedWethAccountedFor",
+      "offset": 0,
+      "slot": "263",
+      "type": "t_uint256",
+      "contract": "NativeStakingSSVStrategy",
+      "src": "contracts/strategies/NativeStaking/NativeStakingSSVStrategy.sol:66"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "264",
+      "type": "t_array(t_uint256)49_storage",
+      "contract": "NativeStakingSSVStrategy",
+      "src": "contracts/strategies/NativeStaking/NativeStakingSSVStrategy.sol:69"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)47_storage": {
+      "label": "uint256[47]",
+      "numberOfBytes": "1504"
+    },
+    "t_array(t_uint256)49_storage": {
+      "label": "uint256[49]",
+      "numberOfBytes": "1568"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_bytes32": {
+      "label": "bytes32",
+      "numberOfBytes": "32"
+    },
+    "t_enum(VALIDATOR_STATE)4478": {
+      "label": "enum ValidatorRegistrator.VALIDATOR_STATE",
+      "members": [
+        "NON_REGISTERED",
+        "REGISTERED",
+        "STAKED",
+        "EXITING",
+        "EXIT_COMPLETE"
+      ],
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_bytes32,t_enum(VALIDATOR_STATE)4478)": {
+      "label": "mapping(bytes32 => enum ValidatorRegistrator.VALIDATOR_STATE)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/NativeStakingSSVStrategy3Proxy-impl.json
+++ b/contracts/storageLayout/mainnet/NativeStakingSSVStrategy3Proxy-impl.json
@@ -1,0 +1,282 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_paused",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_bool",
+      "contract": "Pausable",
+      "src": "@openzeppelin/contracts/security/Pausable.sol:28"
+    },
+    {
+      "label": "validatorRegistrator",
+      "offset": 1,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "ValidatorRegistrator",
+      "src": "contracts/strategies/NativeStaking/ValidatorRegistrator.sol:39"
+    },
+    {
+      "label": "activeDepositedValidators",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_uint256",
+      "contract": "ValidatorRegistrator",
+      "src": "contracts/strategies/NativeStaking/ValidatorRegistrator.sol:43"
+    },
+    {
+      "label": "validatorsStates",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_bytes32,t_enum(VALIDATOR_STATE)4478)",
+      "contract": "ValidatorRegistrator",
+      "src": "contracts/strategies/NativeStaking/ValidatorRegistrator.sol:45"
+    },
+    {
+      "label": "stakingMonitor",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_address",
+      "contract": "ValidatorRegistrator",
+      "src": "contracts/strategies/NativeStaking/ValidatorRegistrator.sol:47"
+    },
+    {
+      "label": "stakeETHThreshold",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_uint256",
+      "contract": "ValidatorRegistrator",
+      "src": "contracts/strategies/NativeStaking/ValidatorRegistrator.sol:50"
+    },
+    {
+      "label": "stakeETHTally",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "ValidatorRegistrator",
+      "src": "contracts/strategies/NativeStaking/ValidatorRegistrator.sol:53"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_array(t_uint256)47_storage",
+      "contract": "ValidatorRegistrator",
+      "src": "contracts/strategies/NativeStaking/ValidatorRegistrator.sol:55"
+    },
+    {
+      "label": "consensusRewards",
+      "offset": 0,
+      "slot": "104",
+      "type": "t_uint256",
+      "contract": "ValidatorAccountant",
+      "src": "contracts/strategies/NativeStaking/ValidatorAccountant.sol:17"
+    },
+    {
+      "label": "fuseIntervalStart",
+      "offset": 0,
+      "slot": "105",
+      "type": "t_uint256",
+      "contract": "ValidatorAccountant",
+      "src": "contracts/strategies/NativeStaking/ValidatorAccountant.sol:20"
+    },
+    {
+      "label": "fuseIntervalEnd",
+      "offset": 0,
+      "slot": "106",
+      "type": "t_uint256",
+      "contract": "ValidatorAccountant",
+      "src": "contracts/strategies/NativeStaking/ValidatorAccountant.sol:22"
+    },
+    {
+      "label": "lastFixAccountingBlockNumber",
+      "offset": 0,
+      "slot": "107",
+      "type": "t_uint256",
+      "contract": "ValidatorAccountant",
+      "src": "contracts/strategies/NativeStaking/ValidatorAccountant.sol:24"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "108",
+      "type": "t_array(t_uint256)49_storage",
+      "contract": "ValidatorAccountant",
+      "src": "contracts/strategies/NativeStaking/ValidatorAccountant.sol:26"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "158",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "159",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "160",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "161",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "162",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "163",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "164",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "165",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "depositedWethAccountedFor",
+      "offset": 0,
+      "slot": "263",
+      "type": "t_uint256",
+      "contract": "NativeStakingSSVStrategy",
+      "src": "contracts/strategies/NativeStaking/NativeStakingSSVStrategy.sol:66"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "264",
+      "type": "t_array(t_uint256)49_storage",
+      "contract": "NativeStakingSSVStrategy",
+      "src": "contracts/strategies/NativeStaking/NativeStakingSSVStrategy.sol:69"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)47_storage": {
+      "label": "uint256[47]",
+      "numberOfBytes": "1504"
+    },
+    "t_array(t_uint256)49_storage": {
+      "label": "uint256[49]",
+      "numberOfBytes": "1568"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_bytes32": {
+      "label": "bytes32",
+      "numberOfBytes": "32"
+    },
+    "t_enum(VALIDATOR_STATE)4478": {
+      "label": "enum ValidatorRegistrator.VALIDATOR_STATE",
+      "members": [
+        "NON_REGISTERED",
+        "REGISTERED",
+        "STAKED",
+        "EXITING",
+        "EXIT_COMPLETE"
+      ],
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_bytes32,t_enum(VALIDATOR_STATE)4478)": {
+      "label": "mapping(bytes32 => enum ValidatorRegistrator.VALIDATOR_STATE)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/NativeStakingSSVStrategyProxy-impl.json
+++ b/contracts/storageLayout/mainnet/NativeStakingSSVStrategyProxy-impl.json
@@ -1,0 +1,282 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_paused",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_bool",
+      "contract": "Pausable",
+      "src": "@openzeppelin/contracts/security/Pausable.sol:28"
+    },
+    {
+      "label": "validatorRegistrator",
+      "offset": 1,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "ValidatorRegistrator",
+      "src": "contracts/strategies/NativeStaking/ValidatorRegistrator.sol:39"
+    },
+    {
+      "label": "activeDepositedValidators",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_uint256",
+      "contract": "ValidatorRegistrator",
+      "src": "contracts/strategies/NativeStaking/ValidatorRegistrator.sol:43"
+    },
+    {
+      "label": "validatorsStates",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_bytes32,t_enum(VALIDATOR_STATE)4478)",
+      "contract": "ValidatorRegistrator",
+      "src": "contracts/strategies/NativeStaking/ValidatorRegistrator.sol:45"
+    },
+    {
+      "label": "stakingMonitor",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_address",
+      "contract": "ValidatorRegistrator",
+      "src": "contracts/strategies/NativeStaking/ValidatorRegistrator.sol:47"
+    },
+    {
+      "label": "stakeETHThreshold",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_uint256",
+      "contract": "ValidatorRegistrator",
+      "src": "contracts/strategies/NativeStaking/ValidatorRegistrator.sol:50"
+    },
+    {
+      "label": "stakeETHTally",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "ValidatorRegistrator",
+      "src": "contracts/strategies/NativeStaking/ValidatorRegistrator.sol:53"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_array(t_uint256)47_storage",
+      "contract": "ValidatorRegistrator",
+      "src": "contracts/strategies/NativeStaking/ValidatorRegistrator.sol:55"
+    },
+    {
+      "label": "consensusRewards",
+      "offset": 0,
+      "slot": "104",
+      "type": "t_uint256",
+      "contract": "ValidatorAccountant",
+      "src": "contracts/strategies/NativeStaking/ValidatorAccountant.sol:17"
+    },
+    {
+      "label": "fuseIntervalStart",
+      "offset": 0,
+      "slot": "105",
+      "type": "t_uint256",
+      "contract": "ValidatorAccountant",
+      "src": "contracts/strategies/NativeStaking/ValidatorAccountant.sol:20"
+    },
+    {
+      "label": "fuseIntervalEnd",
+      "offset": 0,
+      "slot": "106",
+      "type": "t_uint256",
+      "contract": "ValidatorAccountant",
+      "src": "contracts/strategies/NativeStaking/ValidatorAccountant.sol:22"
+    },
+    {
+      "label": "lastFixAccountingBlockNumber",
+      "offset": 0,
+      "slot": "107",
+      "type": "t_uint256",
+      "contract": "ValidatorAccountant",
+      "src": "contracts/strategies/NativeStaking/ValidatorAccountant.sol:24"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "108",
+      "type": "t_array(t_uint256)49_storage",
+      "contract": "ValidatorAccountant",
+      "src": "contracts/strategies/NativeStaking/ValidatorAccountant.sol:26"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "158",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "159",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "160",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "161",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "162",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "163",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "164",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "165",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "depositedWethAccountedFor",
+      "offset": 0,
+      "slot": "263",
+      "type": "t_uint256",
+      "contract": "NativeStakingSSVStrategy",
+      "src": "contracts/strategies/NativeStaking/NativeStakingSSVStrategy.sol:66"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "264",
+      "type": "t_array(t_uint256)49_storage",
+      "contract": "NativeStakingSSVStrategy",
+      "src": "contracts/strategies/NativeStaking/NativeStakingSSVStrategy.sol:69"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)47_storage": {
+      "label": "uint256[47]",
+      "numberOfBytes": "1504"
+    },
+    "t_array(t_uint256)49_storage": {
+      "label": "uint256[49]",
+      "numberOfBytes": "1568"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_bytes32": {
+      "label": "bytes32",
+      "numberOfBytes": "32"
+    },
+    "t_enum(VALIDATOR_STATE)4478": {
+      "label": "enum ValidatorRegistrator.VALIDATOR_STATE",
+      "members": [
+        "NON_REGISTERED",
+        "REGISTERED",
+        "STAKED",
+        "EXITING",
+        "EXIT_COMPLETE"
+      ],
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_bytes32,t_enum(VALIDATOR_STATE)4478)": {
+      "label": "mapping(bytes32 => enum ValidatorRegistrator.VALIDATOR_STATE)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/OETHBalancerMetaPoolrEthStrategyProxy-impl.json
+++ b/contracts/storageLayout/mainnet/OETHBalancerMetaPoolrEthStrategyProxy-impl.json
@@ -1,0 +1,175 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "maxWithdrawalDeviation",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_uint256",
+      "contract": "AbstractBalancerStrategy",
+      "src": "contracts/strategies/balancer/AbstractBalancerStrategy.sol:34"
+    },
+    {
+      "label": "maxDepositDeviation",
+      "offset": 0,
+      "slot": "158",
+      "type": "t_uint256",
+      "contract": "AbstractBalancerStrategy",
+      "src": "contracts/strategies/balancer/AbstractBalancerStrategy.sol:36"
+    },
+    {
+      "label": "__reserved",
+      "offset": 0,
+      "slot": "159",
+      "type": "t_array(t_int256)48_storage",
+      "contract": "AbstractBalancerStrategy",
+      "src": "contracts/strategies/balancer/AbstractBalancerStrategy.sol:38"
+    },
+    {
+      "label": "__reserved_baseAuraStrategy",
+      "offset": 0,
+      "slot": "207",
+      "type": "t_array(t_int256)50_storage",
+      "contract": "AbstractAuraStrategy",
+      "src": "contracts/strategies/balancer/AbstractAuraStrategy.sol:24"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)48_storage": {
+      "label": "int256[48]",
+      "numberOfBytes": "1536"
+    },
+    "t_array(t_int256)50_storage": {
+      "label": "int256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/OETHBuybackProxy-impl.json
+++ b/contracts/storageLayout/mainnet/OETHBuybackProxy-impl.json
@@ -1,0 +1,151 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "strategistAddr",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "Strategizable",
+      "src": "contracts/governance/Strategizable.sol:10"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Strategizable",
+      "src": "contracts/governance/Strategizable.sol:13"
+    },
+    {
+      "label": "swapRouter",
+      "offset": 0,
+      "slot": "102",
+      "type": "t_address",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:31"
+    },
+    {
+      "label": "__deprecated_ousd",
+      "offset": 0,
+      "slot": "103",
+      "type": "t_address",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:34"
+    },
+    {
+      "label": "__deprecated_ogv",
+      "offset": 0,
+      "slot": "104",
+      "type": "t_address",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:36"
+    },
+    {
+      "label": "__deprecated_usdt",
+      "offset": 0,
+      "slot": "105",
+      "type": "t_address",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:38"
+    },
+    {
+      "label": "__deprecated_weth9",
+      "offset": 0,
+      "slot": "106",
+      "type": "t_address",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:40"
+    },
+    {
+      "label": "rewardsSource",
+      "offset": 0,
+      "slot": "107",
+      "type": "t_address",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:43"
+    },
+    {
+      "label": "treasuryManager",
+      "offset": 0,
+      "slot": "108",
+      "type": "t_address",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:46"
+    },
+    {
+      "label": "__deprecated_treasuryBps",
+      "offset": 0,
+      "slot": "109",
+      "type": "t_uint256",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:49"
+    },
+    {
+      "label": "balanceForOGN",
+      "offset": 0,
+      "slot": "110",
+      "type": "t_uint256",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:57"
+    },
+    {
+      "label": "balanceForCVX",
+      "offset": 0,
+      "slot": "111",
+      "type": "t_uint256",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:60"
+    },
+    {
+      "label": "cvxShareBps",
+      "offset": 0,
+      "slot": "112",
+      "type": "t_uint256",
+      "contract": "AbstractBuyback",
+      "src": "contracts/buyback/AbstractBuyback.sol:63"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/OETHCurveAMOProxy-impl.json
+++ b/contracts/storageLayout/mainnet/OETHCurveAMOProxy-impl.json
@@ -1,0 +1,143 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "maxSlippage",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_uint256",
+      "contract": "CurveAMOStrategy",
+      "src": "contracts/strategies/CurveAMOStrategy.sol:79"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/OETHDripperProxy-impl.json
+++ b/contracts/storageLayout/mainnet/OETHDripperProxy-impl.json
@@ -1,0 +1,53 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "dripDuration",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_uint256",
+      "contract": "Dripper",
+      "src": "contracts/harvest/Dripper.sol:57"
+    },
+    {
+      "label": "drip",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_struct(Drip)13710_storage",
+      "contract": "Dripper",
+      "src": "contracts/harvest/Dripper.sol:58"
+    }
+  ],
+  "types": {
+    "t_struct(Drip)13710_storage": {
+      "label": "struct Dripper.Drip",
+      "members": [
+        {
+          "label": "lastCollect",
+          "type": "t_uint64",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "perSecond",
+          "type": "t_uint192",
+          "offset": 8,
+          "slot": "0"
+        }
+      ],
+      "numberOfBytes": "32"
+    },
+    "t_uint192": {
+      "label": "uint192",
+      "numberOfBytes": "24"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    },
+    "t_uint64": {
+      "label": "uint64",
+      "numberOfBytes": "8"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/OETHFixedRateDripperProxy-impl.json
+++ b/contracts/storageLayout/mainnet/OETHFixedRateDripperProxy-impl.json
@@ -1,0 +1,53 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "dripDuration",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_uint256",
+      "contract": "Dripper",
+      "src": "contracts/harvest/Dripper.sol:57"
+    },
+    {
+      "label": "drip",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_struct(Drip)13710_storage",
+      "contract": "Dripper",
+      "src": "contracts/harvest/Dripper.sol:58"
+    }
+  ],
+  "types": {
+    "t_struct(Drip)13710_storage": {
+      "label": "struct Dripper.Drip",
+      "members": [
+        {
+          "label": "lastCollect",
+          "type": "t_uint64",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "perSecond",
+          "type": "t_uint192",
+          "offset": 8,
+          "slot": "0"
+        }
+      ],
+      "numberOfBytes": "32"
+    },
+    "t_uint192": {
+      "label": "uint192",
+      "numberOfBytes": "24"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    },
+    "t_uint64": {
+      "label": "uint64",
+      "numberOfBytes": "8"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/OETHHarvesterProxy-impl.json
+++ b/contracts/storageLayout/mainnet/OETHHarvesterProxy-impl.json
@@ -1,0 +1,189 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "rewardTokenConfigs",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_mapping(t_address,t_struct(RewardTokenConfig)12457_storage)",
+      "contract": "AbstractHarvester",
+      "src": "contracts/harvest/AbstractHarvester.sol:95"
+    },
+    {
+      "label": "supportedStrategies",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_mapping(t_address,t_bool)",
+      "contract": "AbstractHarvester",
+      "src": "contracts/harvest/AbstractHarvester.sol:96"
+    },
+    {
+      "label": "rewardProceedsAddress",
+      "offset": 0,
+      "slot": "2",
+      "type": "t_address",
+      "contract": "AbstractHarvester",
+      "src": "contracts/harvest/AbstractHarvester.sol:104"
+    },
+    {
+      "label": "uniswapV2Path",
+      "offset": 0,
+      "slot": "3",
+      "type": "t_mapping(t_address,t_array(t_address)dyn_storage)",
+      "contract": "AbstractHarvester",
+      "src": "contracts/harvest/AbstractHarvester.sol:115"
+    },
+    {
+      "label": "uniswapV3Path",
+      "offset": 0,
+      "slot": "4",
+      "type": "t_mapping(t_address,t_bytes_storage)",
+      "contract": "AbstractHarvester",
+      "src": "contracts/harvest/AbstractHarvester.sol:117"
+    },
+    {
+      "label": "balancerPoolId",
+      "offset": 0,
+      "slot": "5",
+      "type": "t_mapping(t_address,t_bytes32)",
+      "contract": "AbstractHarvester",
+      "src": "contracts/harvest/AbstractHarvester.sol:119"
+    },
+    {
+      "label": "curvePoolIndices",
+      "offset": 0,
+      "slot": "6",
+      "type": "t_mapping(t_address,t_struct(CurvePoolIndices)12494_storage)",
+      "contract": "AbstractHarvester",
+      "src": "contracts/harvest/AbstractHarvester.sol:127"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_bytes32": {
+      "label": "bytes32",
+      "numberOfBytes": "32"
+    },
+    "t_bytes_storage": {
+      "label": "bytes",
+      "numberOfBytes": "32"
+    },
+    "t_enum(SwapPlatform)12352": {
+      "label": "enum AbstractHarvester.SwapPlatform",
+      "members": [
+        "UniswapV2Compatible",
+        "UniswapV3",
+        "Balancer",
+        "Curve"
+      ],
+      "numberOfBytes": "1"
+    },
+    "t_mapping(t_address,t_array(t_address)dyn_storage)": {
+      "label": "mapping(address => address[])",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_bool)": {
+      "label": "mapping(address => bool)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_bytes32)": {
+      "label": "mapping(address => bytes32)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_bytes_storage)": {
+      "label": "mapping(address => bytes)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_struct(CurvePoolIndices)12494_storage)": {
+      "label": "mapping(address => struct AbstractHarvester.CurvePoolIndices)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_struct(RewardTokenConfig)12457_storage)": {
+      "label": "mapping(address => struct AbstractHarvester.RewardTokenConfig)",
+      "numberOfBytes": "32"
+    },
+    "t_struct(CurvePoolIndices)12494_storage": {
+      "label": "struct AbstractHarvester.CurvePoolIndices",
+      "members": [
+        {
+          "label": "rewardTokenIndex",
+          "type": "t_uint128",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "baseTokenIndex",
+          "type": "t_uint128",
+          "offset": 16,
+          "slot": "0"
+        }
+      ],
+      "numberOfBytes": "32"
+    },
+    "t_struct(RewardTokenConfig)12457_storage": {
+      "label": "struct AbstractHarvester.RewardTokenConfig",
+      "members": [
+        {
+          "label": "allowedSlippageBps",
+          "type": "t_uint16",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "harvestRewardBps",
+          "type": "t_uint16",
+          "offset": 2,
+          "slot": "0"
+        },
+        {
+          "label": "swapPlatformAddr",
+          "type": "t_address",
+          "offset": 4,
+          "slot": "0"
+        },
+        {
+          "label": "doSwapRewardToken",
+          "type": "t_bool",
+          "offset": 24,
+          "slot": "0"
+        },
+        {
+          "label": "swapPlatform",
+          "type": "t_enum(SwapPlatform)12352",
+          "offset": 25,
+          "slot": "0"
+        },
+        {
+          "label": "liquidationLimit",
+          "type": "t_uint256",
+          "offset": 0,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_uint128": {
+      "label": "uint128",
+      "numberOfBytes": "16"
+    },
+    "t_uint16": {
+      "label": "uint16",
+      "numberOfBytes": "2"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/OETHMorphoAaveStrategyProxy-impl.json
+++ b/contracts/storageLayout/mainnet/OETHMorphoAaveStrategyProxy-impl.json
@@ -1,0 +1,135 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/OETHProxy-impl.json
+++ b/contracts/storageLayout/mainnet/OETHProxy-impl.json
@@ -1,0 +1,162 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "_gap",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_array(t_uint256)154_storage",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:69"
+    },
+    {
+      "label": "totalSupply",
+      "offset": 0,
+      "slot": "154",
+      "type": "t_uint256",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:72"
+    },
+    {
+      "label": "allowances",
+      "offset": 0,
+      "slot": "155",
+      "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:73"
+    },
+    {
+      "label": "vaultAddress",
+      "offset": 0,
+      "slot": "156",
+      "type": "t_address",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:76"
+    },
+    {
+      "label": "creditBalances",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:77"
+    },
+    {
+      "label": "rebasingCredits_",
+      "offset": 0,
+      "slot": "158",
+      "type": "t_uint256",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:79"
+    },
+    {
+      "label": "rebasingCreditsPerToken_",
+      "offset": 0,
+      "slot": "159",
+      "type": "t_uint256",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:80"
+    },
+    {
+      "label": "nonRebasingSupply",
+      "offset": 0,
+      "slot": "160",
+      "type": "t_uint256",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:82"
+    },
+    {
+      "label": "alternativeCreditsPerToken",
+      "offset": 0,
+      "slot": "161",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:83"
+    },
+    {
+      "label": "rebaseState",
+      "offset": 0,
+      "slot": "162",
+      "type": "t_mapping(t_address,t_enum(RebaseOptions)47335)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:85"
+    },
+    {
+      "label": "__deprecated_isUpgraded",
+      "offset": 0,
+      "slot": "163",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:86"
+    },
+    {
+      "label": "yieldTo",
+      "offset": 0,
+      "slot": "164",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:91"
+    },
+    {
+      "label": "yieldFrom",
+      "offset": 0,
+      "slot": "165",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:96"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "166",
+      "type": "t_array(t_uint256)34_storage",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:99"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_uint256)154_storage": {
+      "label": "uint256[154]",
+      "numberOfBytes": "4928"
+    },
+    "t_array(t_uint256)34_storage": {
+      "label": "uint256[34]",
+      "numberOfBytes": "1088"
+    },
+    "t_enum(RebaseOptions)47335": {
+      "label": "enum OUSD.RebaseOptions",
+      "members": [
+        "NotSet",
+        "StdNonRebasing",
+        "StdRebasing",
+        "YieldDelegationSource",
+        "YieldDelegationTarget"
+      ],
+      "numberOfBytes": "1"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_enum(RebaseOptions)47335)": {
+      "label": "mapping(address => enum OUSD.RebaseOptions)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+      "label": "mapping(address => mapping(address => uint256))",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_uint256)": {
+      "label": "mapping(address => uint256)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/OETHSimpleHarvesterProxy-impl.json
+++ b/contracts/storageLayout/mainnet/OETHSimpleHarvesterProxy-impl.json
@@ -1,0 +1,95 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "strategistAddr",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "Strategizable",
+      "src": "contracts/governance/Strategizable.sol:10"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Strategizable",
+      "src": "contracts/governance/Strategizable.sol:13"
+    },
+    {
+      "label": "dripper",
+      "offset": 0,
+      "slot": "102",
+      "type": "t_address",
+      "contract": "OETHHarvesterSimple",
+      "src": "contracts/harvest/OETHHarvesterSimple.sol:26"
+    },
+    {
+      "label": "supportedStrategies",
+      "offset": 0,
+      "slot": "103",
+      "type": "t_mapping(t_address,t_bool)",
+      "contract": "OETHHarvesterSimple",
+      "src": "contracts/harvest/OETHHarvesterSimple.sol:29"
+    },
+    {
+      "label": "___gap",
+      "offset": 0,
+      "slot": "104",
+      "type": "t_array(t_uint256)48_storage",
+      "contract": "OETHHarvesterSimple",
+      "src": "contracts/harvest/OETHHarvesterSimple.sol:32"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_uint256)48_storage": {
+      "label": "uint256[48]",
+      "numberOfBytes": "1536"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_mapping(t_address,t_bool)": {
+      "label": "mapping(address => bool)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/OETHVaultProxy-impl.json
+++ b/contracts/storageLayout/mainnet/OETHVaultProxy-impl.json
@@ -1,0 +1,531 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "assets",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_mapping(t_address,t_struct(Asset)57206_storage)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:99"
+    },
+    {
+      "label": "allAssets",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:101"
+    },
+    {
+      "label": "strategies",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_struct(Strategy)57221_storage)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:109"
+    },
+    {
+      "label": "allStrategies",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:111"
+    },
+    {
+      "label": "priceProvider",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:114"
+    },
+    {
+      "label": "rebasePaused",
+      "offset": 20,
+      "slot": "55",
+      "type": "t_bool",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:116"
+    },
+    {
+      "label": "capitalPaused",
+      "offset": 21,
+      "slot": "55",
+      "type": "t_bool",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:119"
+    },
+    {
+      "label": "redeemFeeBps",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:121"
+    },
+    {
+      "label": "vaultBuffer",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:123"
+    },
+    {
+      "label": "autoAllocateThreshold",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:125"
+    },
+    {
+      "label": "rebaseThreshold",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:127"
+    },
+    {
+      "label": "oUSD",
+      "offset": 0,
+      "slot": "60",
+      "type": "t_contract(OUSD)48948",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:130"
+    },
+    {
+      "label": "_deprecated_rebaseHooksAddr",
+      "offset": 0,
+      "slot": "61",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:138"
+    },
+    {
+      "label": "_deprecated_uniswapAddr",
+      "offset": 0,
+      "slot": "62",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:141"
+    },
+    {
+      "label": "strategistAddr",
+      "offset": 0,
+      "slot": "63",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:144"
+    },
+    {
+      "label": "assetDefaultStrategies",
+      "offset": 0,
+      "slot": "64",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:148"
+    },
+    {
+      "label": "maxSupplyDiff",
+      "offset": 0,
+      "slot": "65",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:151"
+    },
+    {
+      "label": "trusteeAddress",
+      "offset": 0,
+      "slot": "66",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:154"
+    },
+    {
+      "label": "trusteeFeeBps",
+      "offset": 0,
+      "slot": "67",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:157"
+    },
+    {
+      "label": "_deprecated_swapTokens",
+      "offset": 0,
+      "slot": "68",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:160"
+    },
+    {
+      "label": "ousdMetaStrategy",
+      "offset": 0,
+      "slot": "69",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:166"
+    },
+    {
+      "label": "netOusdMintedForStrategy",
+      "offset": 0,
+      "slot": "70",
+      "type": "t_int256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:169"
+    },
+    {
+      "label": "netOusdMintForStrategyThreshold",
+      "offset": 0,
+      "slot": "71",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:172"
+    },
+    {
+      "label": "swapConfig",
+      "offset": 0,
+      "slot": "72",
+      "type": "t_struct(SwapConfig)57323_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:186"
+    },
+    {
+      "label": "isMintWhitelistedStrategy",
+      "offset": 0,
+      "slot": "73",
+      "type": "t_mapping(t_address,t_bool)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:190"
+    },
+    {
+      "label": "dripper",
+      "offset": 0,
+      "slot": "74",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:194"
+    },
+    {
+      "label": "withdrawalQueueMetadata",
+      "offset": 0,
+      "slot": "75",
+      "type": "t_struct(WithdrawalQueueMetadata)57350_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:214"
+    },
+    {
+      "label": "withdrawalRequests",
+      "offset": 0,
+      "slot": "77",
+      "type": "t_mapping(t_uint256,t_struct(WithdrawalRequest)57365_storage)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:228"
+    },
+    {
+      "label": "withdrawalClaimDelay",
+      "offset": 0,
+      "slot": "78",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:233"
+    },
+    {
+      "label": "lastRebase",
+      "offset": 0,
+      "slot": "79",
+      "type": "t_uint64",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:236"
+    },
+    {
+      "label": "dripDuration",
+      "offset": 8,
+      "slot": "79",
+      "type": "t_uint64",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:239"
+    },
+    {
+      "label": "rebasePerSecondMax",
+      "offset": 16,
+      "slot": "79",
+      "type": "t_uint64",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:244"
+    },
+    {
+      "label": "rebasePerSecondTarget",
+      "offset": 24,
+      "slot": "79",
+      "type": "t_uint64",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:247"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "80",
+      "type": "t_array(t_uint256)43_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:254"
+    },
+    {
+      "label": "wethAssetIndex",
+      "offset": 0,
+      "slot": "123",
+      "type": "t_uint256",
+      "contract": "OETHVaultCore",
+      "src": "contracts/vault/OETHVaultCore.sol:22"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "124",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "OETHVaultCore",
+      "src": "contracts/vault/OETHVaultCore.sol:25"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_uint256)43_storage": {
+      "label": "uint256[43]",
+      "numberOfBytes": "1376"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_contract(OUSD)48948": {
+      "label": "contract OUSD",
+      "numberOfBytes": "20"
+    },
+    "t_enum(UnitConversion)57196": {
+      "label": "enum VaultStorage.UnitConversion",
+      "members": [
+        "DECIMALS",
+        "GETEXCHANGERATE"
+      ],
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_bool)": {
+      "label": "mapping(address => bool)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_struct(Asset)57206_storage)": {
+      "label": "mapping(address => struct VaultStorage.Asset)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_struct(Strategy)57221_storage)": {
+      "label": "mapping(address => struct VaultStorage.Strategy)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_uint256,t_struct(WithdrawalRequest)57365_storage)": {
+      "label": "mapping(uint256 => struct VaultStorage.WithdrawalRequest)",
+      "numberOfBytes": "32"
+    },
+    "t_struct(Asset)57206_storage": {
+      "label": "struct VaultStorage.Asset",
+      "members": [
+        {
+          "label": "isSupported",
+          "type": "t_bool",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "unitConversion",
+          "type": "t_enum(UnitConversion)57196",
+          "offset": 1,
+          "slot": "0"
+        },
+        {
+          "label": "decimals",
+          "type": "t_uint8",
+          "offset": 2,
+          "slot": "0"
+        },
+        {
+          "label": "allowedOracleSlippageBps",
+          "type": "t_uint16",
+          "offset": 3,
+          "slot": "0"
+        }
+      ],
+      "numberOfBytes": "32"
+    },
+    "t_struct(Strategy)57221_storage": {
+      "label": "struct VaultStorage.Strategy",
+      "members": [
+        {
+          "label": "isSupported",
+          "type": "t_bool",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "_deprecated",
+          "type": "t_uint256",
+          "offset": 0,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(SwapConfig)57323_storage": {
+      "label": "struct VaultStorage.SwapConfig",
+      "members": [
+        {
+          "label": "swapper",
+          "type": "t_address",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "allowedUndervalueBps",
+          "type": "t_uint16",
+          "offset": 20,
+          "slot": "0"
+        }
+      ],
+      "numberOfBytes": "32"
+    },
+    "t_struct(WithdrawalQueueMetadata)57350_storage": {
+      "label": "struct VaultStorage.WithdrawalQueueMetadata",
+      "members": [
+        {
+          "label": "queued",
+          "type": "t_uint128",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "claimable",
+          "type": "t_uint128",
+          "offset": 16,
+          "slot": "0"
+        },
+        {
+          "label": "claimed",
+          "type": "t_uint128",
+          "offset": 0,
+          "slot": "1"
+        },
+        {
+          "label": "nextWithdrawalIndex",
+          "type": "t_uint128",
+          "offset": 16,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(WithdrawalRequest)57365_storage": {
+      "label": "struct VaultStorage.WithdrawalRequest",
+      "members": [
+        {
+          "label": "withdrawer",
+          "type": "t_address",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "claimed",
+          "type": "t_bool",
+          "offset": 20,
+          "slot": "0"
+        },
+        {
+          "label": "timestamp",
+          "type": "t_uint40",
+          "offset": 21,
+          "slot": "0"
+        },
+        {
+          "label": "amount",
+          "type": "t_uint128",
+          "offset": 0,
+          "slot": "1"
+        },
+        {
+          "label": "queued",
+          "type": "t_uint128",
+          "offset": 16,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_uint128": {
+      "label": "uint128",
+      "numberOfBytes": "16"
+    },
+    "t_uint16": {
+      "label": "uint16",
+      "numberOfBytes": "2"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    },
+    "t_uint40": {
+      "label": "uint40",
+      "numberOfBytes": "5"
+    },
+    "t_uint64": {
+      "label": "uint64",
+      "numberOfBytes": "8"
+    },
+    "t_uint8": {
+      "label": "uint8",
+      "numberOfBytes": "1"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/OUSDCurveAMOProxy-impl.json
+++ b/contracts/storageLayout/mainnet/OUSDCurveAMOProxy-impl.json
@@ -1,0 +1,143 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "maxSlippage",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_uint256",
+      "contract": "CurveAMOStrategy",
+      "src": "contracts/strategies/CurveAMOStrategy.sol:79"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/OUSDProxy-impl.json
+++ b/contracts/storageLayout/mainnet/OUSDProxy-impl.json
@@ -1,0 +1,162 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "_gap",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_array(t_uint256)154_storage",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:69"
+    },
+    {
+      "label": "totalSupply",
+      "offset": 0,
+      "slot": "154",
+      "type": "t_uint256",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:72"
+    },
+    {
+      "label": "allowances",
+      "offset": 0,
+      "slot": "155",
+      "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:73"
+    },
+    {
+      "label": "vaultAddress",
+      "offset": 0,
+      "slot": "156",
+      "type": "t_address",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:76"
+    },
+    {
+      "label": "creditBalances",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:77"
+    },
+    {
+      "label": "rebasingCredits_",
+      "offset": 0,
+      "slot": "158",
+      "type": "t_uint256",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:79"
+    },
+    {
+      "label": "rebasingCreditsPerToken_",
+      "offset": 0,
+      "slot": "159",
+      "type": "t_uint256",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:80"
+    },
+    {
+      "label": "nonRebasingSupply",
+      "offset": 0,
+      "slot": "160",
+      "type": "t_uint256",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:82"
+    },
+    {
+      "label": "alternativeCreditsPerToken",
+      "offset": 0,
+      "slot": "161",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:83"
+    },
+    {
+      "label": "rebaseState",
+      "offset": 0,
+      "slot": "162",
+      "type": "t_mapping(t_address,t_enum(RebaseOptions)5186)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:85"
+    },
+    {
+      "label": "__deprecated_isUpgraded",
+      "offset": 0,
+      "slot": "163",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:86"
+    },
+    {
+      "label": "yieldTo",
+      "offset": 0,
+      "slot": "164",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:91"
+    },
+    {
+      "label": "yieldFrom",
+      "offset": 0,
+      "slot": "165",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:96"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "166",
+      "type": "t_array(t_uint256)34_storage",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:99"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_uint256)154_storage": {
+      "label": "uint256[154]",
+      "numberOfBytes": "4928"
+    },
+    "t_array(t_uint256)34_storage": {
+      "label": "uint256[34]",
+      "numberOfBytes": "1088"
+    },
+    "t_enum(RebaseOptions)5186": {
+      "label": "enum OUSD.RebaseOptions",
+      "members": [
+        "NotSet",
+        "StdNonRebasing",
+        "StdRebasing",
+        "YieldDelegationSource",
+        "YieldDelegationTarget"
+      ],
+      "numberOfBytes": "1"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_enum(RebaseOptions)5186)": {
+      "label": "mapping(address => enum OUSD.RebaseOptions)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+      "label": "mapping(address => mapping(address => uint256))",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_uint256)": {
+      "label": "mapping(address => uint256)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/VaultProxy-impl.json
+++ b/contracts/storageLayout/mainnet/VaultProxy-impl.json
@@ -1,0 +1,515 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "assets",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_mapping(t_address,t_struct(Asset)57206_storage)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:99"
+    },
+    {
+      "label": "allAssets",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:101"
+    },
+    {
+      "label": "strategies",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_struct(Strategy)57221_storage)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:109"
+    },
+    {
+      "label": "allStrategies",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:111"
+    },
+    {
+      "label": "priceProvider",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:114"
+    },
+    {
+      "label": "rebasePaused",
+      "offset": 20,
+      "slot": "55",
+      "type": "t_bool",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:116"
+    },
+    {
+      "label": "capitalPaused",
+      "offset": 21,
+      "slot": "55",
+      "type": "t_bool",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:119"
+    },
+    {
+      "label": "redeemFeeBps",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:121"
+    },
+    {
+      "label": "vaultBuffer",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:123"
+    },
+    {
+      "label": "autoAllocateThreshold",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:125"
+    },
+    {
+      "label": "rebaseThreshold",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:127"
+    },
+    {
+      "label": "oUSD",
+      "offset": 0,
+      "slot": "60",
+      "type": "t_contract(OUSD)48948",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:130"
+    },
+    {
+      "label": "_deprecated_rebaseHooksAddr",
+      "offset": 0,
+      "slot": "61",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:138"
+    },
+    {
+      "label": "_deprecated_uniswapAddr",
+      "offset": 0,
+      "slot": "62",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:141"
+    },
+    {
+      "label": "strategistAddr",
+      "offset": 0,
+      "slot": "63",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:144"
+    },
+    {
+      "label": "assetDefaultStrategies",
+      "offset": 0,
+      "slot": "64",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:148"
+    },
+    {
+      "label": "maxSupplyDiff",
+      "offset": 0,
+      "slot": "65",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:151"
+    },
+    {
+      "label": "trusteeAddress",
+      "offset": 0,
+      "slot": "66",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:154"
+    },
+    {
+      "label": "trusteeFeeBps",
+      "offset": 0,
+      "slot": "67",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:157"
+    },
+    {
+      "label": "_deprecated_swapTokens",
+      "offset": 0,
+      "slot": "68",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:160"
+    },
+    {
+      "label": "ousdMetaStrategy",
+      "offset": 0,
+      "slot": "69",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:166"
+    },
+    {
+      "label": "netOusdMintedForStrategy",
+      "offset": 0,
+      "slot": "70",
+      "type": "t_int256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:169"
+    },
+    {
+      "label": "netOusdMintForStrategyThreshold",
+      "offset": 0,
+      "slot": "71",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:172"
+    },
+    {
+      "label": "swapConfig",
+      "offset": 0,
+      "slot": "72",
+      "type": "t_struct(SwapConfig)57323_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:186"
+    },
+    {
+      "label": "isMintWhitelistedStrategy",
+      "offset": 0,
+      "slot": "73",
+      "type": "t_mapping(t_address,t_bool)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:190"
+    },
+    {
+      "label": "dripper",
+      "offset": 0,
+      "slot": "74",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:194"
+    },
+    {
+      "label": "withdrawalQueueMetadata",
+      "offset": 0,
+      "slot": "75",
+      "type": "t_struct(WithdrawalQueueMetadata)57350_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:214"
+    },
+    {
+      "label": "withdrawalRequests",
+      "offset": 0,
+      "slot": "77",
+      "type": "t_mapping(t_uint256,t_struct(WithdrawalRequest)57365_storage)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:228"
+    },
+    {
+      "label": "withdrawalClaimDelay",
+      "offset": 0,
+      "slot": "78",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:233"
+    },
+    {
+      "label": "lastRebase",
+      "offset": 0,
+      "slot": "79",
+      "type": "t_uint64",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:236"
+    },
+    {
+      "label": "dripDuration",
+      "offset": 8,
+      "slot": "79",
+      "type": "t_uint64",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:239"
+    },
+    {
+      "label": "rebasePerSecondMax",
+      "offset": 16,
+      "slot": "79",
+      "type": "t_uint64",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:244"
+    },
+    {
+      "label": "rebasePerSecondTarget",
+      "offset": 24,
+      "slot": "79",
+      "type": "t_uint64",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:247"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "80",
+      "type": "t_array(t_uint256)43_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:254"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_uint256)43_storage": {
+      "label": "uint256[43]",
+      "numberOfBytes": "1376"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_contract(OUSD)48948": {
+      "label": "contract OUSD",
+      "numberOfBytes": "20"
+    },
+    "t_enum(UnitConversion)57196": {
+      "label": "enum VaultStorage.UnitConversion",
+      "members": [
+        "DECIMALS",
+        "GETEXCHANGERATE"
+      ],
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_bool)": {
+      "label": "mapping(address => bool)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_struct(Asset)57206_storage)": {
+      "label": "mapping(address => struct VaultStorage.Asset)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_struct(Strategy)57221_storage)": {
+      "label": "mapping(address => struct VaultStorage.Strategy)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_uint256,t_struct(WithdrawalRequest)57365_storage)": {
+      "label": "mapping(uint256 => struct VaultStorage.WithdrawalRequest)",
+      "numberOfBytes": "32"
+    },
+    "t_struct(Asset)57206_storage": {
+      "label": "struct VaultStorage.Asset",
+      "members": [
+        {
+          "label": "isSupported",
+          "type": "t_bool",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "unitConversion",
+          "type": "t_enum(UnitConversion)57196",
+          "offset": 1,
+          "slot": "0"
+        },
+        {
+          "label": "decimals",
+          "type": "t_uint8",
+          "offset": 2,
+          "slot": "0"
+        },
+        {
+          "label": "allowedOracleSlippageBps",
+          "type": "t_uint16",
+          "offset": 3,
+          "slot": "0"
+        }
+      ],
+      "numberOfBytes": "32"
+    },
+    "t_struct(Strategy)57221_storage": {
+      "label": "struct VaultStorage.Strategy",
+      "members": [
+        {
+          "label": "isSupported",
+          "type": "t_bool",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "_deprecated",
+          "type": "t_uint256",
+          "offset": 0,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(SwapConfig)57323_storage": {
+      "label": "struct VaultStorage.SwapConfig",
+      "members": [
+        {
+          "label": "swapper",
+          "type": "t_address",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "allowedUndervalueBps",
+          "type": "t_uint16",
+          "offset": 20,
+          "slot": "0"
+        }
+      ],
+      "numberOfBytes": "32"
+    },
+    "t_struct(WithdrawalQueueMetadata)57350_storage": {
+      "label": "struct VaultStorage.WithdrawalQueueMetadata",
+      "members": [
+        {
+          "label": "queued",
+          "type": "t_uint128",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "claimable",
+          "type": "t_uint128",
+          "offset": 16,
+          "slot": "0"
+        },
+        {
+          "label": "claimed",
+          "type": "t_uint128",
+          "offset": 0,
+          "slot": "1"
+        },
+        {
+          "label": "nextWithdrawalIndex",
+          "type": "t_uint128",
+          "offset": 16,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(WithdrawalRequest)57365_storage": {
+      "label": "struct VaultStorage.WithdrawalRequest",
+      "members": [
+        {
+          "label": "withdrawer",
+          "type": "t_address",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "claimed",
+          "type": "t_bool",
+          "offset": 20,
+          "slot": "0"
+        },
+        {
+          "label": "timestamp",
+          "type": "t_uint40",
+          "offset": 21,
+          "slot": "0"
+        },
+        {
+          "label": "amount",
+          "type": "t_uint128",
+          "offset": 0,
+          "slot": "1"
+        },
+        {
+          "label": "queued",
+          "type": "t_uint128",
+          "offset": 16,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_uint128": {
+      "label": "uint128",
+      "numberOfBytes": "16"
+    },
+    "t_uint16": {
+      "label": "uint16",
+      "numberOfBytes": "2"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    },
+    "t_uint40": {
+      "label": "uint40",
+      "numberOfBytes": "5"
+    },
+    "t_uint64": {
+      "label": "uint64",
+      "numberOfBytes": "8"
+    },
+    "t_uint8": {
+      "label": "uint8",
+      "numberOfBytes": "1"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/WOETHProxy-impl.json
+++ b/contracts/storageLayout/mainnet/WOETHProxy-impl.json
@@ -1,0 +1,119 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "_balances",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:36"
+    },
+    {
+      "label": "_allowances",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:38"
+    },
+    {
+      "label": "_totalSupply",
+      "offset": 0,
+      "slot": "2",
+      "type": "t_uint256",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:40"
+    },
+    {
+      "label": "_name",
+      "offset": 0,
+      "slot": "3",
+      "type": "t_string_storage",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:42"
+    },
+    {
+      "label": "_symbol",
+      "offset": 0,
+      "slot": "4",
+      "type": "t_string_storage",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:43"
+    },
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "5",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "5",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "6",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "adjuster",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "WOETH",
+      "src": "contracts/token/WOETH.sol:41"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_array(t_uint256)49_storage",
+      "contract": "WOETH",
+      "src": "contracts/token/WOETH.sol:42"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_uint256)49_storage": {
+      "label": "uint256[49]",
+      "numberOfBytes": "1568"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+      "label": "mapping(address => mapping(address => uint256))",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_uint256)": {
+      "label": "mapping(address => uint256)",
+      "numberOfBytes": "32"
+    },
+    "t_string_storage": {
+      "label": "string",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/mainnet/WrappedOUSDProxy-impl.json
+++ b/contracts/storageLayout/mainnet/WrappedOUSDProxy-impl.json
@@ -1,0 +1,119 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "_balances",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:36"
+    },
+    {
+      "label": "_allowances",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:38"
+    },
+    {
+      "label": "_totalSupply",
+      "offset": 0,
+      "slot": "2",
+      "type": "t_uint256",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:40"
+    },
+    {
+      "label": "_name",
+      "offset": 0,
+      "slot": "3",
+      "type": "t_string_storage",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:42"
+    },
+    {
+      "label": "_symbol",
+      "offset": 0,
+      "slot": "4",
+      "type": "t_string_storage",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:43"
+    },
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "5",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "5",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "6",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "adjuster",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "WOETH",
+      "src": "contracts/token/WOETH.sol:41"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_array(t_uint256)49_storage",
+      "contract": "WOETH",
+      "src": "contracts/token/WOETH.sol:42"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_uint256)49_storage": {
+      "label": "uint256[49]",
+      "numberOfBytes": "1568"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+      "label": "mapping(address => mapping(address => uint256))",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_uint256)": {
+      "label": "mapping(address => uint256)",
+      "numberOfBytes": "32"
+    },
+    "t_string_storage": {
+      "label": "string",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/plume/BridgedWOETHProxy-impl.json
+++ b/contracts/storageLayout/plume/BridgedWOETHProxy-impl.json
@@ -1,0 +1,187 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "_roles",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_mapping(t_bytes32,t_struct(RoleData)5668_storage)",
+      "contract": "AccessControl",
+      "src": "@openzeppelin/contracts/access/AccessControl.sol:55"
+    },
+    {
+      "label": "_roleMembers",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_mapping(t_bytes32,t_struct(AddressSet)8931_storage)",
+      "contract": "AccessControlEnumerable",
+      "src": "@openzeppelin/contracts/access/AccessControlEnumerable.sol:16"
+    },
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "2",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "2",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "3",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_balances",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:36"
+    },
+    {
+      "label": "_allowances",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:38"
+    },
+    {
+      "label": "_totalSupply",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_uint256",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:40"
+    },
+    {
+      "label": "_name",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_string_storage",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:42"
+    },
+    {
+      "label": "_symbol",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_string_storage",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:43"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_bytes32)dyn_storage": {
+      "label": "bytes32[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_bytes32": {
+      "label": "bytes32",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_bool)": {
+      "label": "mapping(address => bool)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+      "label": "mapping(address => mapping(address => uint256))",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_uint256)": {
+      "label": "mapping(address => uint256)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_bytes32,t_struct(AddressSet)8931_storage)": {
+      "label": "mapping(bytes32 => struct EnumerableSet.AddressSet)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_bytes32,t_struct(RoleData)5668_storage)": {
+      "label": "mapping(bytes32 => struct AccessControl.RoleData)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_bytes32,t_uint256)": {
+      "label": "mapping(bytes32 => uint256)",
+      "numberOfBytes": "32"
+    },
+    "t_string_storage": {
+      "label": "string",
+      "numberOfBytes": "32"
+    },
+    "t_struct(AddressSet)8931_storage": {
+      "label": "struct EnumerableSet.AddressSet",
+      "members": [
+        {
+          "label": "_inner",
+          "type": "t_struct(Set)8630_storage",
+          "offset": 0,
+          "slot": "0"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(RoleData)5668_storage": {
+      "label": "struct AccessControl.RoleData",
+      "members": [
+        {
+          "label": "members",
+          "type": "t_mapping(t_address,t_bool)",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "adminRole",
+          "type": "t_bytes32",
+          "offset": 0,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(Set)8630_storage": {
+      "label": "struct EnumerableSet.Set",
+      "members": [
+        {
+          "label": "_values",
+          "type": "t_array(t_bytes32)dyn_storage",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "_indexes",
+          "type": "t_mapping(t_bytes32,t_uint256)",
+          "offset": 0,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/plume/BridgedWOETHStrategyProxy-impl.json
+++ b/contracts/storageLayout/plume/BridgedWOETHStrategyProxy-impl.json
@@ -1,0 +1,155 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "lastOraclePrice",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_uint128",
+      "contract": "BridgedWOETHStrategy",
+      "src": "contracts/strategies/BridgedWOETHStrategy.sol:27"
+    },
+    {
+      "label": "maxPriceDiffBps",
+      "offset": 16,
+      "slot": "157",
+      "type": "t_uint128",
+      "contract": "BridgedWOETHStrategy",
+      "src": "contracts/strategies/BridgedWOETHStrategy.sol:28"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_uint128": {
+      "label": "uint128",
+      "numberOfBytes": "16"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/plume/OETHPlumeProxy-impl.json
+++ b/contracts/storageLayout/plume/OETHPlumeProxy-impl.json
@@ -1,0 +1,162 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "_gap",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_array(t_uint256)154_storage",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:69"
+    },
+    {
+      "label": "totalSupply",
+      "offset": 0,
+      "slot": "154",
+      "type": "t_uint256",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:72"
+    },
+    {
+      "label": "allowances",
+      "offset": 0,
+      "slot": "155",
+      "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:73"
+    },
+    {
+      "label": "vaultAddress",
+      "offset": 0,
+      "slot": "156",
+      "type": "t_address",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:76"
+    },
+    {
+      "label": "creditBalances",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:77"
+    },
+    {
+      "label": "rebasingCredits_",
+      "offset": 0,
+      "slot": "158",
+      "type": "t_uint256",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:79"
+    },
+    {
+      "label": "rebasingCreditsPerToken_",
+      "offset": 0,
+      "slot": "159",
+      "type": "t_uint256",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:80"
+    },
+    {
+      "label": "nonRebasingSupply",
+      "offset": 0,
+      "slot": "160",
+      "type": "t_uint256",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:82"
+    },
+    {
+      "label": "alternativeCreditsPerToken",
+      "offset": 0,
+      "slot": "161",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:83"
+    },
+    {
+      "label": "rebaseState",
+      "offset": 0,
+      "slot": "162",
+      "type": "t_mapping(t_address,t_enum(RebaseOptions)47335)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:85"
+    },
+    {
+      "label": "__deprecated_isUpgraded",
+      "offset": 0,
+      "slot": "163",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:86"
+    },
+    {
+      "label": "yieldTo",
+      "offset": 0,
+      "slot": "164",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:91"
+    },
+    {
+      "label": "yieldFrom",
+      "offset": 0,
+      "slot": "165",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:96"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "166",
+      "type": "t_array(t_uint256)34_storage",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:99"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_uint256)154_storage": {
+      "label": "uint256[154]",
+      "numberOfBytes": "4928"
+    },
+    "t_array(t_uint256)34_storage": {
+      "label": "uint256[34]",
+      "numberOfBytes": "1088"
+    },
+    "t_enum(RebaseOptions)47335": {
+      "label": "enum OUSD.RebaseOptions",
+      "members": [
+        "NotSet",
+        "StdNonRebasing",
+        "StdRebasing",
+        "YieldDelegationSource",
+        "YieldDelegationTarget"
+      ],
+      "numberOfBytes": "1"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_enum(RebaseOptions)47335)": {
+      "label": "mapping(address => enum OUSD.RebaseOptions)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+      "label": "mapping(address => mapping(address => uint256))",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_uint256)": {
+      "label": "mapping(address => uint256)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/plume/OETHPlumeVaultProxy-impl.json
+++ b/contracts/storageLayout/plume/OETHPlumeVaultProxy-impl.json
@@ -1,0 +1,531 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "assets",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_mapping(t_address,t_struct(Asset)57206_storage)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:99"
+    },
+    {
+      "label": "allAssets",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:101"
+    },
+    {
+      "label": "strategies",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_struct(Strategy)57221_storage)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:109"
+    },
+    {
+      "label": "allStrategies",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:111"
+    },
+    {
+      "label": "priceProvider",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:114"
+    },
+    {
+      "label": "rebasePaused",
+      "offset": 20,
+      "slot": "55",
+      "type": "t_bool",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:116"
+    },
+    {
+      "label": "capitalPaused",
+      "offset": 21,
+      "slot": "55",
+      "type": "t_bool",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:119"
+    },
+    {
+      "label": "redeemFeeBps",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:121"
+    },
+    {
+      "label": "vaultBuffer",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:123"
+    },
+    {
+      "label": "autoAllocateThreshold",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:125"
+    },
+    {
+      "label": "rebaseThreshold",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:127"
+    },
+    {
+      "label": "oUSD",
+      "offset": 0,
+      "slot": "60",
+      "type": "t_contract(OUSD)48948",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:130"
+    },
+    {
+      "label": "_deprecated_rebaseHooksAddr",
+      "offset": 0,
+      "slot": "61",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:138"
+    },
+    {
+      "label": "_deprecated_uniswapAddr",
+      "offset": 0,
+      "slot": "62",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:141"
+    },
+    {
+      "label": "strategistAddr",
+      "offset": 0,
+      "slot": "63",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:144"
+    },
+    {
+      "label": "assetDefaultStrategies",
+      "offset": 0,
+      "slot": "64",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:148"
+    },
+    {
+      "label": "maxSupplyDiff",
+      "offset": 0,
+      "slot": "65",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:151"
+    },
+    {
+      "label": "trusteeAddress",
+      "offset": 0,
+      "slot": "66",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:154"
+    },
+    {
+      "label": "trusteeFeeBps",
+      "offset": 0,
+      "slot": "67",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:157"
+    },
+    {
+      "label": "_deprecated_swapTokens",
+      "offset": 0,
+      "slot": "68",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:160"
+    },
+    {
+      "label": "ousdMetaStrategy",
+      "offset": 0,
+      "slot": "69",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:166"
+    },
+    {
+      "label": "netOusdMintedForStrategy",
+      "offset": 0,
+      "slot": "70",
+      "type": "t_int256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:169"
+    },
+    {
+      "label": "netOusdMintForStrategyThreshold",
+      "offset": 0,
+      "slot": "71",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:172"
+    },
+    {
+      "label": "swapConfig",
+      "offset": 0,
+      "slot": "72",
+      "type": "t_struct(SwapConfig)57323_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:186"
+    },
+    {
+      "label": "isMintWhitelistedStrategy",
+      "offset": 0,
+      "slot": "73",
+      "type": "t_mapping(t_address,t_bool)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:190"
+    },
+    {
+      "label": "dripper",
+      "offset": 0,
+      "slot": "74",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:194"
+    },
+    {
+      "label": "withdrawalQueueMetadata",
+      "offset": 0,
+      "slot": "75",
+      "type": "t_struct(WithdrawalQueueMetadata)57350_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:214"
+    },
+    {
+      "label": "withdrawalRequests",
+      "offset": 0,
+      "slot": "77",
+      "type": "t_mapping(t_uint256,t_struct(WithdrawalRequest)57365_storage)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:228"
+    },
+    {
+      "label": "withdrawalClaimDelay",
+      "offset": 0,
+      "slot": "78",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:233"
+    },
+    {
+      "label": "lastRebase",
+      "offset": 0,
+      "slot": "79",
+      "type": "t_uint64",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:236"
+    },
+    {
+      "label": "dripDuration",
+      "offset": 8,
+      "slot": "79",
+      "type": "t_uint64",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:239"
+    },
+    {
+      "label": "rebasePerSecondMax",
+      "offset": 16,
+      "slot": "79",
+      "type": "t_uint64",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:244"
+    },
+    {
+      "label": "rebasePerSecondTarget",
+      "offset": 24,
+      "slot": "79",
+      "type": "t_uint64",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:247"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "80",
+      "type": "t_array(t_uint256)43_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:254"
+    },
+    {
+      "label": "wethAssetIndex",
+      "offset": 0,
+      "slot": "123",
+      "type": "t_uint256",
+      "contract": "OETHVaultCore",
+      "src": "contracts/vault/OETHVaultCore.sol:22"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "124",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "OETHVaultCore",
+      "src": "contracts/vault/OETHVaultCore.sol:25"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_uint256)43_storage": {
+      "label": "uint256[43]",
+      "numberOfBytes": "1376"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_contract(OUSD)48948": {
+      "label": "contract OUSD",
+      "numberOfBytes": "20"
+    },
+    "t_enum(UnitConversion)57196": {
+      "label": "enum VaultStorage.UnitConversion",
+      "members": [
+        "DECIMALS",
+        "GETEXCHANGERATE"
+      ],
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_bool)": {
+      "label": "mapping(address => bool)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_struct(Asset)57206_storage)": {
+      "label": "mapping(address => struct VaultStorage.Asset)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_struct(Strategy)57221_storage)": {
+      "label": "mapping(address => struct VaultStorage.Strategy)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_uint256,t_struct(WithdrawalRequest)57365_storage)": {
+      "label": "mapping(uint256 => struct VaultStorage.WithdrawalRequest)",
+      "numberOfBytes": "32"
+    },
+    "t_struct(Asset)57206_storage": {
+      "label": "struct VaultStorage.Asset",
+      "members": [
+        {
+          "label": "isSupported",
+          "type": "t_bool",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "unitConversion",
+          "type": "t_enum(UnitConversion)57196",
+          "offset": 1,
+          "slot": "0"
+        },
+        {
+          "label": "decimals",
+          "type": "t_uint8",
+          "offset": 2,
+          "slot": "0"
+        },
+        {
+          "label": "allowedOracleSlippageBps",
+          "type": "t_uint16",
+          "offset": 3,
+          "slot": "0"
+        }
+      ],
+      "numberOfBytes": "32"
+    },
+    "t_struct(Strategy)57221_storage": {
+      "label": "struct VaultStorage.Strategy",
+      "members": [
+        {
+          "label": "isSupported",
+          "type": "t_bool",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "_deprecated",
+          "type": "t_uint256",
+          "offset": 0,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(SwapConfig)57323_storage": {
+      "label": "struct VaultStorage.SwapConfig",
+      "members": [
+        {
+          "label": "swapper",
+          "type": "t_address",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "allowedUndervalueBps",
+          "type": "t_uint16",
+          "offset": 20,
+          "slot": "0"
+        }
+      ],
+      "numberOfBytes": "32"
+    },
+    "t_struct(WithdrawalQueueMetadata)57350_storage": {
+      "label": "struct VaultStorage.WithdrawalQueueMetadata",
+      "members": [
+        {
+          "label": "queued",
+          "type": "t_uint128",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "claimable",
+          "type": "t_uint128",
+          "offset": 16,
+          "slot": "0"
+        },
+        {
+          "label": "claimed",
+          "type": "t_uint128",
+          "offset": 0,
+          "slot": "1"
+        },
+        {
+          "label": "nextWithdrawalIndex",
+          "type": "t_uint128",
+          "offset": 16,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(WithdrawalRequest)57365_storage": {
+      "label": "struct VaultStorage.WithdrawalRequest",
+      "members": [
+        {
+          "label": "withdrawer",
+          "type": "t_address",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "claimed",
+          "type": "t_bool",
+          "offset": 20,
+          "slot": "0"
+        },
+        {
+          "label": "timestamp",
+          "type": "t_uint40",
+          "offset": 21,
+          "slot": "0"
+        },
+        {
+          "label": "amount",
+          "type": "t_uint128",
+          "offset": 0,
+          "slot": "1"
+        },
+        {
+          "label": "queued",
+          "type": "t_uint128",
+          "offset": 16,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_uint128": {
+      "label": "uint128",
+      "numberOfBytes": "16"
+    },
+    "t_uint16": {
+      "label": "uint16",
+      "numberOfBytes": "2"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    },
+    "t_uint40": {
+      "label": "uint40",
+      "numberOfBytes": "5"
+    },
+    "t_uint64": {
+      "label": "uint64",
+      "numberOfBytes": "8"
+    },
+    "t_uint8": {
+      "label": "uint8",
+      "numberOfBytes": "1"
+    }
+  }
+}

--- a/contracts/storageLayout/plume/WOETHPlumeProxy-impl.json
+++ b/contracts/storageLayout/plume/WOETHPlumeProxy-impl.json
@@ -1,0 +1,119 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "_balances",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:36"
+    },
+    {
+      "label": "_allowances",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:38"
+    },
+    {
+      "label": "_totalSupply",
+      "offset": 0,
+      "slot": "2",
+      "type": "t_uint256",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:40"
+    },
+    {
+      "label": "_name",
+      "offset": 0,
+      "slot": "3",
+      "type": "t_string_storage",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:42"
+    },
+    {
+      "label": "_symbol",
+      "offset": 0,
+      "slot": "4",
+      "type": "t_string_storage",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:43"
+    },
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "5",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "5",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "6",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "adjuster",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "WOETH",
+      "src": "contracts/token/WOETH.sol:41"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_array(t_uint256)49_storage",
+      "contract": "WOETH",
+      "src": "contracts/token/WOETH.sol:42"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_uint256)49_storage": {
+      "label": "uint256[49]",
+      "numberOfBytes": "1568"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+      "label": "mapping(address => mapping(address => uint256))",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_uint256)": {
+      "label": "mapping(address => uint256)",
+      "numberOfBytes": "32"
+    },
+    "t_string_storage": {
+      "label": "string",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/sonic/OSonicDripperProxy-impl.json
+++ b/contracts/storageLayout/sonic/OSonicDripperProxy-impl.json
@@ -1,0 +1,53 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "dripDuration",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_uint256",
+      "contract": "Dripper",
+      "src": "contracts/harvest/Dripper.sol:57"
+    },
+    {
+      "label": "drip",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_struct(Drip)13710_storage",
+      "contract": "Dripper",
+      "src": "contracts/harvest/Dripper.sol:58"
+    }
+  ],
+  "types": {
+    "t_struct(Drip)13710_storage": {
+      "label": "struct Dripper.Drip",
+      "members": [
+        {
+          "label": "lastCollect",
+          "type": "t_uint64",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "perSecond",
+          "type": "t_uint192",
+          "offset": 8,
+          "slot": "0"
+        }
+      ],
+      "numberOfBytes": "32"
+    },
+    "t_uint192": {
+      "label": "uint192",
+      "numberOfBytes": "24"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    },
+    "t_uint64": {
+      "label": "uint64",
+      "numberOfBytes": "8"
+    }
+  }
+}

--- a/contracts/storageLayout/sonic/OSonicHarvesterProxy-impl.json
+++ b/contracts/storageLayout/sonic/OSonicHarvesterProxy-impl.json
@@ -1,0 +1,95 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "strategistAddr",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "Strategizable",
+      "src": "contracts/governance/Strategizable.sol:10"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Strategizable",
+      "src": "contracts/governance/Strategizable.sol:13"
+    },
+    {
+      "label": "dripper",
+      "offset": 0,
+      "slot": "102",
+      "type": "t_address",
+      "contract": "OETHHarvesterSimple",
+      "src": "contracts/harvest/OETHHarvesterSimple.sol:26"
+    },
+    {
+      "label": "supportedStrategies",
+      "offset": 0,
+      "slot": "103",
+      "type": "t_mapping(t_address,t_bool)",
+      "contract": "OETHHarvesterSimple",
+      "src": "contracts/harvest/OETHHarvesterSimple.sol:29"
+    },
+    {
+      "label": "___gap",
+      "offset": 0,
+      "slot": "104",
+      "type": "t_array(t_uint256)48_storage",
+      "contract": "OETHHarvesterSimple",
+      "src": "contracts/harvest/OETHHarvesterSimple.sol:32"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_uint256)48_storage": {
+      "label": "uint256[48]",
+      "numberOfBytes": "1536"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_mapping(t_address,t_bool)": {
+      "label": "mapping(address => bool)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/sonic/OSonicProxy-impl.json
+++ b/contracts/storageLayout/sonic/OSonicProxy-impl.json
@@ -1,0 +1,162 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "_gap",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_array(t_uint256)154_storage",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:69"
+    },
+    {
+      "label": "totalSupply",
+      "offset": 0,
+      "slot": "154",
+      "type": "t_uint256",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:72"
+    },
+    {
+      "label": "allowances",
+      "offset": 0,
+      "slot": "155",
+      "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:73"
+    },
+    {
+      "label": "vaultAddress",
+      "offset": 0,
+      "slot": "156",
+      "type": "t_address",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:76"
+    },
+    {
+      "label": "creditBalances",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:77"
+    },
+    {
+      "label": "rebasingCredits_",
+      "offset": 0,
+      "slot": "158",
+      "type": "t_uint256",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:79"
+    },
+    {
+      "label": "rebasingCreditsPerToken_",
+      "offset": 0,
+      "slot": "159",
+      "type": "t_uint256",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:80"
+    },
+    {
+      "label": "nonRebasingSupply",
+      "offset": 0,
+      "slot": "160",
+      "type": "t_uint256",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:82"
+    },
+    {
+      "label": "alternativeCreditsPerToken",
+      "offset": 0,
+      "slot": "161",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:83"
+    },
+    {
+      "label": "rebaseState",
+      "offset": 0,
+      "slot": "162",
+      "type": "t_mapping(t_address,t_enum(RebaseOptions)47335)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:85"
+    },
+    {
+      "label": "__deprecated_isUpgraded",
+      "offset": 0,
+      "slot": "163",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:86"
+    },
+    {
+      "label": "yieldTo",
+      "offset": 0,
+      "slot": "164",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:91"
+    },
+    {
+      "label": "yieldFrom",
+      "offset": 0,
+      "slot": "165",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:96"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "166",
+      "type": "t_array(t_uint256)34_storage",
+      "contract": "OUSD",
+      "src": "contracts/token/OUSD.sol:99"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_uint256)154_storage": {
+      "label": "uint256[154]",
+      "numberOfBytes": "4928"
+    },
+    "t_array(t_uint256)34_storage": {
+      "label": "uint256[34]",
+      "numberOfBytes": "1088"
+    },
+    "t_enum(RebaseOptions)47335": {
+      "label": "enum OUSD.RebaseOptions",
+      "members": [
+        "NotSet",
+        "StdNonRebasing",
+        "StdRebasing",
+        "YieldDelegationSource",
+        "YieldDelegationTarget"
+      ],
+      "numberOfBytes": "1"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_enum(RebaseOptions)47335)": {
+      "label": "mapping(address => enum OUSD.RebaseOptions)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+      "label": "mapping(address => mapping(address => uint256))",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_uint256)": {
+      "label": "mapping(address => uint256)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/sonic/OSonicVaultProxy-impl.json
+++ b/contracts/storageLayout/sonic/OSonicVaultProxy-impl.json
@@ -1,0 +1,531 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "assets",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_mapping(t_address,t_struct(Asset)57206_storage)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:99"
+    },
+    {
+      "label": "allAssets",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:101"
+    },
+    {
+      "label": "strategies",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_struct(Strategy)57221_storage)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:109"
+    },
+    {
+      "label": "allStrategies",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:111"
+    },
+    {
+      "label": "priceProvider",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:114"
+    },
+    {
+      "label": "rebasePaused",
+      "offset": 20,
+      "slot": "55",
+      "type": "t_bool",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:116"
+    },
+    {
+      "label": "capitalPaused",
+      "offset": 21,
+      "slot": "55",
+      "type": "t_bool",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:119"
+    },
+    {
+      "label": "redeemFeeBps",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:121"
+    },
+    {
+      "label": "vaultBuffer",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:123"
+    },
+    {
+      "label": "autoAllocateThreshold",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:125"
+    },
+    {
+      "label": "rebaseThreshold",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:127"
+    },
+    {
+      "label": "oUSD",
+      "offset": 0,
+      "slot": "60",
+      "type": "t_contract(OUSD)48948",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:130"
+    },
+    {
+      "label": "_deprecated_rebaseHooksAddr",
+      "offset": 0,
+      "slot": "61",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:138"
+    },
+    {
+      "label": "_deprecated_uniswapAddr",
+      "offset": 0,
+      "slot": "62",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:141"
+    },
+    {
+      "label": "strategistAddr",
+      "offset": 0,
+      "slot": "63",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:144"
+    },
+    {
+      "label": "assetDefaultStrategies",
+      "offset": 0,
+      "slot": "64",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:148"
+    },
+    {
+      "label": "maxSupplyDiff",
+      "offset": 0,
+      "slot": "65",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:151"
+    },
+    {
+      "label": "trusteeAddress",
+      "offset": 0,
+      "slot": "66",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:154"
+    },
+    {
+      "label": "trusteeFeeBps",
+      "offset": 0,
+      "slot": "67",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:157"
+    },
+    {
+      "label": "_deprecated_swapTokens",
+      "offset": 0,
+      "slot": "68",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:160"
+    },
+    {
+      "label": "ousdMetaStrategy",
+      "offset": 0,
+      "slot": "69",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:166"
+    },
+    {
+      "label": "netOusdMintedForStrategy",
+      "offset": 0,
+      "slot": "70",
+      "type": "t_int256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:169"
+    },
+    {
+      "label": "netOusdMintForStrategyThreshold",
+      "offset": 0,
+      "slot": "71",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:172"
+    },
+    {
+      "label": "swapConfig",
+      "offset": 0,
+      "slot": "72",
+      "type": "t_struct(SwapConfig)57323_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:186"
+    },
+    {
+      "label": "isMintWhitelistedStrategy",
+      "offset": 0,
+      "slot": "73",
+      "type": "t_mapping(t_address,t_bool)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:190"
+    },
+    {
+      "label": "dripper",
+      "offset": 0,
+      "slot": "74",
+      "type": "t_address",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:194"
+    },
+    {
+      "label": "withdrawalQueueMetadata",
+      "offset": 0,
+      "slot": "75",
+      "type": "t_struct(WithdrawalQueueMetadata)57350_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:214"
+    },
+    {
+      "label": "withdrawalRequests",
+      "offset": 0,
+      "slot": "77",
+      "type": "t_mapping(t_uint256,t_struct(WithdrawalRequest)57365_storage)",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:228"
+    },
+    {
+      "label": "withdrawalClaimDelay",
+      "offset": 0,
+      "slot": "78",
+      "type": "t_uint256",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:233"
+    },
+    {
+      "label": "lastRebase",
+      "offset": 0,
+      "slot": "79",
+      "type": "t_uint64",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:236"
+    },
+    {
+      "label": "dripDuration",
+      "offset": 8,
+      "slot": "79",
+      "type": "t_uint64",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:239"
+    },
+    {
+      "label": "rebasePerSecondMax",
+      "offset": 16,
+      "slot": "79",
+      "type": "t_uint64",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:244"
+    },
+    {
+      "label": "rebasePerSecondTarget",
+      "offset": 24,
+      "slot": "79",
+      "type": "t_uint64",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:247"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "80",
+      "type": "t_array(t_uint256)43_storage",
+      "contract": "VaultStorage",
+      "src": "contracts/vault/VaultStorage.sol:254"
+    },
+    {
+      "label": "wethAssetIndex",
+      "offset": 0,
+      "slot": "123",
+      "type": "t_uint256",
+      "contract": "OETHVaultCore",
+      "src": "contracts/vault/OETHVaultCore.sol:22"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "124",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "OETHVaultCore",
+      "src": "contracts/vault/OETHVaultCore.sol:25"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_uint256)43_storage": {
+      "label": "uint256[43]",
+      "numberOfBytes": "1376"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_contract(OUSD)48948": {
+      "label": "contract OUSD",
+      "numberOfBytes": "20"
+    },
+    "t_enum(UnitConversion)57196": {
+      "label": "enum VaultStorage.UnitConversion",
+      "members": [
+        "DECIMALS",
+        "GETEXCHANGERATE"
+      ],
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_bool)": {
+      "label": "mapping(address => bool)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_struct(Asset)57206_storage)": {
+      "label": "mapping(address => struct VaultStorage.Asset)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_struct(Strategy)57221_storage)": {
+      "label": "mapping(address => struct VaultStorage.Strategy)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_uint256,t_struct(WithdrawalRequest)57365_storage)": {
+      "label": "mapping(uint256 => struct VaultStorage.WithdrawalRequest)",
+      "numberOfBytes": "32"
+    },
+    "t_struct(Asset)57206_storage": {
+      "label": "struct VaultStorage.Asset",
+      "members": [
+        {
+          "label": "isSupported",
+          "type": "t_bool",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "unitConversion",
+          "type": "t_enum(UnitConversion)57196",
+          "offset": 1,
+          "slot": "0"
+        },
+        {
+          "label": "decimals",
+          "type": "t_uint8",
+          "offset": 2,
+          "slot": "0"
+        },
+        {
+          "label": "allowedOracleSlippageBps",
+          "type": "t_uint16",
+          "offset": 3,
+          "slot": "0"
+        }
+      ],
+      "numberOfBytes": "32"
+    },
+    "t_struct(Strategy)57221_storage": {
+      "label": "struct VaultStorage.Strategy",
+      "members": [
+        {
+          "label": "isSupported",
+          "type": "t_bool",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "_deprecated",
+          "type": "t_uint256",
+          "offset": 0,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(SwapConfig)57323_storage": {
+      "label": "struct VaultStorage.SwapConfig",
+      "members": [
+        {
+          "label": "swapper",
+          "type": "t_address",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "allowedUndervalueBps",
+          "type": "t_uint16",
+          "offset": 20,
+          "slot": "0"
+        }
+      ],
+      "numberOfBytes": "32"
+    },
+    "t_struct(WithdrawalQueueMetadata)57350_storage": {
+      "label": "struct VaultStorage.WithdrawalQueueMetadata",
+      "members": [
+        {
+          "label": "queued",
+          "type": "t_uint128",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "claimable",
+          "type": "t_uint128",
+          "offset": 16,
+          "slot": "0"
+        },
+        {
+          "label": "claimed",
+          "type": "t_uint128",
+          "offset": 0,
+          "slot": "1"
+        },
+        {
+          "label": "nextWithdrawalIndex",
+          "type": "t_uint128",
+          "offset": 16,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_struct(WithdrawalRequest)57365_storage": {
+      "label": "struct VaultStorage.WithdrawalRequest",
+      "members": [
+        {
+          "label": "withdrawer",
+          "type": "t_address",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "claimed",
+          "type": "t_bool",
+          "offset": 20,
+          "slot": "0"
+        },
+        {
+          "label": "timestamp",
+          "type": "t_uint40",
+          "offset": 21,
+          "slot": "0"
+        },
+        {
+          "label": "amount",
+          "type": "t_uint128",
+          "offset": 0,
+          "slot": "1"
+        },
+        {
+          "label": "queued",
+          "type": "t_uint128",
+          "offset": 16,
+          "slot": "1"
+        }
+      ],
+      "numberOfBytes": "64"
+    },
+    "t_uint128": {
+      "label": "uint128",
+      "numberOfBytes": "16"
+    },
+    "t_uint16": {
+      "label": "uint16",
+      "numberOfBytes": "2"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    },
+    "t_uint40": {
+      "label": "uint40",
+      "numberOfBytes": "5"
+    },
+    "t_uint64": {
+      "label": "uint64",
+      "numberOfBytes": "8"
+    },
+    "t_uint8": {
+      "label": "uint8",
+      "numberOfBytes": "1"
+    }
+  }
+}

--- a/contracts/storageLayout/sonic/PoolBoostCentralRegistryProxy-impl.json
+++ b/contracts/storageLayout/sonic/PoolBoostCentralRegistryProxy-impl.json
@@ -1,0 +1,23 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "factories",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "PoolBoostCentralRegistry",
+      "src": "contracts/poolBooster/PoolBoostCentralRegistry.sol:17"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/sonic/SonicStakingStrategyProxy-impl.json
+++ b/contracts/storageLayout/sonic/SonicStakingStrategyProxy-impl.json
@@ -1,0 +1,235 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "nextWithdrawId",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_uint256",
+      "contract": "SonicValidatorDelegator",
+      "src": "contracts/strategies/sonic/SonicValidatorDelegator.sol:22"
+    },
+    {
+      "label": "pendingWithdrawals",
+      "offset": 0,
+      "slot": "158",
+      "type": "t_uint256",
+      "contract": "SonicValidatorDelegator",
+      "src": "contracts/strategies/sonic/SonicValidatorDelegator.sol:24"
+    },
+    {
+      "label": "supportedValidators",
+      "offset": 0,
+      "slot": "159",
+      "type": "t_array(t_uint256)dyn_storage",
+      "contract": "SonicValidatorDelegator",
+      "src": "contracts/strategies/sonic/SonicValidatorDelegator.sol:27"
+    },
+    {
+      "label": "defaultValidatorId",
+      "offset": 0,
+      "slot": "160",
+      "type": "t_uint256",
+      "contract": "SonicValidatorDelegator",
+      "src": "contracts/strategies/sonic/SonicValidatorDelegator.sol:30"
+    },
+    {
+      "label": "withdrawals",
+      "offset": 0,
+      "slot": "161",
+      "type": "t_mapping(t_uint256,t_struct(WithdrawRequest)46212_storage)",
+      "contract": "SonicValidatorDelegator",
+      "src": "contracts/strategies/sonic/SonicValidatorDelegator.sol:38"
+    },
+    {
+      "label": "validatorRegistrator",
+      "offset": 0,
+      "slot": "162",
+      "type": "t_address",
+      "contract": "SonicValidatorDelegator",
+      "src": "contracts/strategies/sonic/SonicValidatorDelegator.sol:41"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "163",
+      "type": "t_array(t_uint256)44_storage",
+      "contract": "SonicValidatorDelegator",
+      "src": "contracts/strategies/sonic/SonicValidatorDelegator.sol:44"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "207",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "SonicStakingStrategy",
+      "src": "contracts/strategies/sonic/SonicStakingStrategy.sol:15"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)44_storage": {
+      "label": "uint256[44]",
+      "numberOfBytes": "1408"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_array(t_uint256)dyn_storage": {
+      "label": "uint256[]",
+      "numberOfBytes": "32"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_uint256,t_struct(WithdrawRequest)46212_storage)": {
+      "label": "mapping(uint256 => struct SonicValidatorDelegator.WithdrawRequest)",
+      "numberOfBytes": "32"
+    },
+    "t_struct(WithdrawRequest)46212_storage": {
+      "label": "struct SonicValidatorDelegator.WithdrawRequest",
+      "members": [
+        {
+          "label": "validatorId",
+          "type": "t_uint256",
+          "offset": 0,
+          "slot": "0"
+        },
+        {
+          "label": "undelegatedAmount",
+          "type": "t_uint256",
+          "offset": 0,
+          "slot": "1"
+        },
+        {
+          "label": "timestamp",
+          "type": "t_uint256",
+          "offset": 0,
+          "slot": "2"
+        }
+      ],
+      "numberOfBytes": "96"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/sonic/SonicSwapXAMOStrategyProxy-impl.json
+++ b/contracts/storageLayout/sonic/SonicSwapXAMOStrategyProxy-impl.json
@@ -1,0 +1,143 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "0",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "_deprecated_platformAddress",
+      "offset": 0,
+      "slot": "51",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:43"
+    },
+    {
+      "label": "_deprecated_vaultAddress",
+      "offset": 0,
+      "slot": "52",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:47"
+    },
+    {
+      "label": "assetToPToken",
+      "offset": 0,
+      "slot": "53",
+      "type": "t_mapping(t_address,t_address)",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:50"
+    },
+    {
+      "label": "assetsMapped",
+      "offset": 0,
+      "slot": "54",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:53"
+    },
+    {
+      "label": "_deprecated_rewardTokenAddress",
+      "offset": 0,
+      "slot": "55",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:57"
+    },
+    {
+      "label": "_deprecated_rewardLiquidationThreshold",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:61"
+    },
+    {
+      "label": "harvesterAddress",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_address",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:64"
+    },
+    {
+      "label": "rewardTokenAddresses",
+      "offset": 0,
+      "slot": "58",
+      "type": "t_array(t_address)dyn_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:67"
+    },
+    {
+      "label": "_reserved",
+      "offset": 0,
+      "slot": "59",
+      "type": "t_array(t_int256)98_storage",
+      "contract": "InitializableAbstractStrategy",
+      "src": "contracts/utils/InitializableAbstractStrategy.sol:74"
+    },
+    {
+      "label": "maxDepeg",
+      "offset": 0,
+      "slot": "157",
+      "type": "t_uint256",
+      "contract": "SonicSwapXAMOStrategy",
+      "src": "contracts/strategies/sonic/SonicSwapXAMOStrategy.sol:52"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_address)dyn_storage": {
+      "label": "address[]",
+      "numberOfBytes": "32"
+    },
+    "t_array(t_int256)98_storage": {
+      "label": "int256[98]",
+      "numberOfBytes": "3136"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_int256": {
+      "label": "int256",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_address)": {
+      "label": "mapping(address => address)",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/storageLayout/sonic/WOSonicProxy-impl.json
+++ b/contracts/storageLayout/sonic/WOSonicProxy-impl.json
@@ -1,0 +1,119 @@
+{
+  "solcVersion": "0.8.28",
+  "storage": [
+    {
+      "label": "_balances",
+      "offset": 0,
+      "slot": "0",
+      "type": "t_mapping(t_address,t_uint256)",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:36"
+    },
+    {
+      "label": "_allowances",
+      "offset": 0,
+      "slot": "1",
+      "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:38"
+    },
+    {
+      "label": "_totalSupply",
+      "offset": 0,
+      "slot": "2",
+      "type": "t_uint256",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:40"
+    },
+    {
+      "label": "_name",
+      "offset": 0,
+      "slot": "3",
+      "type": "t_string_storage",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:42"
+    },
+    {
+      "label": "_symbol",
+      "offset": 0,
+      "slot": "4",
+      "type": "t_string_storage",
+      "contract": "ERC20",
+      "src": "@openzeppelin/contracts/token/ERC20/ERC20.sol:43"
+    },
+    {
+      "label": "initialized",
+      "offset": 0,
+      "slot": "5",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:12"
+    },
+    {
+      "label": "initializing",
+      "offset": 1,
+      "slot": "5",
+      "type": "t_bool",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:17"
+    },
+    {
+      "label": "______gap",
+      "offset": 0,
+      "slot": "6",
+      "type": "t_array(t_uint256)50_storage",
+      "contract": "Initializable",
+      "src": "contracts/utils/Initializable.sol:41"
+    },
+    {
+      "label": "adjuster",
+      "offset": 0,
+      "slot": "56",
+      "type": "t_uint256",
+      "contract": "WOETH",
+      "src": "contracts/token/WOETH.sol:41"
+    },
+    {
+      "label": "__gap",
+      "offset": 0,
+      "slot": "57",
+      "type": "t_array(t_uint256)49_storage",
+      "contract": "WOETH",
+      "src": "contracts/token/WOETH.sol:42"
+    }
+  ],
+  "types": {
+    "t_address": {
+      "label": "address",
+      "numberOfBytes": "20"
+    },
+    "t_array(t_uint256)49_storage": {
+      "label": "uint256[49]",
+      "numberOfBytes": "1568"
+    },
+    "t_array(t_uint256)50_storage": {
+      "label": "uint256[50]",
+      "numberOfBytes": "1600"
+    },
+    "t_bool": {
+      "label": "bool",
+      "numberOfBytes": "1"
+    },
+    "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+      "label": "mapping(address => mapping(address => uint256))",
+      "numberOfBytes": "32"
+    },
+    "t_mapping(t_address,t_uint256)": {
+      "label": "mapping(address => uint256)",
+      "numberOfBytes": "32"
+    },
+    "t_string_storage": {
+      "label": "string",
+      "numberOfBytes": "32"
+    },
+    "t_uint256": {
+      "label": "uint256",
+      "numberOfBytes": "32"
+    }
+  }
+}

--- a/contracts/tasks/storageSlots.js
+++ b/contracts/tasks/storageSlots.js
@@ -14,7 +14,7 @@ const log = require("../utils/logger")("task:storage");
 
 const isFork = process.env.FORK === "true";
 
-const getStorageFileLocation = (hre, contractName) => {
+const getStorageFileLocation = (hre, contractName, isUpgradeableProxy) => {
   const isMainnet = hre.network.name === "mainnet";
   const isArbitrum = hre.network.name === "arbitrumOne";
   const isSonic = hre.network.name === "sonic";
@@ -24,6 +24,8 @@ const getStorageFileLocation = (hre, contractName) => {
   const isMainnetFork = isFork && forkNetworkName == "mainnet";
   const isPlume = hre.network.name == "plume";
   const isPlumeFork = isFork && forkNetworkName == "plume";
+  const isBase = hre.network.name == "base";
+  const isBaseFork = isFork && forkNetworkName == "base";
 
   let folder = "localhost";
   if (isMainnetFork || isMainnet) {
@@ -34,6 +36,8 @@ const getStorageFileLocation = (hre, contractName) => {
     folder = "sonic";
   } else if (isPlumeFork || isPlume) {
     folder = "plume";
+  } else if (isBaseFork || isBase) {
+    folder = "base";
   }
 
   const layoutFolder = `./storageLayout/${folder}/`;
@@ -41,7 +45,9 @@ const getStorageFileLocation = (hre, contractName) => {
     mkdirSync(layoutFolder);
   }
 
-  return `${layoutFolder}${contractName}.json`;
+  return `${layoutFolder}${contractName}${
+    isUpgradeableProxy ? "-impl" : ""
+  }.json`;
 };
 
 const getStorageLayoutForContract = async (hre, contractName, contract) => {
@@ -59,8 +65,16 @@ const getStorageLayoutForContract = async (hre, contractName, contract) => {
   return getStorageLayout(validations, version);
 };
 
-const loadPreviousStorageLayoutForContract = async (hre, contractName) => {
-  const location = getStorageFileLocation(hre, contractName);
+const loadPreviousStorageLayoutForContract = async (
+  hre,
+  contractName,
+  isUpgradeableProxy
+) => {
+  const location = getStorageFileLocation(
+    hre,
+    contractName,
+    isUpgradeableProxy
+  );
 
   // new contract
   if (!existsSync(location)) {
@@ -76,9 +90,18 @@ const loadPreviousStorageLayoutForContract = async (hre, contractName) => {
 // @param contract the name of the contract as is in the source code of the contract
 // @param contractName a potential override of the contract as is to be stored in the
 //        deployment descriptors
-const storeStorageLayoutForContract = async (hre, contractName, contract) => {
+const storeStorageLayoutForContract = async (
+  hre,
+  contractName,
+  contract,
+  isUpgradeableProxy
+) => {
   const layout = await getStorageLayoutForContract(hre, contractName, contract);
-  const storageLayoutFile = getStorageFileLocation(hre, contractName);
+  const storageLayoutFile = getStorageFileLocation(
+    hre,
+    contractName,
+    isUpgradeableProxy
+  );
 
   // pretty print storage layout for the contract
   await promises.writeFile(storageLayoutFile, JSON.stringify(layout, null, 2));
@@ -102,6 +125,9 @@ const isContractEligible = (contractName) => {
     "MinuteTimelock",
     "OpenUniswapOracle",
     "RebaseHooks",
+    "LidoWithdrawalStrategy",
+    "SingleAssetStaking",
+    "ThreePoolStrategy",
   ];
 
   // Need to exclude proxies as well since they are not upgradeable
@@ -364,6 +390,153 @@ const readValidations = async (hre) => {
   }
 };
 
+const getStorageLayoutForProxy = async (hre, proxyName) => {
+  if (proxyName.startsWith("Mock")) {
+    console.error(
+      `Skipping storage slot validation for mock contract: ${proxyName}.`
+    );
+    return false;
+  }
+
+  const deployments = await hre.deployments.all();
+  const dProxy = deployments[proxyName];
+
+  if (!dProxy) {
+    throw new Error(`Proxy contract ${proxyName} not found`);
+  }
+
+  const cProxy = await hre.ethers.getContractAt(
+    ["function implementation() view returns (address)"],
+    dProxy.address
+  );
+  const implAddr = await cProxy.implementation();
+
+  if (implAddr == "0x0000000000000000000000000000000000000000") {
+    console.error(
+      `Skipping storage slot validation for proxy with no implementation: ${proxyName}.`
+    );
+    return false;
+  }
+
+  // We used the same artifact name for different contracts. This is a mapping of
+  // implementation addresses to the contract name to resolve any conflicts.
+  const implementationNamesForDuplicateArtifacts = {
+    // SSR Strategy
+    "0xb3155b7eb46e75ae20c9562af697c144f34c2509": "Generalized4626Strategy",
+    // DSR Strategy
+    "0x8a3b6d3739461137d20825c36ed6016803d3104f": "Generalized4626Strategy",
+    // MetaMorpho Strategy:
+    "0x41bd943923c31d277aa1becbc702b825f2bb8639": "Generalized4626Strategy",
+    // FeeAccumulator for second Native Staking Strategy
+    "0x9178a430b0fc78adec0ae1686557a53ebb382361": "FeeAccumulator",
+    // FeeAccumulator for third Native Staking Strategy
+    "0xebb078722b231a889351e13e05f1a694d89ce8a9": "FeeAccumulator",
+    // Second NativeStakingStrategy
+    "0x0643b19f9f978322b4f2f13b091a13e60ecbbce3": "NativeStakingSSVStrategy",
+    // Third NativeStakingStrategy
+    "0x492500a6cfb1248b5b6b7c674fd66c66ca57b905": "NativeStakingSSVStrategy",
+    // OUSDCurveAMO
+    "0xd7e36afe9dac8424b180b850616ba34be57277f9": "CurveAMOStrategy",
+  };
+
+  const implName =
+    Object.keys(deployments).find(
+      (x) => deployments[x].address.toLowerCase() == implAddr.toLowerCase()
+    ) || implementationNamesForDuplicateArtifacts[implAddr.toLowerCase()];
+  if (!implName) {
+    throw new Error(
+      `Implementation not found in artifacts for Proxy: ${proxyName} -> ${implAddr}`
+    );
+  }
+
+  if (!isContractEligible(implName)) {
+    console.error(
+      `Skipping storage slot validation for deprecated contract: ${proxyName} -> ${implName}.`
+    );
+    return false;
+  }
+
+  return await getStorageLayoutForContract(hre, implName);
+};
+
+const storeStorageLayoutForProxy = async (hre, proxyName) => {
+  const layout = await getStorageLayoutForProxy(hre, proxyName);
+  if (!layout) {
+    return;
+  }
+
+  const storageLayoutFile = getStorageFileLocation(hre, proxyName, true);
+  await promises.writeFile(storageLayoutFile, JSON.stringify(layout, null, 2));
+  console.log(
+    `Storage slots layout for ${proxyName} saved to ${storageLayoutFile} `
+  );
+};
+
+const getAllEligibleProxyNames = async (hre) => {
+  const deployments = await hre.deployments.all();
+  const proxyNames = [];
+  for (const deploymentName of Object.keys(deployments)) {
+    if (await isProxyContractEligible(hre, deploymentName)) {
+      proxyNames.push(deploymentName);
+    }
+  }
+  return proxyNames;
+};
+
+const isProxyContractEligible = async (hre, proxyName) => {
+  // These contracts have been deprecated and we no longer have the
+  // source code of implementation in our repo.
+  const excludeContracts = [
+    "LidoWithdrawalStrategyProxy",
+    "MakerDsrStrategyProxy",
+    "CurveUSDTStrategyProxy",
+    "CurveUSDCStrategyProxy",
+  ];
+
+  if (excludeContracts.includes(proxyName) || !proxyName.endsWith("Proxy")) {
+    return false;
+  }
+
+  const deployments = await hre.deployments.all();
+  return Boolean(deployments[proxyName]);
+};
+
+const storeStorageLayoutForAllProxies = async (hre) => {
+  const proxyNames = await getAllEligibleProxyNames(hre);
+  for (const proxyName of proxyNames) {
+    await storeStorageLayoutForProxy(hre, proxyName);
+  }
+};
+
+const assertStorageLayoutForProxy = async (hre, proxyName) => {
+  const storageLayout = await getStorageLayoutForProxy(hre, proxyName);
+  if (!storageLayout) {
+    return;
+  }
+
+  const oldLayout = await loadPreviousStorageLayoutForContract(
+    hre,
+    proxyName,
+    true
+  );
+  if (!oldLayout) {
+    console.log(
+      `Previous storage layout for ${proxyName} not found. Treating ${proxyName} as a new contract.`
+    );
+  } else {
+    // 3rd param is opts.unsafeAllowCustomTypes
+    assertStorageUpgradeSafe(oldLayout, storageLayout, false);
+    console.log(`[storage-slots] Contract ${proxyName} is safe for upgrade`);
+  }
+};
+
+const assertStorageLayoutForAllProxies = async (hre) => {
+  const proxyNames = await getAllEligibleProxyNames(hre);
+  for (const proxyName of proxyNames) {
+    await assertStorageLayoutForProxy(hre, proxyName);
+  }
+};
+
 module.exports = {
   storeStorageLayoutForAllContracts,
   assertStorageLayoutChangeSafe,
@@ -371,4 +544,9 @@ module.exports = {
   assertUpgradeIsSafe,
   storeStorageLayoutForContract,
   showStorageLayout,
+  getStorageLayoutForProxy,
+  storeStorageLayoutForProxy,
+  storeStorageLayoutForAllProxies,
+  assertStorageLayoutForProxy,
+  assertStorageLayoutForAllProxies,
 };

--- a/contracts/tasks/storageSlots.js
+++ b/contracts/tasks/storageSlots.js
@@ -520,8 +520,8 @@ const assertStorageLayoutForProxy = async (hre, proxyName) => {
     true
   );
   if (!oldLayout) {
-    console.log(
-      `Previous storage layout for ${proxyName} not found. Treating ${proxyName} as a new contract.`
+    throw new Error(
+      `Cannot find storage layout for ${proxyName}. Run "npx hardhat storeStorageLayoutForProxy --network ${hre.network.name} --proxy ${proxyName}"`
     );
   } else {
     // 3rd param is opts.unsafeAllowCustomTypes

--- a/contracts/tasks/tasks.js
+++ b/contracts/tasks/tasks.js
@@ -25,6 +25,10 @@ const {
   assertStorageLayoutChangeSafe,
   assertStorageLayoutChangeSafeForAll,
   showStorageLayout,
+  storeStorageLayoutForProxy,
+  storeStorageLayoutForAllProxies,
+  assertStorageLayoutForProxy,
+  assertStorageLayoutForAllProxies,
 } = require("./storageSlots");
 const {
   isAdjusterLocked,
@@ -1829,3 +1833,23 @@ task("lzSetConfig")
   .setAction(async (taskArgs) => {
     await lzSetConfig(taskArgs, hre);
   });
+
+task("storeStorageLayoutForProxy")
+  .addParam("proxy", "Name of the proxy contract")
+  .setAction(async (taskArgs) => {
+    await storeStorageLayoutForProxy(hre, taskArgs.proxy);
+  });
+
+task("storeStorageLayoutForAllProxies").setAction(async () => {
+  await storeStorageLayoutForAllProxies(hre);
+});
+
+task("assertStorageLayoutForProxy")
+  .addParam("proxy", "Name of the proxy contract")
+  .setAction(async (taskArgs) => {
+    await assertStorageLayoutForProxy(hre, taskArgs.proxy);
+  });
+
+task("assertStorageLayoutForAllProxies").setAction(async () => {
+  await assertStorageLayoutForAllProxies(hre);
+});

--- a/contracts/test/upgrades/storage-layout.arb.fork-test.js
+++ b/contracts/test/upgrades/storage-layout.arb.fork-test.js
@@ -1,0 +1,19 @@
+const { createFixtureLoader } = require("../_fixture");
+const { defaultArbitrumFixture } = require("../_fixture-arbitrum");
+const {
+  assertStorageLayoutForAllProxies,
+} = require("../../tasks/storageSlots");
+
+const hre = require("hardhat");
+const loadFixture = createFixtureLoader(defaultArbitrumFixture);
+
+describe("ForkTest: Storage Layout", function () {
+  beforeEach(async () => {
+    // Load fixture to run deployments
+    await loadFixture();
+  });
+
+  it("No proxy should have unexpected storage layout changes", async () => {
+    await assertStorageLayoutForAllProxies(hre);
+  });
+});

--- a/contracts/test/upgrades/storage-layout.arb.fork-test.js
+++ b/contracts/test/upgrades/storage-layout.arb.fork-test.js
@@ -1,5 +1,5 @@
 const { createFixtureLoader } = require("../_fixture");
-const { defaultArbitrumFixture } = require("../_fixture-arbitrum");
+const { defaultArbitrumFixture } = require("../_fixture-arb");
 const {
   assertStorageLayoutForAllProxies,
 } = require("../../tasks/storageSlots");

--- a/contracts/test/upgrades/storage-layout.base.fork-test.js
+++ b/contracts/test/upgrades/storage-layout.base.fork-test.js
@@ -1,0 +1,19 @@
+const { createFixtureLoader } = require("../_fixture");
+const { defaultBaseFixture } = require("../_fixture-base");
+const {
+  assertStorageLayoutForAllProxies,
+} = require("../../tasks/storageSlots");
+
+const hre = require("hardhat");
+const baseFixture = createFixtureLoader(defaultBaseFixture);
+
+describe("ForkTest: Storage Layout", function () {
+  beforeEach(async () => {
+    // Load fixture to run deployments
+    await baseFixture();
+  });
+
+  it("No proxy should have unexpected storage layout changes", async () => {
+    await assertStorageLayoutForAllProxies(hre);
+  });
+});

--- a/contracts/test/upgrades/storage-layout.mainnet.fork-test.js
+++ b/contracts/test/upgrades/storage-layout.mainnet.fork-test.js
@@ -1,0 +1,19 @@
+const { createFixtureLoader } = require("../_fixture");
+const { defaultFixture } = require("../_fixture");
+const {
+  assertStorageLayoutForAllProxies,
+} = require("../../tasks/storageSlots");
+
+const hre = require("hardhat");
+const loadFixture = createFixtureLoader(defaultFixture);
+
+describe("ForkTest: Storage Layout", function () {
+  beforeEach(async () => {
+    // Load fixture to run deployments
+    await loadFixture();
+  });
+
+  it("No proxy should have unexpected storage layout changes", async () => {
+    await assertStorageLayoutForAllProxies(hre);
+  });
+});

--- a/contracts/test/upgrades/storage-layout.plume.fork-test.js
+++ b/contracts/test/upgrades/storage-layout.plume.fork-test.js
@@ -1,0 +1,19 @@
+const { createFixtureLoader } = require("../_fixture");
+const { defaultPlumeFixture } = require("../_fixture-plume");
+const {
+  assertStorageLayoutForAllProxies,
+} = require("../../tasks/storageSlots");
+
+const hre = require("hardhat");
+const plumeFixture = createFixtureLoader(defaultPlumeFixture);
+
+describe("ForkTest: Storage Layout", function () {
+  beforeEach(async () => {
+    // Load fixture to run deployments
+    await plumeFixture();
+  });
+
+  it("No proxy should have unexpected storage layout changes", async () => {
+    await assertStorageLayoutForAllProxies(hre);
+  });
+});

--- a/contracts/test/upgrades/storage-layout.sonic.fork-test.js
+++ b/contracts/test/upgrades/storage-layout.sonic.fork-test.js
@@ -1,0 +1,19 @@
+const { createFixtureLoader } = require("../_fixture");
+const { defaultSonicFixture } = require("../_fixture-sonic");
+const {
+  assertStorageLayoutForAllProxies,
+} = require("../../tasks/storageSlots");
+
+const hre = require("hardhat");
+const loadFixture = createFixtureLoader(defaultSonicFixture);
+
+describe("ForkTest: Storage Layout", function () {
+  beforeEach(async () => {
+    // Load fixture to run deployments
+    await loadFixture();
+  });
+
+  it("No proxy should have unexpected storage layout changes", async () => {
+    await assertStorageLayoutForAllProxies(hre);
+  });
+});

--- a/contracts/utils/deploy.js
+++ b/contracts/utils/deploy.js
@@ -105,6 +105,12 @@ const deployWithConfirmation = async (
   // if upgrade happened on the mainnet save the new storage slot layout to the repo
   if (isMainnet || isArbitrumOne || isBase || isSonic || isPlume) {
     await storeStorageLayoutForContract(hre, contractName, contract);
+
+    // Verify the contract
+    await hre.run("etherscan-verify", {
+      network: hre.network.name,
+      contractName: contractName,
+    });
   }
 
   log(`Deployed ${contractName}`, result);


### PR DESCRIPTION
## Code changes
- Runs `etherscan-verify` whenever a contract is deployed with `deployWithConfirmation` (no more manual verification)
- Adds new hardhat tasks to store and assert implementation storage layouts for proxies (filenames have `-impl` suffix)
- Adds fork tests for each of the networks to make sure that they are all safe to upgrade
- We have certain contracts where we used duplicate artifact names, a new mapping object helps resolve that

### Generating/Updating the storage layout for a proxy contract
```
$ npx hardhat storeStorageLayoutForProxy --network mainnet --proxy OUSDProxy
```

### Generating/Updating the storage layout for all proxy contracts on a network
```
$ npx hardhat storeStorageLayoutForAllProxies --network mainnet
```

### Asserting that there's no conflict for a single proxy
```
$ npx hardhat assertStorageLayoutForProxy --network mainnet --proxy OUSDProxy
```

### Asserting that there's no conflict for all proxy contracts
```
$ npx hardhat assertStorageLayoutForAllProxies --network mainnet
```




## Code Change Checklist

To be completed before internal review begins:

- [ ]  The contract code is complete
- [ ]  Executable deployment file
- [ ]  Fork tests that test after the deployment file runs
- [ ]  Unit tests *if needed
- [ ]  The owner has done a [full checklist review](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) of the code + tests

Internal review:

- [ ] Two approvals by internal reviewers

