### PR TITLE
fix: decode BalancesSnapped event via strategy interface in snapBalances task

### DIFF
--- a/contracts/tasks/validatorCompound.js
+++ b/contracts/tasks/validatorCompound.js
@@ -50,17 +50,28 @@ async function snapBalances({ consol = false }) {
   await logTxDetails(tx, "snapBalances");
 
   const receipt = await tx.wait();
-  const event = receipt.events.find(
-    (event) => event.event === "BalancesSnapped"
+
+  // When called via ConsolidationController the BalancesSnapped event is emitted
+  // by the target strategy, so decode logs against the strategy's interface.
+  const strategy = await resolveContract(
+    "CompoundingStakingSSVStrategyProxy",
+    "CompoundingStakingSSVStrategy"
   );
-  if (!event) {
+  const eventTopic = strategy.interface.getEventTopic("BalancesSnapped");
+  const rawLog = receipt.logs.find(
+    (l) =>
+      l.address.toLowerCase() === strategy.address.toLowerCase() &&
+      l.topics[0] === eventTopic
+  );
+  if (!rawLog) {
     throw new Error("BalancesSnapped event not found in transaction receipt");
   }
+  const parsed = strategy.interface.parseLog(rawLog);
   console.log(
     `Balances snapped successfully. Beacon block root ${
-      event.args.blockRoot
+      parsed.args.blockRoot
     }, block ${receipt.blockNumber}, ETH balance ${formatUnits(
-      event.args.ethBalance
+      parsed.args.ethBalance
     )}`
   );
 }


### PR DESCRIPTION
## Summary
- When the `snapBalances` hardhat task runs with `--consol true`, the tx is routed through `ConsolidationController`, but the `BalancesSnapped` event is emitted by the target `CompoundingStakingSSVStrategy`. Ethers only decodes `receipt.events[*].event` against the ABI of the contract used to send the tx, so the event lookup failed and the task threw even though the on-chain call succeeded.
- Fix locates the raw log by topic on the strategy's address and parses it through the strategy's interface. No contract changes required.