### PR TITLE
restrict pending deposit index to uint32

### DIFF
--- a/contracts/contracts/beacon/BeaconProofs.sol
+++ b/contracts/contracts/beacon/BeaconProofs.sol
@@ -115,7 +115,7 @@ contract BeaconProofs is IBeaconProofs {
         bytes32 pendingDepositsContainerRoot,
         bytes32 pendingDepositRoot,
         bytes calldata proof,
-        uint64 pendingDepositIndex
+        uint32 pendingDepositIndex
     ) external view {
         BeaconProofsLib.verifyPendingDeposit(
             pendingDepositsContainerRoot,

--- a/contracts/contracts/beacon/BeaconProofsLib.sol
+++ b/contracts/contracts/beacon/BeaconProofsLib.sol
@@ -276,12 +276,12 @@ library BeaconProofsLib {
     /// @param pendingDepositRoot The merkle root of the pending deposit to verify
     /// @param proof The merkle proof for the pending deposit root to the pending deposits list container root.
     /// This is 28 witness hashes of 32 bytes each concatenated together starting from the leaf node.
-    /// @param depositIndex The index in the pending deposits list container for the deposit to verify.
+    /// @param pendingDepositIndex The index in the pending deposits list container for the deposit to verify.
     function verifyPendingDeposit(
         bytes32 pendingDepositsContainerRoot,
         bytes32 pendingDepositRoot,
         bytes calldata proof,
-        uint64 depositIndex
+        uint32 pendingDepositIndex
     ) internal view {
         require(pendingDepositsContainerRoot != bytes32(0), "Invalid root");
 
@@ -289,7 +289,7 @@ library BeaconProofsLib {
         uint256 generalizedIndex = concatGenIndices(
             1,
             PENDING_DEPOSITS_LIST_HEIGHT,
-            depositIndex
+            pendingDepositIndex
         );
 
         require(

--- a/contracts/contracts/interfaces/IBeaconProofs.sol
+++ b/contracts/contracts/interfaces/IBeaconProofs.sol
@@ -40,7 +40,7 @@ interface IBeaconProofs {
         bytes32 pendingDepositsContainerRoot,
         bytes32 pendingDepositRoot,
         bytes calldata proof,
-        uint64 depositIndex
+        uint32 pendingDepositIndex
     ) external view;
 
     function verifyFirstPendingDeposit(

--- a/contracts/contracts/mocks/beacon/MockBeaconProofs.sol
+++ b/contracts/contracts/mocks/beacon/MockBeaconProofs.sol
@@ -112,7 +112,7 @@ contract MockBeaconProofs is IBeaconProofs {
         bytes32 pendingDepositsContainerRoot,
         bytes32 pendingDepositRoot,
         bytes calldata proof,
-        uint64 depositIndex
+        uint32 pendingDepositIndex
     ) external view {
         // always pass
     }

--- a/contracts/contracts/strategies/NativeStaking/CompoundingValidatorManager.sol
+++ b/contracts/contracts/strategies/NativeStaking/CompoundingValidatorManager.sol
@@ -983,7 +983,7 @@ abstract contract CompoundingValidatorManager is Governable, Pausable {
     struct PendingDepositProofs {
         bytes32 pendingDepositContainerRoot;
         bytes pendingDepositContainerProof;
-        uint40[] pendingDepositIndexes;
+        uint32[] pendingDepositIndexes;
         bytes[] pendingDepositProofs;
     }
 


### PR DESCRIPTION
# Changes

* Restricted the pending deposit index to `uint32` as the pending deposits container height is only 28

## Code Change Checklist

To be completed before internal review begins:

- [ ]  The contract code is complete
- [ ]  Executable deployment file
- [ ]  Fork tests that test after the deployment file runs
- [ ]  Unit tests *if needed
- [ ]  The owner has done a [full checklist review](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) of the code + tests

Internal review:

- [ ] Two approvals by internal reviewers


## Deploy checklist

Two reviewers complete the following checklist:

```
- [ ] All deployed contracts are listed in the deploy PR's description
- [ ] Deployed contract's verified code (and all dependencies) match the code in master
- [ ] Contract constructors have correct arguments
- [ ] The transactions that interacted with the newly deployed contract match the deploy script.
- [ ] Governance proposal matches the deploy script
- [ ] Smoke tests pass after fork test execution of the governance proposal
```

