### PR TITLE
[Task] Withdrawal buffer for OS Vault

### DIFF
--- a/contracts/scripts/defender-actions/sonicRequestWithdrawal.js
+++ b/contracts/scripts/defender-actions/sonicRequestWithdrawal.js
@@ -15,7 +15,10 @@ const handler = async (event) => {
   const provider = new DefenderRelayProvider(event);
   const signer = new DefenderRelaySigner(event, provider, { speed: "fastest" });
 
-  await undelegateValidator({ signer });
+  // The vault buffer in basis points, so 100 = 1%
+  const bufferPct = 50;
+
+  await undelegateValidator({ signer, bufferPct });
 };
 
 module.exports = { handler };

--- a/contracts/tasks/tasks.js
+++ b/contracts/tasks/tasks.js
@@ -1786,10 +1786,20 @@ subtask("sonicUndelegate", "Remove liquidity from a Sonic validator")
     undefined,
     types.float
   )
+  .addOptionalParam(
+    "buffer",
+    "Percentage of total assets to keep as buffer in basis points. 100 = 1%",
+    50,
+    types.float
+  )
   .setAction(async (taskArgs) => {
     const signer = await getSigner();
 
-    await undelegateValidator({ ...taskArgs, signer });
+    await undelegateValidator({
+      ...taskArgs,
+      bufferPct: taskArgs.buffer,
+      signer,
+    });
   });
 task("sonicUndelegate").setAction(async (_, __, runSuper) => {
   return runSuper();


### PR DESCRIPTION
This pull request introduces a buffer mechanism to the undelegation logic in `sonicActions.js` so the OS ARM can convert its purchased OS back to wS quicker, the OS Vault will undelegate a small percentage each day. The main changes are:

**Vault withdrawal logic update:**

* Added a buffer calculation (0.01% of vault's total assets) to ensure that a portion of the assets is reserved and not immediately available for undelegation. The available balance for undelegation is now reduced by this buffer.

**Transaction handling:**

* Commented out the actual `undelegate` transaction call, possibly for debugging or to prevent execution during testing, while retaining the logging of transaction details.

## Testing

Start a local Sonic fork
```bash
# Set SONIC_PROVIDER_URL in .env file or export it
export SONIC_PROVIDER_URL=
yarn run node:sonic
```

```bash
# Set IMPERSONATE in .env file or export it
export IMPERSONATE=0x531B8D5eD6db72A56cF1238D4cE478E7cB7f2825
FORK=true npx hardhat sonicUndelegate --network localhost
```

Results from a local test
```
FORK=true npx hardhat sonicUndelegate --network localhost --buffer 100
  origin:utils:signers Impersonating account 0x531B8D5eD6db72A56cF1238D4cE478E7cB7f2825 from IMPERSONATE environment variable +0ms
  origin:utils:signers Impersonating account 0x531B8D5eD6db72A56cF1238D4cE478E7cB7f2825 +1ms
  origin:utils:signers Funding account 0x531B8D5eD6db72A56cF1238D4cE478E7cB7f2825 with 100 ETH +105ms
  origin:task:sonic wS balance in vault           : 607705.025171298185245333 wS +0ms
  origin:task:sonic Unclaimed vault withdrawals   : 504969.170175302148824723 wS +143ms
  origin:task:sonic Available wS in vault         : 102735.85499599603642061 wS +0ms
  origin:task:sonic Pending validator withdrawals : 68315.404903981938878939 wS +19ms
  origin:task:sonic wS with validator withdrawals : 171051.259899977975299549 wS +0ms
  origin:task:sonic Total vault assets            : 34210251.979995595059909886 wS +87ms
  origin:task:sonic Buffer (1% of total assets) : 342102.519799955950599098 wS +1ms
  origin:task:sonic wS target with buffer         : -171051.259899977975299549 wS +1ms
  origin:task:sonic About to undelegate 171051.259899977975299549 S from validator 18 +9ms
  origin:utils:txLogger Sent undelegate transaction with hash 0xab9bec41793fbd7d9ae3cac2539261b2a13d24dcfec8b766fd4d448bd78f35bf from 0x531B8D5eD6db72A56cF1238D4cE478E7cB7f2825 with gas price 1 Gwei +0ms
  origin:utils:txLogger Processed undelegate tx in block 45545459, using 269132 gas costing 0.000269132 ETH +8ms
```

## Deployment

```
cd ./scripts/defender-actions
npx rollup -c

export API_KEY=
export API_SECRET=

npx defender-autotask update-code 84988850-6816-4074-8e7b-c11cb2b32e7e ./dist/sonicRequestWithdrawal
```