### PR TITLE
Defender Key value store backfill

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -365,6 +365,7 @@ pnpm hardhat setActionVars --id f74f24b4-d98b-4181-89cc-6608369b6f91
 pnpm hardhat setActionVars --id aa194c13-0dbf-49d2-8e87-70e61f3d71a8
 pnpm hardhat setActionVars --id 65b53496-e426-4850-8349-059e63eb2120
 pnpm hardhat setActionVars --id a4f8ca5f-7144-469b-b84a-58b30fed72ce
+pnpm hardhat setActionVars --id cbddb98e-a0f6-4aa8-bd73-20aa8e81d704
 
 # Mainnet
 pnpm hardhat updateAction --id e2929f53-db56-49b2-b054-35f7df7fc4fb --file doAccounting
@@ -387,11 +388,28 @@ pnpm hardhat updateAction --id a4f8ca5f-7144-469b-b84a-58b30fed72ce --file claim
 pnpm hardhat updateAction --id bb43e5da-f936-4185-84da-253394583665 --file crossChainRelay
 pnpm hardhat updateAction --id e571409b-5399-48e4-bfb2-50b7af9903aa --file crossChainRelay
 
+# One-off action for backfilling a missing tx-level key in Defender KV store
+pnpm hardhat updateAction --id cbddb98e-a0f6-4aa8-bd73-20aa8e81d704 --file crossChainRelayBackfillTx
+
 # OUSD Ethereum -> HyperEVM actions
 pnpm hardhat updateAction --id 0b852456-96a0-4f1d-9d6c-39e1c6ae9dfc --file crossChainRelayHyperEVM
 pnpm hardhat updateAction --id 65f04f74-8da7-4fc5-94b3-96be31bac03b --file crossChainRelayHyperEVM
 
 ```
+
+To backfill a missing tx-level cross-chain relay key, set
+`HARDCODED_TRANSACTION_ID` and `HARDCODED_DESTINATION_CHAIN_ID` in
+`scripts/defender-actions/crossChainRelayBackfillTx.js`, then bundle/upload and
+run the `crossChainRelayBackfillTx` Action manually in Defender.
+
+This stores both tx-level keys with value `processed` in Defender's key-value
+store:
+
+- `cctp_message_<HARDCODED_TRANSACTION_ID>` (legacy format)
+- `cctp_message_<HARDCODED_TRANSACTION_ID>_<cctpDestinationDomainId>` (current
+  format from `tasks/crossChain.js`, where domain id is derived from the
+  hardcoded destination chain id: mainnet `1 -> 0`, base `8453 -> 6`, hyperevm
+  `999 -> 19`)
 
 `rollup` can be installed globally to avoid the `npx` prefix.
 

--- a/contracts/scripts/defender-actions/crossChainRelayBackfillTx.js
+++ b/contracts/scripts/defender-actions/crossChainRelayBackfillTx.js
@@ -1,0 +1,104 @@
+const { Defender } = require("@openzeppelin/defender-sdk");
+
+/**
+ * =========================
+ *      Config Settings
+ * =========================
+ */
+const HARDCODED_TRANSACTION_ID =
+  "0x0000000000000000000000000000000000000000000000000000000000000000";
+const HARDCODED_DESTINATION_CHAIN_ID = 1;
+/**
+ * =========================
+ *      End of Settings
+ * =========================
+ */
+
+const TX_HASH_REGEX = /^0x([A-Fa-f0-9]{64})$/;
+// we are hardcoding the destination chain id so the rollup built file is clean
+const CHAIN_ID_TO_CCTP_DESTINATION_DOMAIN_ID = {
+  1: 0, // Ethereum
+  8453: 6, // Base
+  999: 19, // HyperEVM
+};
+
+const getTransactionId = () => {
+  if (!TX_HASH_REGEX.test(HARDCODED_TRANSACTION_ID)) {
+    throw new Error(
+      "HARDCODED_TRANSACTION_ID must be a valid 0x-prefixed 32-byte tx hash"
+    );
+  }
+  return HARDCODED_TRANSACTION_ID.toLowerCase();
+};
+
+const getDestinationChainId = () => {
+  if (
+    typeof HARDCODED_DESTINATION_CHAIN_ID !== "number" ||
+    !Number.isInteger(HARDCODED_DESTINATION_CHAIN_ID)
+  ) {
+    throw new Error("HARDCODED_DESTINATION_CHAIN_ID must be an integer");
+  }
+  if (
+    CHAIN_ID_TO_CCTP_DESTINATION_DOMAIN_ID[HARDCODED_DESTINATION_CHAIN_ID] ===
+    undefined
+  ) {
+    throw new Error(
+      `Unsupported HARDCODED_DESTINATION_CHAIN_ID: ${HARDCODED_DESTINATION_CHAIN_ID}`
+    );
+  }
+  return HARDCODED_DESTINATION_CHAIN_ID;
+};
+
+// Entrypoint for the Defender Action
+const handler = async (event) => {
+  console.log(
+    `DEBUG env var in handler before being set: "${process.env.DEBUG}"`
+  );
+
+  const client = new Defender(event);
+  const chainId = getDestinationChainId();
+  const cctpDestinationDomainId =
+    CHAIN_ID_TO_CCTP_DESTINATION_DOMAIN_ID[chainId];
+
+  const transactionId = getTransactionId();
+  const legacyKey = `cctp_message_${transactionId}`;
+  const chainScopedKey = `cctp_message_${transactionId}_${cctpDestinationDomainId}`;
+
+  const [legacyValue, chainScopedValue] = await Promise.all([
+    client.keyValueStore.get(legacyKey),
+    client.keyValueStore.get(chainScopedKey),
+  ]);
+
+  const updates = {
+    legacy: false,
+    chainScoped: false,
+  };
+
+  if (legacyValue !== "processed") {
+    await client.keyValueStore.put(legacyKey, "processed");
+    updates.legacy = true;
+    console.log(`Stored key ${legacyKey} with value processed`);
+  } else {
+    console.log(`Key ${legacyKey} already marked as processed`);
+  }
+
+  if (chainScopedValue !== "processed") {
+    await client.keyValueStore.put(chainScopedKey, "processed");
+    updates.chainScoped = true;
+    console.log(`Stored key ${chainScopedKey} with value processed`);
+  } else {
+    console.log(`Key ${chainScopedKey} already marked as processed`);
+  }
+
+  return {
+    transactionId,
+    chainId,
+    cctpDestinationDomainId,
+    legacyKey,
+    chainScopedKey,
+    value: "processed",
+    updated: updates,
+  };
+};
+
+module.exports = { handler };

--- a/contracts/scripts/defender-actions/rollup.config.cjs
+++ b/contracts/scripts/defender-actions/rollup.config.cjs
@@ -41,6 +41,7 @@ const actions = [
   "sonicClaimWithdrawals",
   "claimBribes",
   "crossChainRelay",
+  "crossChainRelayBackfillTx",
   "updateVotemarketEpochs",
   "crossChainRelayHyperEVM",
   "manageBribes",


### PR DESCRIPTION
Adds a defender action that can backfill  a transaction hash and destination chain id when necessary.
The rollup built code is pretty clean (no imports) so it is easy to change transaction hash / destination chain id directly on defender 
<img width="692" height="181" alt="Screenshot 2026-04-17 at 14 08 17" src="https://github.com/user-attachments/assets/fa170550-4bef-4aa1-8a06-781851d86af2" />
