### PR TITLE
Yield forwarding for a Merkl Pool booster

### DIFF
--- a/contracts/scripts/runlogs/2025_10.s.sol
+++ b/contracts/scripts/runlogs/2025_10.s.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+// Setup
+import { SetupBase } from "./utils/Setup.sol";
+import { SetupSonic } from "./utils/Setup.sol";
+import { SetupMainnet } from "./utils/Setup.sol";
+
+import { CrossChain } from "./utils/Addresses.sol";
+
+// Foundry
+import { console } from "forge-std/console.sol";
+
+contract Runlogs_2025_10_Mainnet is SetupMainnet {
+  function run() public {
+    _2025_10_01();
+    //_2025_10_02();
+  }
+
+  // ------------------------------------------------------------------
+  // Oct 3, 2025 - Yield Forward to Computed Merkl Pool Booster
+  // ------------------------------------------------------------------
+  function _2025_10_01() internal {
+    bytes memory campaignData =
+      hex"b8fef900b383db2dbbf4458c7f46acf5b140f26d603a6d1829963f241b82510e00000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+
+    vm.startBroadcast(strategist);
+
+    console.log("-----");
+    console.log("strategist address", address(strategist));
+    console.log("poolBoosterFactoryMerkl address", address(poolBoosterFactoryMerkl));
+    
+    address poolBoosterAddress = poolBoosterFactoryMerkl.computePoolBoosterAddress({
+      _campaignType: 45,
+      _ammPoolAddress: CrossChain.MORPHO_BLUE,
+      _campaignDuration: 7 days,
+      campaignData: campaignData,
+      _salt: uint256(keccak256(abi.encodePacked("Merkl Morpho PB OUSD/USDC v1")))
+    });
+
+    console.log("computed address", poolBoosterAddress);
+
+    // Run yield forward
+    oeth.delegateYield(CrossChain.MORPHO_BLUE, poolBoosterAddress);
+    vm.stopBroadcast();
+  }
+
+// ------------------------------------------------------------------
+  // Oct 3+ TODO, 2025 - Create Merkl Pool Booster once Central Registry governance passes
+  // ------------------------------------------------------------------
+  function _2025_10_02() internal {
+    bytes memory campaignData =
+      hex"b8fef900b383db2dbbf4458c7f46acf5b140f26d603a6d1829963f241b82510e00000000000000000000000000000000000000000000000000000000000000c000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000120000000000000000000000000000000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
+
+    vm.startBroadcast(strategist);
+    // Create the pool booster
+    poolBoosterFactoryMerkl.createPoolBoosterMerkl({
+      _campaignType: 45, // Incentivise Borrow rate of OETH/USDC
+      _ammPoolAddress: CrossChain.MORPHO_BLUE,
+      _campaignDuration: 7 days,
+      campaignData: campaignData,
+      _salt: uint256(keccak256(abi.encodePacked("Merkl Morpho PB OUSD/USDC v1")))
+    });
+
+    vm.stopBroadcast();
+  }
+}

--- a/contracts/scripts/runlogs/2025_10.s.sol
+++ b/contracts/scripts/runlogs/2025_10.s.sol
@@ -35,7 +35,7 @@ contract Runlogs_2025_10_Mainnet is SetupMainnet {
       _ammPoolAddress: CrossChain.MORPHO_BLUE,
       _campaignDuration: 7 days,
       campaignData: campaignData,
-      _salt: uint256(keccak256(abi.encodePacked("Merkl Morpho PB OUSD/USDC v1")))
+      _salt: uint256(keccak256(abi.encodePacked("Merkl Morpho PB OETH/USDC v1")))
     });
 
     console.log("computed address", poolBoosterAddress);
@@ -59,7 +59,7 @@ contract Runlogs_2025_10_Mainnet is SetupMainnet {
       _ammPoolAddress: CrossChain.MORPHO_BLUE,
       _campaignDuration: 7 days,
       campaignData: campaignData,
-      _salt: uint256(keccak256(abi.encodePacked("Merkl Morpho PB OUSD/USDC v1")))
+      _salt: uint256(keccak256(abi.encodePacked("Merkl Morpho PB OETH/USDC v1")))
     });
 
     vm.stopBroadcast();

--- a/contracts/scripts/runlogs/README.md
+++ b/contracts/scripts/runlogs/README.md
@@ -26,7 +26,7 @@ To convert a `broadcast-ready` into a Safe-compatible JSON file, use the forge s
 
 In the `contracts` folder run:
 ```bash
-forge script BroadcastConvertor contracts/broadcast/2025_09.sol/146/dry-run/
+forge script BroadcastConvertor --sig "run(string)" contracts/broadcast/2025_09.sol/146/dry-run/
 ```
 > Note adjust the input accordingly:
 > first the path to the run file, but stop at the dry-run folder.

--- a/contracts/scripts/runlogs/utils/Addresses.sol
+++ b/contracts/scripts/runlogs/utils/Addresses.sol
@@ -27,6 +27,10 @@ library Mainnet {
   // OETH Strategies
   address public constant OETH_WETH_CURVE_AMO = 0xba0e352AB5c13861C26e4E773e7a833C3A223FE6;
 
+  // Pool Booster
+  address public constant POOL_BOOSTER_FACTORY_MERKL = 0x0FC66355B681503eFeE7741BD848080d809FD6db;
+  address public constant POOL_BOOSTER_CENTRAL_REGISTRY = 0xAA8af8Db4B6a827B51786334d26349eb03569731;
+
   // Other token
   address public constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
   address public constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;

--- a/contracts/scripts/runlogs/utils/Setup.sol
+++ b/contracts/scripts/runlogs/utils/Setup.sol
@@ -63,6 +63,12 @@ abstract contract SetupMainnet is Test, Script {
   OETHVaultValueChecker public oethVaultValueChecker =
     OETHVaultValueChecker(Mainnet.OETH_VAULT_VALUE_CHECKER);
 
+  // Pool Booster
+  PoolBoosterFactoryMerkl public poolBoosterFactoryMerkl =
+    PoolBoosterFactoryMerkl(Mainnet.POOL_BOOSTER_FACTORY_MERKL);
+  PoolBoostCentralRegistry public poolBoosterCentralRegistry =
+    PoolBoostCentralRegistry(Mainnet.POOL_BOOSTER_CENTRAL_REGISTRY);
+
   // Interfaces
   IWETH9 public weth = IWETH9(Mainnet.WETH);
   ICurveStableSwapNG public oethWethCurvePool = ICurveStableSwapNG(Mainnet.OETH_WETH_CURVE_POOL);


### PR DESCRIPTION
## Overview
- This takes the Merkl pool booster factory and computes the address of the Merkl Pool booster that will be created once the Merkl factory gets approved by the timelock transaction to the Central registry.
- Merkl pool booster will be crated for the Morpho Blue [OETH/USDC marketplace](https://app.morpho.org/ethereum/market/0xb8fef900b383db2dbbf4458c7f46acf5b140f26d603a6d1829963f241b82510e/oeth-usdc). The id ( 0xb8fef900b383db2dbbf4458c7f46acf5b140f26d603a6d1829963f241b82510e ) can be confirmed in the campaign data of the runlog
- yield forwarding is then delegated to the computed address `0x266CDd690Ab3133C3FE532aaB3f48cE0FA5E19F5` of the Merkl pool booster

### Runlog logs 
<img width="550" height="175" alt="Screenshot 2025-10-03 at 13 41 53" src="https://github.com/user-attachments/assets/5250b1f3-8aff-4fe9-8e26-ae1807111e27" />


## Governance action checklist
Two reviewers complete the following checklist:

```
- [ ] Governance proposal matches the deploy script
```

