### PR TITLE
[SP - 1] change validator index from uint64 to uint40

### DIFF
--- a/contracts/contracts/beacon/BeaconProofs.sol
+++ b/contracts/contracts/beacon/BeaconProofs.sol
@@ -22,7 +22,7 @@ contract BeaconProofs is IBeaconProofs {
         bytes32 beaconBlockRoot,
         bytes32 pubKeyHash,
         bytes calldata proof,
-        uint64 validatorIndex,
+        uint40 validatorIndex,
         address withdrawalAddress
     ) external view {
         BeaconProofsLib.verifyValidator(
@@ -47,7 +47,7 @@ contract BeaconProofs is IBeaconProofs {
     /// This is 2 witness hashes of 32 bytes each concatenated together starting from the leaf node.
     function verifyValidatorWithdrawable(
         bytes32 beaconBlockRoot,
-        uint64 validatorIndex,
+        uint40 validatorIndex,
         bytes32 pubKeyHash,
         uint64 withdrawableEpoch,
         bytes calldata withdrawableEpochProof,
@@ -73,7 +73,7 @@ contract BeaconProofs is IBeaconProofs {
 
     function verifyValidatorWithdrawable(
         bytes32 beaconBlockRoot,
-        uint64 validatorIndex,
+        uint40 validatorIndex,
         uint64 withdrawableEpoch,
         bytes calldata withdrawableEpochProof
     ) external view {
@@ -114,7 +114,7 @@ contract BeaconProofs is IBeaconProofs {
         bytes32 balancesContainerRoot,
         bytes32 validatorBalanceLeaf,
         bytes calldata balanceProof,
-        uint64 validatorIndex
+        uint40 validatorIndex
     ) external view returns (uint256 validatorBalanceGwei) {
         validatorBalanceGwei = BeaconProofsLib.verifyValidatorBalance(
             balancesContainerRoot,

--- a/contracts/contracts/beacon/BeaconProofsLib.sol
+++ b/contracts/contracts/beacon/BeaconProofsLib.sol
@@ -92,7 +92,7 @@ library BeaconProofsLib {
         bytes32 beaconBlockRoot,
         bytes32 pubKeyHash,
         bytes calldata proof,
-        uint64 validatorIndex,
+        uint40 validatorIndex,
         address withdrawalAddress
     ) internal view {
         require(beaconBlockRoot != bytes32(0), "Invalid block root");
@@ -147,7 +147,7 @@ library BeaconProofsLib {
     /// This is 53 witness hashes of 32 bytes each concatenated together starting from the leaf node.
     function verifyValidatorWithdrawableEpoch(
         bytes32 beaconBlockRoot,
-        uint64 validatorIndex,
+        uint40 validatorIndex,
         uint64 withdrawableEpoch,
         bytes calldata proof
     ) internal view {
@@ -241,7 +241,7 @@ library BeaconProofsLib {
         bytes32 balancesContainerRoot,
         bytes32 validatorBalanceLeaf,
         bytes calldata proof,
-        uint64 validatorIndex
+        uint40 validatorIndex
     ) internal view returns (uint256 validatorBalanceGwei) {
         require(balancesContainerRoot != bytes32(0), "Invalid container root");
 
@@ -396,7 +396,7 @@ library BeaconProofsLib {
     ///       Internal Helper Functions
     ////////////////////////////////////////////////////
 
-    function balanceAtIndex(bytes32 validatorBalanceLeaf, uint64 validatorIndex)
+    function balanceAtIndex(bytes32 validatorBalanceLeaf, uint40 validatorIndex)
         internal
         pure
         returns (uint256)

--- a/contracts/contracts/interfaces/IBeaconProofs.sol
+++ b/contracts/contracts/interfaces/IBeaconProofs.sol
@@ -6,13 +6,13 @@ interface IBeaconProofs {
         bytes32 beaconBlockRoot,
         bytes32 pubKeyHash,
         bytes calldata validatorPubKeyProof,
-        uint64 validatorIndex,
+        uint40 validatorIndex,
         address withdrawalAddress
     ) external view;
 
     function verifyValidatorWithdrawable(
         bytes32 beaconBlockRoot,
-        uint64 validatorIndex,
+        uint40 validatorIndex,
         bytes32 pubKeyHash,
         uint64 withdrawableEpoch,
         bytes calldata withdrawableEpochProof,
@@ -21,7 +21,7 @@ interface IBeaconProofs {
 
     function verifyValidatorWithdrawable(
         bytes32 beaconBlockRoot,
-        uint64 validatorIndex,
+        uint40 validatorIndex,
         uint64 withdrawableEpoch,
         bytes calldata withdrawableEpochProof
     ) external view;
@@ -36,7 +36,7 @@ interface IBeaconProofs {
         bytes32 balancesContainerRoot,
         bytes32 validatorBalanceLeaf,
         bytes calldata balanceProof,
-        uint64 validatorIndex
+        uint40 validatorIndex
     ) external view returns (uint256 validatorBalance);
 
     function verifyFirstPendingDeposit(

--- a/contracts/contracts/strategies/NativeStaking/CompoundingValidatorManager.sol
+++ b/contracts/contracts/strategies/NativeStaking/CompoundingValidatorManager.sol
@@ -134,7 +134,7 @@ abstract contract CompoundingValidatorManager is Governable {
     // Validator data
     struct ValidatorData {
         ValidatorState state; // The state of the validator known to this contract
-        uint64 index; // The index of the validator on the beacon chain
+        uint40 index; // The index of the validator on the beacon chain
     }
     /// @notice List of validator public key hashes that have been verified to exist on the beacon chain.
     /// These have had a deposit processed and the validator's balance increased.
@@ -188,7 +188,7 @@ abstract contract CompoundingValidatorManager is Governable {
     );
     event ValidatorVerified(
         bytes32 indexed pubKeyHash,
-        uint64 indexed validatorIndex
+        uint40 indexed validatorIndex
     );
     event ValidatorInvalid(bytes32 indexed pubKeyHash);
     event DepositVerified(uint256 indexed depositID, uint256 amountWei);
@@ -554,7 +554,7 @@ abstract contract CompoundingValidatorManager is Governable {
     /// BeaconBlock.state.validators[validatorIndex].pubkey
     function verifyValidator(
         uint64 nextBlockTimestamp,
-        uint64 validatorIndex,
+        uint40 validatorIndex,
         bytes32 pubKeyHash,
         address withdrawalAddress,
         bytes calldata validatorPubKeyProof
@@ -623,7 +623,7 @@ abstract contract CompoundingValidatorManager is Governable {
     }
     struct FirstPendingDepositWithdrawableProofData {
         uint64 slot;
-        uint64 validatorIndex;
+        uint40 validatorIndex;
         bytes32 pubKeyHash;
         bytes pendingDepositPubKeyProof;
         bytes withdrawableEpochProof;

--- a/contracts/test/beacon/beaconProofs.js
+++ b/contracts/test/beacon/beaconProofs.js
@@ -361,7 +361,7 @@ describe("Beacon chain proofs", async () => {
         const { beaconProofs } = fixture;
 
         await beaconProofs[
-          "verifyValidatorWithdrawable(bytes32,uint64,uint64,bytes)"
+          "verifyValidatorWithdrawable(bytes32,uint40,uint64,bytes)"
         ](
           beaconRoot,
           validatorIndex,
@@ -370,7 +370,7 @@ describe("Beacon chain proofs", async () => {
         );
 
         await beaconProofs[
-          "verifyValidatorWithdrawable(bytes32,uint64,bytes32,uint64,bytes,bytes)"
+          "verifyValidatorWithdrawable(bytes32,uint40,bytes32,uint64,bytes,bytes)"
         ](
           beaconRoot,
           validatorIndex,
@@ -386,7 +386,7 @@ describe("Beacon chain proofs", async () => {
         const beaconRoot = ZERO_BYTES32;
 
         let tx = beaconProofs[
-          "verifyValidatorWithdrawable(bytes32,uint64,uint64,bytes)"
+          "verifyValidatorWithdrawable(bytes32,uint40,uint64,bytes)"
         ](
           beaconRoot,
           validatorIndex,
@@ -396,7 +396,7 @@ describe("Beacon chain proofs", async () => {
         await expect(tx).to.be.revertedWith("Invalid block root");
 
         tx = beaconProofs[
-          "verifyValidatorWithdrawable(bytes32,uint64,bytes32,uint64,bytes,bytes)"
+          "verifyValidatorWithdrawable(bytes32,uint40,bytes32,uint64,bytes,bytes)"
         ](
           beaconRoot,
           validatorIndex,
@@ -415,7 +415,7 @@ describe("Beacon chain proofs", async () => {
           "0x002b00b0ff536f96bacdb0f9d65055fb7b392d0d199a78719b5ef59225c7d7c6";
 
         let tx = beaconProofs[
-          "verifyValidatorWithdrawable(bytes32,uint64,uint64,bytes)"
+          "verifyValidatorWithdrawable(bytes32,uint40,uint64,bytes)"
         ](
           beaconRoot,
           validatorIndex,
@@ -425,7 +425,7 @@ describe("Beacon chain proofs", async () => {
         await expect(tx).to.be.revertedWith("Invalid withdrawable proof");
 
         tx = beaconProofs[
-          "verifyValidatorWithdrawable(bytes32,uint64,bytes32,uint64,bytes,bytes)"
+          "verifyValidatorWithdrawable(bytes32,uint40,bytes32,uint64,bytes,bytes)"
         ](
           beaconRoot,
           validatorIndex,
@@ -442,7 +442,7 @@ describe("Beacon chain proofs", async () => {
         const invalidValidatorIndex = validatorIndex + 1;
 
         let tx = beaconProofs[
-          "verifyValidatorWithdrawable(bytes32,uint64,uint64,bytes)"
+          "verifyValidatorWithdrawable(bytes32,uint40,uint64,bytes)"
         ](
           beaconRoot,
           invalidValidatorIndex,
@@ -452,7 +452,7 @@ describe("Beacon chain proofs", async () => {
         await expect(tx).to.be.revertedWith("Invalid withdrawable proof");
 
         tx = beaconProofs[
-          "verifyValidatorWithdrawable(bytes32,uint64,bytes32,uint64,bytes,bytes)"
+          "verifyValidatorWithdrawable(bytes32,uint40,bytes32,uint64,bytes,bytes)"
         ](
           beaconRoot,
           invalidValidatorIndex,
@@ -469,7 +469,7 @@ describe("Beacon chain proofs", async () => {
         const withdrawableEpoch = 0;
 
         let tx = beaconProofs[
-          "verifyValidatorWithdrawable(bytes32,uint64,uint64,bytes)"
+          "verifyValidatorWithdrawable(bytes32,uint40,uint64,bytes)"
         ](
           beaconRoot,
           validatorIndex,
@@ -479,7 +479,7 @@ describe("Beacon chain proofs", async () => {
         await expect(tx).to.be.revertedWith("Invalid withdrawable proof");
 
         tx = beaconProofs[
-          "verifyValidatorWithdrawable(bytes32,uint64,bytes32,uint64,bytes,bytes)"
+          "verifyValidatorWithdrawable(bytes32,uint40,bytes32,uint64,bytes,bytes)"
         ](
           beaconRoot,
           validatorIndex,
@@ -496,7 +496,7 @@ describe("Beacon chain proofs", async () => {
         const withdrawableEpochProof = hexZeroPad("0x", 1696);
 
         let tx = beaconProofs[
-          "verifyValidatorWithdrawable(bytes32,uint64,uint64,bytes)"
+          "verifyValidatorWithdrawable(bytes32,uint40,uint64,bytes)"
         ](
           beaconRoot,
           validatorIndex,
@@ -506,7 +506,7 @@ describe("Beacon chain proofs", async () => {
         await expect(tx).to.be.revertedWith("Invalid withdrawable proof");
 
         tx = beaconProofs[
-          "verifyValidatorWithdrawable(bytes32,uint64,bytes32,uint64,bytes,bytes)"
+          "verifyValidatorWithdrawable(bytes32,uint40,bytes32,uint64,bytes,bytes)"
         ](
           beaconRoot,
           validatorIndex,
@@ -526,7 +526,7 @@ describe("Beacon chain proofs", async () => {
         );
 
         const tx = beaconProofs[
-          "verifyValidatorWithdrawable(bytes32,uint64,bytes32,uint64,bytes,bytes)"
+          "verifyValidatorWithdrawable(bytes32,uint40,bytes32,uint64,bytes,bytes)"
         ](
           beaconRoot,
           validatorIndex,
@@ -543,7 +543,7 @@ describe("Beacon chain proofs", async () => {
         const publicKeyProof = hexZeroPad("0x", 64);
 
         const tx = beaconProofs[
-          "verifyValidatorWithdrawable(bytes32,uint64,bytes32,uint64,bytes,bytes)"
+          "verifyValidatorWithdrawable(bytes32,uint40,bytes32,uint64,bytes,bytes)"
         ](
           beaconRoot,
           validatorIndex,
@@ -573,7 +573,7 @@ describe("Beacon chain proofs", async () => {
         const { beaconProofs } = fixture;
 
         await beaconProofs[
-          "verifyValidatorWithdrawable(bytes32,uint64,uint64,bytes)"
+          "verifyValidatorWithdrawable(bytes32,uint40,uint64,bytes)"
         ](
           beaconRoot,
           validatorIndex,
@@ -582,7 +582,7 @@ describe("Beacon chain proofs", async () => {
         );
 
         await beaconProofs[
-          "verifyValidatorWithdrawable(bytes32,uint64,bytes32,uint64,bytes,bytes)"
+          "verifyValidatorWithdrawable(bytes32,uint40,bytes32,uint64,bytes,bytes)"
         ](
           beaconRoot,
           validatorIndex,
@@ -598,7 +598,7 @@ describe("Beacon chain proofs", async () => {
         const invalidWithdrawableEpoch = withdrawableEpoch + 1;
 
         let tx = beaconProofs[
-          "verifyValidatorWithdrawable(bytes32,uint64,uint64,bytes)"
+          "verifyValidatorWithdrawable(bytes32,uint40,uint64,bytes)"
         ](
           beaconRoot,
           validatorIndex,
@@ -608,7 +608,7 @@ describe("Beacon chain proofs", async () => {
         await expect(tx).to.be.revertedWith("Invalid withdrawable proof");
 
         tx = beaconProofs[
-          "verifyValidatorWithdrawable(bytes32,uint64,bytes32,uint64,bytes,bytes)"
+          "verifyValidatorWithdrawable(bytes32,uint40,bytes32,uint64,bytes,bytes)"
         ](
           beaconRoot,
           validatorIndex,


### PR DESCRIPTION
**Sigma prime report:**
As mentioned in the kickoff call, validatorIndex should be uint40 instead of uint64. Providing a validatorIndex that is out-of-bounds can contaminate the generalizedIndex and hence the leaf that is being proven. We looked deep into this and found that a 64-bit validatorIndex allows an attacker to completely change the branch selection of the entire proof (from any Validator container field or validator balance leaf all the way to the beacon block root) due to how concatGenIndices() works. The attack surface is quite limited though since you can only flip 0 bits to 1. A potential attack was to divert the proof through historical summaries and try to reach BeaconBlockBody.graffiti, but that proof would require 55 witness hashes, and verifyValidator() limited us to 53. In the end, we couldn't find a valid exploit path for this vulnerability, though we still recommend fixing it as it affects the index that's stored onchain and emitted in events. A general way to prevent contaminating the generalized index in concatGenIndices() is to do input validation by checking that indexBits <= height

**Solution:** done as suggested