### PR TITLE
[SP - 4] Verify validator type

### DIFF
--- a/contracts/contracts/beacon/BeaconProofsLib.sol
+++ b/contracts/contracts/beacon/BeaconProofsLib.sol
@@ -123,6 +123,7 @@ library BeaconProofsLib {
             withdrawalAddressFromProof == withdrawalAddress,
             "Invalid withdrawal address"
         );
+        require(proof[0] == 0x02, "Invalid validator type");
 
         require(
             // 53 * 32 bytes = 1696 bytes

--- a/contracts/test/strategies/compoundingSSVStaking.js
+++ b/contracts/test/strategies/compoundingSSVStaking.js
@@ -1542,6 +1542,19 @@ describe("Unit test: Compounding SSV Staking Strategy", function () {
         expect(balancesAfter.verifiedEthBalance).to.equal(depositAmountWei);
         expect(balancesAfter.stratBalance).to.equal(depositAmountWei);
       });
+
+      it("Should not verify a validator with incorrect withdrawal credentials", async () => {
+        const originalValidatorProof = testValidators[0].validatorProof.bytes;
+        // replace the 0x02 validator type credentials to an invalid 0x01 one
+        const wrongValidatorTypeProof = "0x01" + originalValidatorProof.substring(4);
+        testValidators[0].validatorProof.bytes = wrongValidatorTypeProof;
+
+        await expect(processValidator(testValidators[0], "VERIFIED_DEPOSIT"))
+          .to.be.revertedWith("Invalid validator type");
+
+        testValidators[0].validatorProof.bytes = originalValidatorProof;
+      });
+
       it("Should verify balances with one verified deposit", async () => {
         await processValidator(testValidators[0], "VERIFIED_DEPOSIT");
 


### PR DESCRIPTION
**Sigma Prime report:**
BeaconProofsLib.verifyValidator() does not check that the withdrawal credentials are 0x01 or 0x02. Through a validator frontrunning attack, the registrator can change the withdrawal credentials to any other prefix (e.g. 0x00 or 0x03) and be able to successfully verify the validator. The withdrawal credentials is invalid, so the ETH cannot be withdrawn to the strategy contract. Since the validator can be verified on the strategy contract, firstDeposit does not protect against this attack. Furthermore, it's impossible to remove this validator from the strategy, so it uses up the MAX_VERIFIED_VALIDATORS limit and cannot be removed with removeSsvValidator(), since VERIFIED validators cannot be removed

**Solution:**
Fixed