### PR TITLE
[Sonic] Increase timelock duration: 1d -> 2d

### DIFF
--- a/contracts/deploy/sonic/024_increase_timelock_delay.js
+++ b/contracts/deploy/sonic/024_increase_timelock_delay.js
@@ -1,0 +1,41 @@
+const addresses = require("../../utils/addresses.js");
+const { deployOnSonic } = require("../../utils/deploy-l2.js");
+
+module.exports = deployOnSonic(
+  {
+    deployName: "024_increase_timelock_delay",
+    forceSkip: false,
+  },
+  async ({ ethers }) => {
+    // 1. Deploy new OS implementation
+    const cARMProxy = await ethers.getContractAt(
+      ["function setOwner(address) external"],
+      "0x2F872623d1E1Af5835b08b0E49aAd2d81d649D30"
+    );
+    const cTimelock = await ethers.getContractAt(
+      "ITimelockController",
+      addresses.sonic.timelock
+    );
+
+    console.log("ARM Proxy:", cARMProxy.address);
+    console.log("Timelock:", cTimelock.address);
+
+    return {
+      name: "Upgrade OS token contract",
+      actions: [
+        // 1. Upgrade the OSonic proxy to the new implementation
+        //{
+        //  contract: cARMProxy,
+        //  signature: "setOwner(address)",
+        //  args: [addresses.sonic.timelock],
+        //},
+        // 2. Update delay to 2d
+        {
+          contract: cTimelock,
+          signature: "updateDelay(uint256)",
+          args: [24 * 60 * 60 * 2],
+        },
+      ],
+    };
+  }
+);

--- a/contracts/deployments/sonic/operations/024_increase_timelock_delay.execute.json
+++ b/contracts/deployments/sonic/operations/024_increase_timelock_delay.execute.json
@@ -1,0 +1,52 @@
+{
+  "version": "1.0",
+  "chainId": "146",
+  "createdAt": 1753982728,
+  "meta": {
+    "name": "Transaction Batch",
+    "description": "",
+    "txBuilderVersion": "1.16.1",
+    "createdFromSafeAddress": "0xAdDEA7933Db7d83855786EB43a238111C69B00b6",
+    "createdFromOwnerAddress": ""
+  },
+  "transactions": [
+    {
+      "to": "0x31a91336414d3B955E494E7d485a6B06b55FC8fB",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "type": "address[]",
+            "name": "targets"
+          },
+          {
+            "type": "uint256[]",
+            "name": "values"
+          },
+          {
+            "type": "bytes[]",
+            "name": "payloads"
+          },
+          {
+            "type": "bytes32",
+            "name": "predecessor"
+          },
+          {
+            "type": "bytes32",
+            "name": "salt"
+          }
+        ],
+        "name": "executeBatch",
+        "payable": true
+      },
+      "contractInputsValues": {
+        "targets": "[\"0x31a91336414d3B955E494E7d485a6B06b55FC8fB\"]",
+        "values": "[\"0\"]",
+        "payloads": "[\"0x64d62353000000000000000000000000000000000000000000000000000000000002a300\"]",
+        "predecessor": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "salt": "0xa032d1732ec3183f590936095088bedecc0f641d04d27ab2c35081d31efc22ea"
+      }
+    }
+  ]
+}

--- a/contracts/deployments/sonic/operations/024_increase_timelock_delay.schedule.json
+++ b/contracts/deployments/sonic/operations/024_increase_timelock_delay.schedule.json
@@ -1,0 +1,57 @@
+{
+  "version": "1.0",
+  "chainId": "146",
+  "createdAt": 1753982728,
+  "meta": {
+    "name": "Transaction Batch",
+    "description": "",
+    "txBuilderVersion": "1.16.1",
+    "createdFromSafeAddress": "0xAdDEA7933Db7d83855786EB43a238111C69B00b6",
+    "createdFromOwnerAddress": ""
+  },
+  "transactions": [
+    {
+      "to": "0x31a91336414d3B955E494E7d485a6B06b55FC8fB",
+      "value": "0",
+      "data": null,
+      "contractMethod": {
+        "inputs": [
+          {
+            "type": "address[]",
+            "name": "targets"
+          },
+          {
+            "type": "uint256[]",
+            "name": "values"
+          },
+          {
+            "type": "bytes[]",
+            "name": "payloads"
+          },
+          {
+            "type": "bytes32",
+            "name": "predecessor"
+          },
+          {
+            "type": "bytes32",
+            "name": "salt"
+          },
+          {
+            "type": "uint256",
+            "name": "delay"
+          }
+        ],
+        "name": "scheduleBatch",
+        "payable": false
+      },
+      "contractInputsValues": {
+        "targets": "[\"0x31a91336414d3B955E494E7d485a6B06b55FC8fB\"]",
+        "values": "[\"0\"]",
+        "payloads": "[\"0x64d62353000000000000000000000000000000000000000000000000000000000002a300\"]",
+        "predecessor": "0x0000000000000000000000000000000000000000000000000000000000000000",
+        "salt": "0xa032d1732ec3183f590936095088bedecc0f641d04d27ab2c35081d31efc22ea",
+        "delay": "86400"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description
- Increase timelock duration from 1 day to 2 day on Sonic.

With the 5/8 multisig load:
`contracts/deployments/localhost/operations/024_increase_timelock_delay.schedule.json`

Then after 1 day, on the 2/9 multisig, load:
`contracts/deployments/sonic/operations/024_increase_timelock_delay.execute.json`