### PR TITLE
add initial files to separate consolidation into a separate strategy

### DIFF
--- a/contracts/contracts/interfaces/IConsolidation.sol
+++ b/contracts/contracts/interfaces/IConsolidation.sol
@@ -7,9 +7,15 @@ interface IConsolidationSource {
         returns (uint256 consolidationCount);
 }
 
-interface IConsolidationTarget {
+interface IConsolidationStrategy {
     function requestConsolidation(
-        bytes32 lastSourcePubKeyHash,
         bytes32 targetPubKeyHash
     ) external;
+}
+
+interface IConsolidationTarget {
+    function receiveConsolidatedValidator(
+        bytes32 pubKeyHash,
+        uint256 ethStaked
+    )external ;
 }


### PR DESCRIPTION
This PR: 
- separates consolidations into a separate intermediate strategy
- verifies the target validator balance instead for balances of the source validators
- process: 
  - create SSV validator on the Consolidation strategy, stake 32 ETH to it, verify validator, verify deposit
  - start consolidation on the old Native Staking strategy 
  - verify the consolidation on the Consolidation strategy
  - Consolidation strategy hands off the validator to the Compounding SSV strategy