### PR TITLE
Do not allow exiting a validator with a pending deposit

### DIFF
--- a/contracts/contracts/strategies/NativeStaking/CompoundingValidatorManager.sol
+++ b/contracts/contracts/strategies/NativeStaking/CompoundingValidatorManager.sol
@@ -464,6 +464,17 @@ abstract contract CompoundingValidatorManager is Governable {
 
         // If a full withdrawal (validator exit)
         if (amountGwei == 0) {
+            // For each staking strategy's deposits
+            uint256 depositsCount = depositList.length;
+            for (uint256 i = 0; i < depositsCount; ++i) {
+                uint256 depositID = depositList[i];
+                // Check there is no pending deposits to the exiting validator
+                require(
+                    pubKeyHash != deposits[depositID].pubKeyHash,
+                    "Pending deposit"
+                );
+            }
+
             // Store the validator state as exiting so no more deposits can be made to it.
             validator[pubKeyHash].state = ValidatorState.EXITING;
         }

--- a/contracts/tasks/tasks.js
+++ b/contracts/tasks/tasks.js
@@ -1541,7 +1541,7 @@ subtask(
     "0x02",
     types.string
   )
-  .addOptionalParam("amount", "The deposit amount.", 32, types.int)
+  .addOptionalParam("amount", "The deposit amount.", 32, types.float)
   .setAction(async (taskArgs) => {
     const root = await calcDepositRoot(
       taskArgs.owner,
@@ -2152,7 +2152,7 @@ subtask(
     "amount",
     "Amount of ETH to deposit to the validator.",
     undefined,
-    types.int
+    types.float
   )
   .addOptionalParam(
     "withdrawalCredentials",

--- a/contracts/tasks/validatorCompound.js
+++ b/contracts/tasks/validatorCompound.js
@@ -377,14 +377,18 @@ async function logDeposits(strategyView, blockTag = "latest") {
   let totalDeposits = BigNumber.from(0);
   console.log(`\n${deposits.length || "No"} pending strategy deposits:`);
   if (deposits.length > 0) {
-    console.log(`  ID  amount   slot    withdrawable         public key hash`);
+    console.log(
+      `  ID  amount    slot    withdrawable         public key hash`
+    );
   }
   for (const deposit of deposits) {
     console.log(
       `  ${deposit.depositID.toString().padEnd(3)} ${formatUnits(
         deposit.amountGwei,
         9
-      )} ETH ${deposit.slot} ${deposit.withdrawableEpoch} ${deposit.pubKeyHash}`
+      ).padEnd(5)} ETH ${deposit.slot} ${deposit.withdrawableEpoch} ${
+        deposit.pubKeyHash
+      }`
     );
     totalDeposits = totalDeposits.add(deposit.amountGwei);
   }


### PR DESCRIPTION
# Change

* `validatorWithdrawal` now checks for pending deposits when exiting a validator.

## Code Change Checklist

To be completed before internal review begins:

- [ ]  The contract code is complete
- [ ]  Executable deployment file
- [ ]  Fork tests that test after the deployment file runs
- [ ]  Unit tests *if needed
- [ ]  The owner has done a [full checklist review](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) of the code + tests

Internal review:

- [ ] Two approvals by internal reviewers


## Deploy checklist

Two reviewers complete the following checklist:

```
- [ ] All deployed contracts are listed in the deploy PR's description
- [ ] Deployed contract's verified code (and all dependencies) match the code in master
- [ ] Contract constructors have correct arguments
- [ ] The transactions that interacted with the newly deployed contract match the deploy script.
- [ ] Governance proposal matches the deploy script
- [ ] Smoke tests pass after fork test execution of the governance proposal
```

