### PR TITLE
N-07 Code Simplifications

### DIFF
--- a/contracts/contracts/beacon/Merkle.sol
+++ b/contracts/contracts/beacon/Merkle.sol
@@ -76,7 +76,6 @@ library Merkle {
                     ) {
                         revert(0, 0)
                     }
-                    index := div(index, 2)
                 }
             } else {
                 // if ith bit of index is 1, then computedHash is a right sibling
@@ -96,8 +95,10 @@ library Merkle {
                     ) {
                         revert(0, 0)
                     }
-                    index := div(index, 2)
                 }
+            }
+            assembly {
+                index := div(index, 2)
             }
         }
         return computedHash[0];


### PR DESCRIPTION
## Description 
Move the `index := div(index, 2)`outside of if/else statement, as it does the same division in both the if/else branches.

## Note
I kept the div into an assembly block to changes less. However, I can remove the assembly block and change it into 
```
index /= 2;
or 
index = index / 2;
```