### PR TITLE
Fix for: Deposit Balance Undercount Due To Missing Timestamp Validation In verifyDeposit()

### DIFF
--- a/contracts/contracts/strategies/NativeStaking/CompoundingValidatorManager.sol
+++ b/contracts/contracts/strategies/NativeStaking/CompoundingValidatorManager.sol
@@ -716,7 +716,7 @@ abstract contract CompoundingValidatorManager is Governable {
         require(
             (_calcNextBlockTimestamp(depositProcessedSlot) <= snapTimestamp) ||
                 snapTimestamp == 0,
-            "Deposit processed after last balance snapshot"
+            "Deposit after balance snapshot"
         );
 
         // Get the parent beacon block root of the next block which is the block root of the deposit verification slot.

--- a/contracts/test/strategies/compoundingSSVStaking.js
+++ b/contracts/test/strategies/compoundingSSVStaking.js
@@ -857,6 +857,53 @@ describe("Unit test: Compounding SSV Staking Strategy", function () {
       await expect(tx).to.be.revertedWith("Pending deposit");
     });
 
+    it("Should revert when verifying deposit between snapBalances and verifyBalances", async () => {
+      const {
+        beaconRoots,
+        compoundingStakingSSVStrategy,
+      } = fixture;
+      const testValidator = testValidators[3];
+
+      // Third validator is later withdrawn later
+      const verifyTx = await processValidator(
+        testValidator,
+        "VERIFIED_VALIDATOR"
+      );
+
+      const verifyReceipt = await verifyTx.wait();
+      const verifyBlock = await ethers.provider.getBlock(
+        verifyReceipt.blockNumber
+      );
+      // roughly the deposit slot
+      const depositSlot = calcSlot(verifyBlock.timestamp);
+
+      let depositID = await compoundingStakingSSVStrategy.nextDepositID();
+      // - 1 to get the previously staked deposit id
+      depositID = depositID.sub(BigNumber.from("1"));
+
+      // Snap balances before the deposit is processed
+      await compoundingStakingSSVStrategy.snapBalances();
+
+      // Set parent beacon root for the block after the verification slots
+      const depositProcessedSlot = depositSlot + 10000n;
+
+      await beaconRoots["setBeaconRoot(uint256,bytes32)"](
+        calcBlockTimestamp(depositProcessedSlot) + 12n,
+        testValidator.depositProof.processedBeaconBlockRoot
+      );
+
+      const verifiedDepositTx = compoundingStakingSSVStrategy.verifyDeposit(
+        depositID,
+        depositProcessedSlot,
+        testValidator.depositProof.firstPendingDeposit,
+        testValidator.depositProof.strategyValidator
+      );
+
+      await expect(verifiedDepositTx).to.be.revertedWith(
+        "Deposit processed after last balance snapshot"
+      );
+    });
+
     it("Should partial withdraw from a validator with a pending deposit", async () => {
       const { validatorRegistrator, compoundingStakingSSVStrategy } = fixture;
 

--- a/contracts/test/strategies/compoundingSSVStaking.js
+++ b/contracts/test/strategies/compoundingSSVStaking.js
@@ -900,7 +900,7 @@ describe("Unit test: Compounding SSV Staking Strategy", function () {
       );
 
       await expect(verifiedDepositTx).to.be.revertedWith(
-        "Deposit processed after last balance snapshot"
+        "Deposit after balance snapshot"
       );
     });
 


### PR DESCRIPTION
**Sigma Prime report:**
The CompoundingValidatorManager contract uses a balance verification system where snapBalances() records the
The verifyDeposit() function allows systematic ETH balance undercounting due to missing timestamp validation,
enabling removal of deposits that were processed after the current balance snapshot.
contract’s ETH balance and timestamp, and verifyBalances() calculates the total balance at that timestamp by sum-
ming the contract balance with validator balances and pending deposits. However, the verifyDeposit() function
lacks crucial timestamp validation that prevents deposits processed after from being verified and
removed from the pending deposits list.
This creates a systematic accounting error where:
1. snapBalances() records ETH balance at time T and sets lastSnapTimestamp = T
2. Deposits are processed on the beacon chain after time T but before verifyBalances() is called
3. verifyDeposit() allows these deposits to be verified and removed from totalDepositsWei calculation
4. The removed deposits were not included in validator balances at snapshot time T , causing an undercount
The current verifyDeposit() function only validates that the deposit was processed before the validator creation slot,
but fails to check if the deposit was processed after the balance snapshot:

**Response:** fixed as suggested 

