### PR TITLE
N-06 _disableInitializers() Not Being Called from Initializable Contract Constructors

### DIFF
--- a/contracts/contracts/strategies/NativeStaking/CompoundingStakingSSVStrategy.sol
+++ b/contracts/contracts/strategies/NativeStaking/CompoundingStakingSSVStrategy.sol
@@ -49,6 +49,7 @@ contract CompoundingStakingSSVStrategy is
         )
     {
         SSV_TOKEN = _ssvToken;
+        _disableInitializers();
     }
 
     /// @notice Set up initial internal state including

--- a/contracts/contracts/utils/Initializable.sol
+++ b/contracts/contracts/utils/Initializable.sol
@@ -38,5 +38,16 @@ abstract contract Initializable {
         }
     }
 
+    /**
+     * @dev Locks the contract, preventing any future reinitialization. This cannot be part of an initializer call.
+     * Calling this in the constructor of a contract will prevent that contract from being initialized or reinitialized
+     * to any version. It is recommended to use this to lock implementation contracts that are designed to be called
+     * through proxies.
+     */
+    function _disableInitializers() internal virtual {
+        require(!initializing, "Initializable: contract is initializing");
+        initialized = true;
+    }
+
     uint256[50] private ______gap;
 }


### PR DESCRIPTION
## Description
- Add a new function `_disableInitializers()` in `Initializable.sol`, that mark the contract as `initialized`.
- Call this function in the constructor of `CompoundingStakingSSVStrategy.sol` to prevent implementation to be initialized.

## Note
- This introduce *big* change for `Initializable.sol` contract, which is used in a lot of our contract
- `_disableInitializers()`is an adjusted function based on the OZ version.
- I didn't add this function in the constructor of `NativeStakingSSVStrategy.sol` as we don't plan to deploy it again and to keep the code repo as close from the deployed one. However, I have no problem making the change.