### PR TITLE
Fixed withdrawSsvClusterEth to ignore consensus rewards in NativeStakingSSVStrategy

### DIFF
--- a/contracts/contracts/strategies/NativeStaking/NativeStakingSSVStrategy.sol
+++ b/contracts/contracts/strategies/NativeStaking/NativeStakingSSVStrategy.sol
@@ -133,13 +133,15 @@ contract NativeStakingSSVStrategy is
         uint256 amount,
         Cluster calldata cluster
     ) external onlyGovernor nonReentrant {
+        uint256 ethBalanceBefore = address(this).balance;
+
         ISSVNetwork(SSV_NETWORK).withdraw(operatorIds, amount, cluster);
 
-        uint256 ethBalance = address(this).balance;
-        if (ethBalance > 0) {
-            IWETH9(WETH).deposit{ value: ethBalance }();
-            IERC20(WETH).safeTransfer(vaultAddress, ethBalance);
-            emit Withdrawal(WETH, address(0), ethBalance);
+        uint256 withdrawn = address(this).balance - ethBalanceBefore;
+        if (withdrawn > 0) {
+            IWETH9(WETH).deposit{ value: withdrawn }();
+            IERC20(WETH).safeTransfer(vaultAddress, withdrawn);
+            emit Withdrawal(WETH, address(0), withdrawn);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes `NativeStakingSSVStrategy.withdrawSsvClusterEth` so it only wraps and transfers ETH received from the SSV cluster withdrawal call.

Previously, the function swept the strategy’s entire ETH balance after calling `ISSVNetwork.withdraw`. On the legacy native staking strategy, that balance can include already-accounted `consensusRewards` or unaccounted beacon withdrawal ETH. Sweeping the full balance could leave accounting inconsistent and cause later `doAccounting()` calls to fail.

The fix snapshots the strategy ETH balance before the SSV withdrawal and only transfers the post-call delta to the vault.

## Code Change Checklist

To be completed before internal review begins:

- [ ]  The contract code is complete
- [ ]  Executable deployment file
- [ ]  Fork tests that test after the deployment file runs
- [ ]  Unit tests *if needed
- [ ]  The owner has done a [full checklist review](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) of the code + tests

Internal review:

- [ ] Two approvals by internal reviewers


## Deploy checklist

Two reviewers complete the following checklist:

```
- [ ] All deployed contracts are listed in the deploy PR's description
- [ ] Deployed contract's verified code (and all dependencies) match the code in master
- [ ] Contract constructors have correct arguments
- [ ] The transactions that interacted with the newly deployed contract match the deploy script.
- [ ] Governance proposal matches the deploy script
- [ ] Smoke tests pass after fork test execution of the governance proposal
```

