### PR TITLE
[SP - 3] account as early as possible for the front run loss

### DIFF
--- a/contracts/contracts/strategies/NativeStaking/CompoundingValidatorManager.sol
+++ b/contracts/contracts/strategies/NativeStaking/CompoundingValidatorManager.sol
@@ -594,6 +594,12 @@ abstract contract CompoundingValidatorManager is Governable {
             for (uint256 i = 0; i < depositCount; i++) {
                 DepositData memory deposit = deposits[depositList[i]];
                 if (deposit.pubKeyHash == pubKeyHash) {
+                    // next verifyBalances will correctly account for the loss of a front-run
+                    // deposit. Doing it here accounts for the loss as soon as possible
+                    lastVerifiedEthBalance -= Math.min(
+                        lastVerifiedEthBalance,
+                        uint256(deposit.amountGwei) * 1 gwei
+                    );
                     _removeDeposit(depositList[i], deposit);
                     break;
                 }


### PR DESCRIPTION
**Sigma prime report:** 
If balances are snapped and verified right after a validator frontrunning attack occurs (before verifyValidator() is called), then the stolen ETH will be counted in lastVerifiedEthBalance

**Solution:**
The contract needs to account for the loss at some point. That can't be done at the time of `stakeEth` (initial validator deposit) so a change is made to move the accounting of the loss to as soon as possible. Which is within the `verifyValidator` once a front-run is detected. The next `verifyBalances` will also correctly account for the loss. 