### PR TITLE
Migrate vault & cross-chain operators to the new Talos signer (+ unpause rebases)

### DIFF
--- a/contracts/deploy/base/051_migrate_base_operators_to_talos_kms.js
+++ b/contracts/deploy/base/051_migrate_base_operators_to_talos_kms.js
@@ -1,0 +1,45 @@
+const { deployOnBase } = require("../../utils/deploy-l2");
+const addresses = require("../../utils/addresses");
+
+// Executed by base.governor 5/8 -> Base Timelock (these setters are onlyGovernor).
+// Re-points the Base CrossChainRemoteStrategy operator and the OETHBaseVault
+// operatorAddr to the new Talos signer, and unpauses OETHb rebases so Talos can
+// rebase the vault directly (operator-gated) — replacing the PermissionedRebaseModule.
+module.exports = deployOnBase(
+  {
+    deployName: "051_migrate_base_operators_to_talos",
+  },
+  async () => {
+    const cCrossChainRemoteStrategy = await ethers.getContractAt(
+      "CrossChainRemoteStrategy",
+      addresses.base.CrossChainRemoteStrategy
+    );
+
+    const cOETHbVaultProxy = await ethers.getContract("OETHBaseVaultProxy");
+    const cOETHbVault = await ethers.getContractAt(
+      "IVault",
+      cOETHbVaultProxy.address
+    );
+
+    return {
+      name: "Migrate the Base CrossChainRemoteStrategy operator and OETHBaseVault operatorAddr to the new Talos signer, and unpause OETHb rebases.",
+      actions: [
+        {
+          contract: cCrossChainRemoteStrategy,
+          signature: "setOperator(address)",
+          args: [addresses.talosRelayer],
+        },
+        {
+          contract: cOETHbVault,
+          signature: "setOperatorAddr(address)",
+          args: [addresses.talosRelayer],
+        },
+        {
+          contract: cOETHbVault,
+          signature: "unpauseRebase()",
+          args: [],
+        },
+      ],
+    };
+  }
+);

--- a/contracts/deploy/base/052_migrate_base_merkl_module_to_talos_kms.js
+++ b/contracts/deploy/base/052_migrate_base_merkl_module_to_talos_kms.js
@@ -22,12 +22,18 @@ module.exports = deploymentWithGnosisSafe(
     );
 
     return {
-      name: "Grant the OPERATOR_ROLE of the Base MerklPoolBoosterBribesModule to the new Talos signer.",
+      name: "Grant the OPERATOR_ROLE of the Base MerklPoolBoosterBribesModule to the new Talos signer, and revoke it from the old relayer.",
       actions: [
         {
           contract: cMerklModule,
           signature: "grantRole(bytes32,address)",
           args: [OPERATOR_ROLE, addresses.talosRelayer],
+        },
+        // grantRole is additive — the old relayer keeps OPERATOR_ROLE, so revoke it.
+        {
+          contract: cMerklModule,
+          signature: "revokeRole(bytes32,address)",
+          args: [OPERATOR_ROLE, addresses.base.OZRelayerAddress],
         },
       ],
     };

--- a/contracts/deploy/base/052_migrate_base_merkl_module_to_talos_kms.js
+++ b/contracts/deploy/base/052_migrate_base_merkl_module_to_talos_kms.js
@@ -1,0 +1,35 @@
+const addresses = require("../../utils/addresses");
+const { deploymentWithGnosisSafe } = require("../../utils/deploy");
+
+// The Base MerklPoolBoosterBribesModule is admined by the multichainStrategist
+// 2/8 Safe (its DEFAULT_ADMIN_ROLE holder), so granting OPERATOR_ROLE to the new
+// Talos signer is a plain Safe transaction
+module.exports = deploymentWithGnosisSafe(
+  {
+    deployName: "052_migrate_base_merkl_module_to_talos",
+    safe: addresses.multichainStrategist,
+    network: "base",
+    forceDeploy: false,
+  },
+  async () => {
+    const cMerklModule = await ethers.getContractAt(
+      "MerklPoolBoosterBribesModule",
+      addresses.base.MerklPoolBoosterBribesModule
+    );
+
+    const OPERATOR_ROLE = ethers.utils.keccak256(
+      ethers.utils.toUtf8Bytes("OPERATOR_ROLE")
+    );
+
+    return {
+      name: "Grant the OPERATOR_ROLE of the Base MerklPoolBoosterBribesModule to the new Talos signer.",
+      actions: [
+        {
+          contract: cMerklModule,
+          signature: "grantRole(bytes32,address)",
+          args: [OPERATOR_ROLE, addresses.talosRelayer],
+        },
+      ],
+    };
+  }
+);

--- a/contracts/deploy/base/053_grant_base_claim_bribes_module1_talos_kms.js
+++ b/contracts/deploy/base/053_grant_base_claim_bribes_module1_talos_kms.js
@@ -1,0 +1,33 @@
+const addresses = require("../../utils/addresses");
+const { deploymentWithGnosisSafe } = require("../../utils/deploy");
+
+// ClaimBribesSafeModule1 is admined by the ClaimBribes 2/8 Safe (its
+// DEFAULT_ADMIN_ROLE holder and immutable safeContract()), so granting
+// OPERATOR_ROLE to the new Talos signer is a plain Safe transaction.
+module.exports = deploymentWithGnosisSafe(
+  {
+    deployName: "053_grant_base_claim_bribes_module1_talos",
+    network: "base",
+    forceDeploy: false,
+  },
+  async () => {
+    const cModule = await ethers.getContract("ClaimBribesSafeModule1");
+    const safe = await cModule.safeContract();
+
+    const OPERATOR_ROLE = ethers.utils.keccak256(
+      ethers.utils.toUtf8Bytes("OPERATOR_ROLE")
+    );
+
+    return {
+      safe,
+      name: "Grant the OPERATOR_ROLE of the Base ClaimBribesSafeModule1 to the new Talos signer.",
+      actions: [
+        {
+          contract: cModule,
+          signature: "grantRole(bytes32,address)",
+          args: [OPERATOR_ROLE, addresses.talosRelayer],
+        },
+      ],
+    };
+  }
+);

--- a/contracts/deploy/base/053_grant_base_claim_bribes_module1_talos_kms.js
+++ b/contracts/deploy/base/053_grant_base_claim_bribes_module1_talos_kms.js
@@ -20,12 +20,18 @@ module.exports = deploymentWithGnosisSafe(
 
     return {
       safe,
-      name: "Grant the OPERATOR_ROLE of the Base ClaimBribesSafeModule1 to the new Talos signer.",
+      name: "Grant the OPERATOR_ROLE of the Base ClaimBribesSafeModule1 to the new Talos signer, and revoke it from the old relayer.",
       actions: [
         {
           contract: cModule,
           signature: "grantRole(bytes32,address)",
           args: [OPERATOR_ROLE, addresses.talosRelayer],
+        },
+        // grantRole is additive — the old relayer keeps OPERATOR_ROLE, so revoke it.
+        {
+          contract: cModule,
+          signature: "revokeRole(bytes32,address)",
+          args: [OPERATOR_ROLE, addresses.base.OZRelayerAddress],
         },
       ],
     };

--- a/contracts/deploy/base/054_grant_base_claim_bribes_module3_talos_kms.js
+++ b/contracts/deploy/base/054_grant_base_claim_bribes_module3_talos_kms.js
@@ -1,0 +1,33 @@
+const addresses = require("../../utils/addresses");
+const { deploymentWithGnosisSafe } = require("../../utils/deploy");
+
+// ClaimBribesSafeModule3 is admined by the base.strategist 1/2 Safe (its
+// DEFAULT_ADMIN_ROLE holder and immutable safeContract()), so granting
+// OPERATOR_ROLE to the new Talos signer is a plain Safe transaction.
+module.exports = deploymentWithGnosisSafe(
+  {
+    deployName: "054_grant_base_claim_bribes_module3_talos",
+    network: "base",
+    forceDeploy: false,
+  },
+  async () => {
+    const cModule = await ethers.getContract("ClaimBribesSafeModule3");
+    const safe = await cModule.safeContract();
+
+    const OPERATOR_ROLE = ethers.utils.keccak256(
+      ethers.utils.toUtf8Bytes("OPERATOR_ROLE")
+    );
+
+    return {
+      safe,
+      name: "Grant the OPERATOR_ROLE of the Base ClaimBribesSafeModule3 to the new Talos signer.",
+      actions: [
+        {
+          contract: cModule,
+          signature: "grantRole(bytes32,address)",
+          args: [OPERATOR_ROLE, addresses.talosRelayer],
+        },
+      ],
+    };
+  }
+);

--- a/contracts/deploy/base/054_grant_base_claim_bribes_module3_talos_kms.js
+++ b/contracts/deploy/base/054_grant_base_claim_bribes_module3_talos_kms.js
@@ -20,12 +20,18 @@ module.exports = deploymentWithGnosisSafe(
 
     return {
       safe,
-      name: "Grant the OPERATOR_ROLE of the Base ClaimBribesSafeModule3 to the new Talos signer.",
+      name: "Grant the OPERATOR_ROLE of the Base ClaimBribesSafeModule3 to the new Talos signer, and revoke it from the old relayer.",
       actions: [
         {
           contract: cModule,
           signature: "grantRole(bytes32,address)",
           args: [OPERATOR_ROLE, addresses.talosRelayer],
+        },
+        // grantRole is additive — the old relayer keeps OPERATOR_ROLE, so revoke it.
+        {
+          contract: cModule,
+          signature: "revokeRole(bytes32,address)",
+          args: [OPERATOR_ROLE, addresses.base.OZRelayerAddress],
         },
       ],
     };

--- a/contracts/deploy/hyperevm/003_migrate_crosschain_strategy_to_talos_kms.js
+++ b/contracts/deploy/hyperevm/003_migrate_crosschain_strategy_to_talos_kms.js
@@ -1,0 +1,30 @@
+const { deployOnHyperEVM } = require("../../utils/deploy-l2");
+const addresses = require("../../utils/addresses");
+
+// Re-point the HyperEVM CrossChainRemoteStrategy operator to the new Talos KMS
+// signer (from the old relayer 0xC79A…0517). setOperator is onlyGovernor and the
+// strategy's governor is the HyperEVM Timelock, so this is executed via that
+// timelock (scheduled/executed by the hyperevm 5/8 admin). deployOnHyperEVM
+// writes the schedule + execute Safe Transaction Builder JSON for the 5/8 admin.
+module.exports = deployOnHyperEVM(
+  {
+    deployName: "003_migrate_crosschain_strategy_to_talos",
+  },
+  async () => {
+    const cCrossChainRemoteStrategy = await ethers.getContractAt(
+      "CrossChainRemoteStrategy",
+      addresses.hyperevm.CrossChainRemoteStrategy
+    );
+
+    return {
+      name: "Migrate the HyperEVM CrossChainRemoteStrategy operator to the new Talos signer.",
+      actions: [
+        {
+          contract: cCrossChainRemoteStrategy,
+          signature: "setOperator(address)",
+          args: [addresses.talosRelayer],
+        },
+      ],
+    };
+  }
+);

--- a/contracts/deploy/mainnet/196_migrate_operators_to_talos_kms.js
+++ b/contracts/deploy/mainnet/196_migrate_operators_to_talos_kms.js
@@ -1,0 +1,72 @@
+const addresses = require("../../utils/addresses");
+const { deploymentWithGovernanceProposal } = require("../../utils/deploy");
+
+module.exports = deploymentWithGovernanceProposal(
+  {
+    deployName: "196_migrate_operators_to_talos",
+    forceDeploy: false,
+    reduceQueueTime: true,
+    deployerIsProposer: false,
+    proposalId: "", // fill in after the proposal is submitted on-chain
+  },
+  async () => {
+    // OUSD Vault (proxy "VaultProxy") + OETH Vault — IVault exposes both setters
+    const cVaultProxy = await ethers.getContract("VaultProxy");
+    const cOUSDVault = await ethers.getContractAt(
+      "IVault",
+      cVaultProxy.address
+    );
+
+    const cOETHVaultProxy = await ethers.getContract("OETHVaultProxy");
+    const cOETHVault = await ethers.getContractAt(
+      "IVault",
+      cOETHVaultProxy.address
+    );
+
+    // Cross-chain strategies (same contract code, two Create2 proxies)
+    const cCrossChainMasterStrategy = await ethers.getContractAt(
+      "CrossChainMasterStrategy",
+      addresses.mainnet.CrossChainMasterStrategy
+    );
+    const cCrossChainHyperEVMMasterStrategy = await ethers.getContractAt(
+      "CrossChainMasterStrategy",
+      addresses.mainnet.CrossChainHyperEVMMasterStrategy
+    );
+
+    return {
+      name: "Migrate scheduled-action operator of the OUSD/OETH vaults and the Crosschain (Base + HyperEVM) strategies to the new signer, and unpause OUSD/OETH rebases.",
+      actions: [
+        {
+          contract: cOUSDVault,
+          signature: "setOperatorAddr(address)",
+          args: [addresses.talosRelayer],
+        },
+        {
+          contract: cOETHVault,
+          signature: "setOperatorAddr(address)",
+          args: [addresses.talosRelayer],
+        },
+        {
+          contract: cCrossChainMasterStrategy,
+          signature: "setOperator(address)",
+          args: [addresses.talosRelayer],
+        },
+        {
+          contract: cCrossChainHyperEVMMasterStrategy,
+          signature: "setOperator(address)",
+          args: [addresses.talosRelayer],
+        },
+        {
+          contract: cOUSDVault,
+          signature: "unpauseRebase()",
+          args: [],
+        },
+        {
+          contract: cOETHVault,
+          signature: "unpauseRebase()",
+          args: [],
+        },
+      ],
+    };
+  }
+);

--- a/contracts/deploy/mainnet/196_migrate_operators_to_talos_kms.js
+++ b/contracts/deploy/mainnet/196_migrate_operators_to_talos_kms.js
@@ -1,6 +1,7 @@
 const addresses = require("../../utils/addresses");
 const { deploymentWithGovernanceProposal } = require("../../utils/deploy");
 
+// the governor to execute this proposal is OGN governance
 module.exports = deploymentWithGovernanceProposal(
   {
     deployName: "196_migrate_operators_to_talos",

--- a/contracts/deploy/mainnet/197_migrate_xogn_module6_to_talos_kms.js
+++ b/contracts/deploy/mainnet/197_migrate_xogn_module6_to_talos_kms.js
@@ -1,0 +1,33 @@
+const addresses = require("../../utils/addresses");
+const { deploymentWithGuardianGovernor } = require("../../utils/deploy");
+
+// CollectXOGNRewardsModule6 is admined by the mainnet Guardian 5/8 Safe (its
+// DEFAULT_ADMIN_ROLE holder), so the operator migration is executed by that Safe
+// directly — a different signing entity than the GovernorSix -> Timelock used in
+// deploy 196, hence a separate deploy file.
+module.exports = deploymentWithGuardianGovernor(
+  {
+    deployName: "197_migrate_xogn_module6_to_talos",
+    forceDeploy: false,
+  },
+  async () => {
+    const cCollectXOGNRewardsModule6 = await ethers.getContract(
+      "CollectXOGNRewardsModule6"
+    );
+
+    const OPERATOR_ROLE = ethers.utils.keccak256(
+      ethers.utils.toUtf8Bytes("OPERATOR_ROLE")
+    );
+
+    return {
+      name: "Grant the OPERATOR_ROLE of CollectXOGNRewardsModule6 to the new Talos signer.",
+      actions: [
+        {
+          contract: cCollectXOGNRewardsModule6,
+          signature: "grantRole(bytes32,address)",
+          args: [OPERATOR_ROLE, addresses.talosRelayer],
+        },
+      ],
+    };
+  }
+);

--- a/contracts/deploy/mainnet/197_migrate_xogn_module6_to_talos_kms.js
+++ b/contracts/deploy/mainnet/197_migrate_xogn_module6_to_talos_kms.js
@@ -1,10 +1,7 @@
 const addresses = require("../../utils/addresses");
 const { deploymentWithGnosisSafe } = require("../../utils/deploy");
 
-// CollectXOGNRewardsModule6 is admined by the mainnet Guardian 5/8 Safe (its
-// DEFAULT_ADMIN_ROLE holder), so the operator migration is executed by that Safe
-// directly — a different signing entity than the GovernorSix -> Timelock used in
-// deploy 196, hence a separate deploy file.
+// the governor to execute this proposal is Gnosis 5/8 Multisig
 module.exports = deploymentWithGnosisSafe(
   {
     deployName: "197_migrate_xogn_module6_to_talos",

--- a/contracts/deploy/mainnet/197_migrate_xogn_module6_to_talos_kms.js
+++ b/contracts/deploy/mainnet/197_migrate_xogn_module6_to_talos_kms.js
@@ -1,13 +1,14 @@
 const addresses = require("../../utils/addresses");
-const { deploymentWithGuardianGovernor } = require("../../utils/deploy");
+const { deploymentWithGnosisSafe } = require("../../utils/deploy");
 
 // CollectXOGNRewardsModule6 is admined by the mainnet Guardian 5/8 Safe (its
 // DEFAULT_ADMIN_ROLE holder), so the operator migration is executed by that Safe
 // directly — a different signing entity than the GovernorSix -> Timelock used in
 // deploy 196, hence a separate deploy file.
-module.exports = deploymentWithGuardianGovernor(
+module.exports = deploymentWithGnosisSafe(
   {
     deployName: "197_migrate_xogn_module6_to_talos",
+    safe: addresses.mainnet.Guardian,
     forceDeploy: false,
   },
   async () => {

--- a/contracts/deploy/mainnet/197_migrate_xogn_module6_to_talos_kms.js
+++ b/contracts/deploy/mainnet/197_migrate_xogn_module6_to_talos_kms.js
@@ -18,12 +18,18 @@ module.exports = deploymentWithGnosisSafe(
     );
 
     return {
-      name: "Grant the OPERATOR_ROLE of CollectXOGNRewardsModule6 to the new Talos signer.",
+      name: "Grant the OPERATOR_ROLE of CollectXOGNRewardsModule6 to the new Talos signer, and revoke it from the old relayer.",
       actions: [
         {
           contract: cCollectXOGNRewardsModule6,
           signature: "grantRole(bytes32,address)",
           args: [OPERATOR_ROLE, addresses.talosRelayer],
+        },
+        // grantRole is additive — the old relayer keeps OPERATOR_ROLE, so revoke it.
+        {
+          contract: cCollectXOGNRewardsModule6,
+          signature: "revokeRole(bytes32,address)",
+          args: [OPERATOR_ROLE, addresses.mainnet.validatorRegistrator],
         },
       ],
     };

--- a/contracts/deploy/mainnet/198_migrate_strategist_modules_to_talos_kms.js
+++ b/contracts/deploy/mainnet/198_migrate_strategist_modules_to_talos_kms.js
@@ -1,0 +1,39 @@
+const addresses = require("../../utils/addresses");
+const { deploymentWithGnosisSafe } = require("../../utils/deploy");
+
+// All four safe modules are admined by the multichainStrategist 2/8 Safe (their
+// DEFAULT_ADMIN_ROLE holder), so granting OPERATOR_ROLE to the new Talos signer
+// is a plain Safe transaction batch — a different signing entity than the
+// GovernorSix->Timelock (deploy 196) and the Guardian 5/8 Safe (deploy 197).
+module.exports = deploymentWithGnosisSafe(
+  {
+    deployName: "198_migrate_strategist_modules_to_talos",
+    safe: addresses.multichainStrategist,
+    forceDeploy: false,
+  },
+  async () => {
+    const moduleNames = [
+      "ClaimStrategyRewardsSafeModule",
+      "AutoWithdrawalModule",
+      "MerklPoolBoosterBribesModule",
+      "CurvePoolBoosterBribesModule",
+    ];
+    const modules = [];
+    for (const name of moduleNames) {
+      modules.push(await ethers.getContract(name));
+    }
+
+    const OPERATOR_ROLE = ethers.utils.keccak256(
+      ethers.utils.toUtf8Bytes("OPERATOR_ROLE")
+    );
+
+    return {
+      name: "Grant the OPERATOR_ROLE of all strategist safe modules to the new Talos signer.",
+      actions: modules.map((cModule) => ({
+        contract: cModule,
+        signature: "grantRole(bytes32,address)",
+        args: [OPERATOR_ROLE, addresses.talosRelayer],
+      })),
+    };
+  }
+);

--- a/contracts/deploy/mainnet/198_migrate_strategist_modules_to_talos_kms.js
+++ b/contracts/deploy/mainnet/198_migrate_strategist_modules_to_talos_kms.js
@@ -1,10 +1,7 @@
 const addresses = require("../../utils/addresses");
 const { deploymentWithGnosisSafe } = require("../../utils/deploy");
 
-// All four safe modules are admined by the multichainStrategist 2/8 Safe (their
-// DEFAULT_ADMIN_ROLE holder), so granting OPERATOR_ROLE to the new Talos signer
-// is a plain Safe transaction batch — a different signing entity than the
-// GovernorSix->Timelock (deploy 196) and the Guardian 5/8 Safe (deploy 197).
+// the governor to execute this proposal is 2/8 Cross chain strategist
 module.exports = deploymentWithGnosisSafe(
   {
     deployName: "198_migrate_strategist_modules_to_talos",

--- a/contracts/deploy/mainnet/198_migrate_strategist_modules_to_talos_kms.js
+++ b/contracts/deploy/mainnet/198_migrate_strategist_modules_to_talos_kms.js
@@ -25,12 +25,21 @@ module.exports = deploymentWithGnosisSafe(
     );
 
     return {
-      name: "Grant the OPERATOR_ROLE of all strategist safe modules to the new Talos signer.",
-      actions: modules.map((cModule) => ({
-        contract: cModule,
-        signature: "grantRole(bytes32,address)",
-        args: [OPERATOR_ROLE, addresses.talosRelayer],
-      })),
+      name: "Grant the OPERATOR_ROLE of all strategist safe modules to the new Talos signer, and revoke it from the old relayer.",
+      // grantRole is additive — the old relayer keeps OPERATOR_ROLE, so for each
+      // module grant the new signer AND revoke the old relayer.
+      actions: modules.flatMap((cModule) => [
+        {
+          contract: cModule,
+          signature: "grantRole(bytes32,address)",
+          args: [OPERATOR_ROLE, addresses.talosRelayer],
+        },
+        {
+          contract: cModule,
+          signature: "revokeRole(bytes32,address)",
+          args: [OPERATOR_ROLE, addresses.mainnet.validatorRegistrator],
+        },
+      ]),
     };
   }
 );

--- a/contracts/deploy/sonic/030_migrate_sonic_operators_to_talos_kms.js
+++ b/contracts/deploy/sonic/030_migrate_sonic_operators_to_talos_kms.js
@@ -1,0 +1,49 @@
+const addresses = require("../../utils/addresses");
+const { deployOnSonic } = require("../../utils/deploy-l2");
+
+// Migrate the Sonic operator/registrator roles from the old relayer EOA to the
+// new Talos KMS signer. All three actions are governor-gated and executed via
+// the Sonic Timelock (scheduled by the Sonic 5/8 admin). The vault rebase is
+// operator-gated and currently paused, so we also unpause it once the operator
+// is set.
+module.exports = deployOnSonic(
+  {
+    deployName: "030_migrate_sonic_operators_to_talos",
+  },
+  async ({ ethers }) => {
+    const cOSonicVaultProxy = await ethers.getContract("OSonicVaultProxy");
+    const cOSonicVault = await ethers.getContractAt(
+      "IVault",
+      cOSonicVaultProxy.address
+    );
+
+    const cSonicStakingStrategyProxy = await ethers.getContract(
+      "SonicStakingStrategyProxy"
+    );
+    const cSonicStakingStrategy = await ethers.getContractAt(
+      "SonicStakingStrategy",
+      cSonicStakingStrategyProxy.address
+    );
+
+    return {
+      name: "Migrate Sonic operators to the Talos KMS signer",
+      actions: [
+        {
+          contract: cOSonicVault,
+          signature: "setOperatorAddr(address)",
+          args: [addresses.talosRelayer],
+        },
+        {
+          contract: cOSonicVault,
+          signature: "unpauseRebase()",
+          args: [],
+        },
+        {
+          contract: cSonicStakingStrategy,
+          signature: "setRegistrator(address)",
+          args: [addresses.talosRelayer],
+        },
+      ],
+    };
+  }
+);

--- a/contracts/test/_fixture-hyperevm.js
+++ b/contracts/test/_fixture-hyperevm.js
@@ -105,7 +105,11 @@ const crossChainHyperEVMFixture = deployments.createFixture(async () => {
     addresses.CCTPTokenMessengerV2
   );
 
-  const relayer = await impersonateAndFund(addresses.hyperevm.OZRelayerAddress);
+  // The cross-chain operator is re-pointed during the Talos signer migration
+  // (deploy 003), so read it from the strategy instead of hardcoding a relayer.
+  const relayer = await impersonateAndFund(
+    await fixture.crossChainRemoteStrategy.operator()
+  );
 
   return {
     ...fixture,

--- a/contracts/test/_fixture.js
+++ b/contracts/test/_fixture.js
@@ -1632,8 +1632,10 @@ async function crossChainFixture() {
     addresses.CCTPTokenMessengerV2
   );
 
+  // The cross-chain operator is repointed during the Talos signer migration
+  // (deploy 196), so read it from the strategy instead of hardcoding a relayer.
   fixture.relayer = await impersonateAndFund(
-    addresses.mainnet.validatorRegistrator
+    await cCrossChainMasterStrategy.operator()
   );
 
   await setERC20TokenBalance(

--- a/contracts/utils/addresses.js
+++ b/contracts/utils/addresses.js
@@ -8,7 +8,6 @@ addresses.createX = "0xba5Ed099633D3B313e4D5F7bdc1305d3c28ba5Ed";
 addresses.multichainStrategist = "0x4FF1b9D9ba8558F5EAfCec096318eA0d8b541971";
 addresses.multichainBuybackOperator =
   "0xBB077E716A5f1F1B63ed5244eBFf5214E50fec8c";
-addresses.talosRelayer = "0x0aBCDa6Fa7d500cf69B0eA5de9a607Cd9941221C";
 addresses.talosRelayer = "0x739212d5bAfE6AAC8Be49a60B7d003bD41DBf38b"; // new Talos signer
 addresses.votemarket = "0x8c2c5A295450DDFf4CB360cA73FCCC12243D14D9";
 

--- a/contracts/utils/addresses.js
+++ b/contracts/utils/addresses.js
@@ -9,6 +9,7 @@ addresses.multichainStrategist = "0x4FF1b9D9ba8558F5EAfCec096318eA0d8b541971";
 addresses.multichainBuybackOperator =
   "0xBB077E716A5f1F1B63ed5244eBFf5214E50fec8c";
 addresses.talosRelayer = "0x0aBCDa6Fa7d500cf69B0eA5de9a607Cd9941221C";
+addresses.talosRelayer = "0x739212d5bAfE6AAC8Be49a60B7d003bD41DBf38b"; // new Talos signer
 addresses.votemarket = "0x8c2c5A295450DDFf4CB360cA73FCCC12243D14D9";
 
 // CCTP contracts (uses same addresses on all chains)

--- a/contracts/utils/deploy.js
+++ b/contracts/utils/deploy.js
@@ -48,6 +48,8 @@ const {
   getStorageAt,
 } = require("@nomicfoundation/hardhat-network-helpers");
 const { keccak256, defaultAbiCoder } = require("ethers/lib/utils.js");
+const fs = require("fs");
+const path = require("path");
 
 // Wait for 3 blocks confirmation on Mainnet.
 let NUM_CONFIRMATIONS = isMainnet ? 3 : 0;
@@ -993,6 +995,47 @@ async function buildGnosisSafeJson(
   });
 }
 
+// Inlined to avoid a circular import: deploy-l2.js already requires deploy.js,
+// so its getNetworkName() can't be imported here.
+function safeOpsNetworkName() {
+  if (isForkTest) return "hardhat";
+  if (isFork) return "localhost";
+  return process.env.NETWORK_NAME || "mainnet";
+}
+
+function safeValueToString(value) {
+  if (BigNumber.isBigNumber(value)) return value.toString();
+  if (Array.isArray(value)) return JSON.stringify(value.map(safeValueToString));
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  // address / bytes32 / bytes / string pass through unchanged
+  return String(value);
+}
+
+// (contract, signature, args) -> { paramName: stringValue } for the Gnosis Safe
+// Transaction Builder. Param names come from the ABI fragment. Tuple/struct
+// params are unsupported (not used by the Safe migrations) and throw loudly.
+function buildContractInputsValues(contract, signature, args) {
+  const inputs = contract.interface.getFunction(signature).inputs;
+  if (inputs.length !== args.length) {
+    throw new Error(
+      `${signature}: expected ${inputs.length} args, got ${args.length}`
+    );
+  }
+  const out = {};
+  inputs.forEach((input, i) => {
+    if (input.baseType === "tuple" || input.components) {
+      throw new Error(
+        `${signature}: tuple/struct param "${input.name}" is not supported`
+      );
+    }
+    const name = input.name && input.name.length ? input.name : `arg${i}`;
+    out[name] = safeValueToString(args[i]);
+  });
+  return out;
+}
+
 async function getProposalExecutionValue(governor, proposalId) {
   const actions = await governor.getActions(proposalId);
   const rawValues =
@@ -1311,6 +1354,122 @@ function deploymentWithGuardianGovernor(opts, fn) {
   return main;
 }
 
+/**
+ * Shortcut to create a deployment executed by a plain Gnosis Safe (NOT GovernorSix
+ * governance, NOT the Guardian-via-timelock path). The deploy fn returns a single
+ * list of actions ({ contract, signature, args, value }). The helper always builds
+ * the Gnosis Safe Transaction Builder JSON and writes it to
+ * deployments/<network>/operations/<deployName>.json (mainnet -> committed
+ * artifact, fork -> gitignored). On fork it additionally executes the actions by
+ * impersonating the Safe, so fork tests pass and downstream deploys see the state.
+ *
+ * @param {Object} opts deployment options. `safe` is the executing Safe address.
+ * @param {Function} fn async (tools) => { name?, safe?, actions: [...] }
+ * @returns {Function} main object used by hardhat
+ */
+function deploymentWithGnosisSafe(opts, fn) {
+  const { deployName, dependencies, forceDeploy, onlyOnFork, forceSkip } = opts;
+  const optsSafe = opts.safe;
+
+  const runDeployment = async (hre) => {
+    const assetAddresses = await getAssetAddresses(hre.deployments);
+    const proposal = await fn({
+      assetAddresses,
+      deployWithConfirmation,
+      ethers,
+      getTxOpts,
+      withConfirmation,
+    });
+
+    if (!proposal?.actions?.length) {
+      log("No Safe proposal actions.");
+      return;
+    }
+
+    const safeAddress = proposal.safe || optsSafe;
+    if (!safeAddress) {
+      throw new Error(
+        `deploymentWithGnosisSafe (${deployName}): no Safe address. ` +
+          `Set opts.safe or return { safe } from the deploy fn.`
+      );
+    }
+
+    const { actions } = proposal;
+
+    // Build + write the Safe Transaction Builder JSON (every environment).
+    const safeJson = await buildGnosisSafeJson(
+      safeAddress,
+      actions.map((a) => a.contract.address),
+      actions.map((a) => constructContractMethod(a.contract, a.signature)),
+      actions.map((a) =>
+        buildContractInputsValues(a.contract, a.signature, a.args)
+      ),
+      actions.map((a) => BigNumber.from(a.value ?? 0).toString())
+    );
+    const filePath = path.resolve(
+      __dirname,
+      `./../deployments/${safeOpsNetworkName()}/operations/${deployName}.json`
+    );
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify(safeJson, null, 2));
+    console.log(`Safe batch JSON written to ${filePath}`);
+
+    if (isMainnet) {
+      // Mainnet: JSON only. The operator imports it into the Safe Transaction
+      // Builder for the Safe to execute.
+      console.log(
+        `Import ${deployName}.json into the Gnosis Safe (${safeAddress}) Transaction Builder to execute.`
+      );
+      return;
+    }
+
+    // Fork: execute the batch by impersonating the Safe.
+    const safeSigner = await impersonateAndFund(safeAddress);
+    console.log(`Impersonating Safe ${safeAddress} to execute actions on fork`);
+    for (const action of actions) {
+      const { contract, signature, args, value } = action;
+      const txOpts = {
+        ...(await getTxOpts()),
+        ...(value ? { value } : {}),
+      };
+      log(`Sending Safe action ${signature} to ${contract.address}`);
+      await withConfirmation(
+        contract.connect(safeSigner)[signature](...args, txOpts)
+      );
+      console.log(`... ${signature} completed`);
+    }
+  };
+
+  const main = async (hre) => {
+    console.log(`Running ${deployName} deployment...`);
+    if (!hre) {
+      hre = require("hardhat");
+    }
+    await runDeployment(hre);
+    console.log(`${deployName} deploy done.`);
+    return true;
+  };
+
+  main.id = deployName;
+  main.dependencies = dependencies;
+  if (forceSkip) {
+    main.skip = () => true;
+  } else if (forceDeploy) {
+    main.skip = () => false;
+  } else {
+    main.skip = async () => {
+      if (isFork) {
+        const networkName = isForkTest ? "hardhat" : "localhost";
+        const migrations = require(`./../deployments/${networkName}/.migrations.json`);
+        return Boolean(migrations[deployName]);
+      } else {
+        return onlyOnFork ? true : !isMainnet || isSmokeTest;
+      }
+    };
+  }
+  return main;
+}
+
 function encodeSaltForCreateX(deployer, crosschainProtectionFlag, salt) {
   // Generate encoded salt (deployer address || crosschainProtectionFlag || bytes11(keccak256(rewardToken, gauge)))
 
@@ -1471,6 +1630,7 @@ module.exports = {
   executeProposalOnFork,
   deploymentWithGovernanceProposal,
   deploymentWithGuardianGovernor,
+  deploymentWithGnosisSafe,
 
   constructContractMethod,
   buildGnosisSafeJson,

--- a/contracts/utils/deploy.js
+++ b/contracts/utils/deploy.js
@@ -1370,9 +1370,21 @@ function deploymentWithGuardianGovernor(opts, fn) {
 function deploymentWithGnosisSafe(opts, fn) {
   const { deployName, dependencies, forceDeploy, onlyOnFork, forceSkip } = opts;
   const optsSafe = opts.safe;
+  // Target network the Safe lives on; gates the real-deploy run + skip. Defaults
+  // to mainnet so existing mainnet deploys are unaffected.
+  const targetNetwork = opts.network || "mainnet";
 
   const runDeployment = async (hre) => {
-    const assetAddresses = await getAssetAddresses(hre.deployments);
+    // getAssetAddresses is mainnet-centric (resolves mock assets); on L2s it can
+    // throw. Safe-batch deploys don't need it, so tolerate failure.
+    let assetAddresses = {};
+    try {
+      assetAddresses = await getAssetAddresses(hre.deployments);
+    } catch (e) {
+      log(
+        `getAssetAddresses unavailable (${e.message}); continuing without it.`
+      );
+    }
     const proposal = await fn({
       assetAddresses,
       deployWithConfirmation,
@@ -1414,9 +1426,9 @@ function deploymentWithGnosisSafe(opts, fn) {
     fs.writeFileSync(filePath, JSON.stringify(safeJson, null, 2));
     console.log(`Safe batch JSON written to ${filePath}`);
 
-    if (isMainnet) {
-      // Mainnet: JSON only. The operator imports it into the Safe Transaction
-      // Builder for the Safe to execute.
+    if (!isFork) {
+      // Real deploy: JSON only. The operator imports it into the Safe
+      // Transaction Builder for the Safe to execute.
       console.log(
         `Import ${deployName}.json into the Gnosis Safe (${safeAddress}) Transaction Builder to execute.`
       );
@@ -1452,6 +1464,11 @@ function deploymentWithGnosisSafe(opts, fn) {
 
   main.id = deployName;
   main.dependencies = dependencies;
+  // L2 fixtures filter deploys by network tag (deployments.fixture(["base"]));
+  // mainnet's fixture runs all deploys untagged, so only tag for non-mainnet.
+  if (targetNetwork !== "mainnet") {
+    main.tags = [targetNetwork];
+  }
   if (forceSkip) {
     main.skip = () => true;
   } else if (forceDeploy) {
@@ -1463,7 +1480,13 @@ function deploymentWithGnosisSafe(opts, fn) {
         const migrations = require(`./../deployments/${networkName}/.migrations.json`);
         return Boolean(migrations[deployName]);
       } else {
-        return onlyOnFork ? true : !isMainnet || isSmokeTest;
+        const onTarget =
+          targetNetwork === "base"
+            ? isBase
+            : targetNetwork === "sonic"
+            ? isSonic
+            : isMainnet;
+        return onlyOnFork ? true : isSmokeTest || !onTarget;
       }
     };
   }


### PR DESCRIPTION
# Overview
Contains migration files to migrate the signer to `0x739212d5bAfE6AAC8Be49a60B7d003bD41DBf38b` which is the new Talos Relayer. The migration includes
- **196 migration**. Sets the operator on OETH, OUSD Vaults, unpauses rebases and cross chain master strategy. Executed by OGN governance
- **197 migration** sets the operator on XOGNRewardsModule6. Directly executed by the 5/8
- **198 migration** sets the oprator on 4 modules. Directly executed by the 2/8
- **051 migration (Base)**. Sets the operator on the Base CrossChainRemoteStrategy and the OETHBaseVault (`operatorAddr`), and unpauses OETHb rebases. Executed via the Base Timelock (schedule + execute by the 5/8).
- **052 migration (Base)**. Grants `OPERATOR_ROLE` on the Base MerklPoolBoosterBribesModule. Directly executed by the 2/8.
- **053 migration (Base)**. Grants `OPERATOR_ROLE` on `ClaimBribesSafeModule1`. Directly executed by the ClaimBribes 2/8 (`0xb6D85Ce798660076152d6FD3a484129668839c95`).
- **054 migration (Base)**. Grants `OPERATOR_ROLE` on `ClaimBribesSafeModule3`. Directly executed by the base.strategist 1/2 (`0x28bce2eE5775B652D92bB7c2891A89F036619703`).
- **030 migration (Sonic)**. Sets the operator on the OSonicVault (`operatorAddr`), unpauses rebases, and sets the registrator on the SonicStakingStrategy. Executed via the Sonic Timelock (schedule + execute by the 5/8). The Sonic OriginARM operator is migrated separately in the `arm-oeth` repo.
- **003 migration (HyperEVM)**. Sets the operator on the HyperEVM CrossChainRemoteStrategy. Executed via the HyperEVM Timelock (schedule + execute by the 5/8).
- **Supporting changes**. The directly-executed Safe migrations (197, 198, 052–054) share a new `deploymentWithGnosisSafe` helper (`utils/deploy.js`) that writes a Gnosis Safe Transaction Builder JSON and impersonates the Safe on fork; the timelock migrations (051, 030, 003) use `deployOnBase`/`deployOnSonic`/`deployOnHyperEVM` (schedule + execute JSON). Cross-chain fork fixtures now read the operator from the strategy instead of hardcoding the relayer.
-  **Collect XOGN Rewards Module** (below) — each of the 5 external 3/5 Safes manually executes a **grant + revoke** on its module

**Collect XOGN Rewards Module:**
Grants `OPERATOR_ROLE` on `CollectXOGNRewardsModule1`–`5` to the new Talos signer (so it can call `collectRewards` / `ogn_claimAndForwardRewards`), and **revokes** it from the old relayer `0x4b91827516f79d6F6a1F292eD99671663b09169a` — `grantRole` is additive, so the old operator must be explicitly removed.

Each module is admined by its **own** external 3/5 XOGN Safe, so this is **5 separate Safe submissions**; each Safe executes **two calls on its module** (grant then revoke), ideally as a single Transaction Builder batch.

### Shared calls (identical across all 5 modules — only the executing Safe + target `to` module differ)

`role` = OPERATOR_ROLE = `0x97667070c54ef182b0f5858b034beac1b6f3089aa2d3188bb1e8929f4fa9b929`; ETH value `0`; both sent **to the module**.

| Call | Function | `account` | Raw calldata (`data`) |
|---|---|---|---|
| 1. grant | `grantRole(bytes32,address)` | new Talos `0x739212d5bAfE6AAC8Be49a60B7d003bD41DBf38b` | `0x2f2ff15d97667070c54ef182b0f5858b034beac1b6f3089aa2d3188bb1e8929f4fa9b929000000000000000000000000739212d5bafe6aac8be49a60b7d003bd41dbf38b` |
| 2. revoke | `revokeRole(bytes32,address)` | old relayer `0x4b91827516f79d6F6a1F292eD99671663b09169a` | `0xd547741f97667070c54ef182b0f5858b034beac1b6f3089aa2d3188bb1e8929f4fa9b9290000000000000000000000004b91827516f79d6f6a1f292ed99671663b09169a` |

  ### The 5 transactions

  | # | Execute from Safe (3/5) | To — target `CollectXOGNRewardsModuleN` |
  |---|---|---|
  | 1 | `eth:0x5c8228e709D7F91209DE898F6a7B8c6035A7B78f` | `0x15228dAE3B228175fBD9639d049265eFb08e60b6` |
  | 2 | `eth:0x69497A2A170c138876F05Df01bFfDd5C4b651CF2` | `0x8e32A930CcFE108DC560eC9e630BA6b5f7E179c9` |
  | 3 | `eth:0x684b38997afbBBC055e0BEB6d536686Ebd171bdB` | `0x460e4a0B14bD3F1e12f0c2194830c0204E5Bb147` |
  | 4 | `eth:0xe555EFA16d38747F9e496926b576FD1ebD31DeCa` | `0xFbBb82c4F3B6f479DE1451C04A76ea80da4ff010` |
  | 5 | `eth:0x6E75645EeDCCCAA0f472323Afce8f82B875C8CB9` | `0xAE67b612bD859378b7d0f6314E7Ee39ad4c6aBE6` |
  | 7 | `base:0x28bce2eE5775B652D92bB7c2891A89F036619703` | `0x26179ada0f7cb714c11a8190e1f517988c28e759` |

