### PR TITLE
chore: switch husky pre-commit hook to pnpm

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 cd contracts
-yarn run lint:js
+pnpm run lint:js


### PR DESCRIPTION
The pre-commit hook ran yarn run lint:js, which now fails because contracts/package.json declares "packageManager": "pnpm@10.18.3". Yarn 1 reads that field,  sees a non-yarn version, and exits non-zero — so every commit aborts with:

This project's package.json defines "packageManager": "yarn@pnpm@10.18.3".

The rest of the repo (scripts, crons, CLAUDE.md) already standardized on pnpm; this updates the hook to match.