### PR TITLE
Add manual gasLimit for Morpho harvest script

### DIFF
--- a/contracts/scripts/defender-actions/harvest.js
+++ b/contracts/scripts/defender-actions/harvest.js
@@ -143,7 +143,9 @@ const harvestMorphoStrategies = async (signer) => {
     signer
   );
 
-  const safeModuleTx = await safeModule.connect(signer).claimRewards(true);
+  const safeModuleTx = await safeModule.connect(signer).claimRewards(true, {
+    gasLimit: 2500000,
+  });
   await logTxDetails(safeModuleTx, `claimRewards`);
 };
 


### PR DESCRIPTION
- gasEstimate seems to fail for the module at times. This sets a hardcoded gasLimit that should be higher than usual