### PR TITLE
Bump @talos/client to e0c53b2f06b8

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -145,7 +145,7 @@
     "@lodestar/state-transition": "^1.41.0",
     "@lodestar/types": "^1.41.0",
     "@lodestar/utils": "^1.41.0",
-    "@talos/client": "github:oplabs/talos#0a6ecc9c273561dfad4dbe69c3708f3521a1670b&path:packages/client",
+    "@talos/client": "github:oplabs/talos#e0c53b2f06b8aa627640a7cb3631140dcae14f41&path:packages/client",
     "@types/pg": "^8.20.0",
     "origin-morpho-utils": "^0.1.1",
     "pg": "^8.20.0"

--- a/contracts/pnpm-lock.yaml
+++ b/contracts/pnpm-lock.yaml
@@ -38,8 +38,8 @@ importers:
         specifier: ^1.41.0
         version: 1.41.0
       '@talos/client':
-        specifier: github:oplabs/talos#0a6ecc9c273561dfad4dbe69c3708f3521a1670b&path:packages/client
-        version: git+https://git@github.com:oplabs/talos.git#0a6ecc9c273561dfad4dbe69c3708f3521a1670b&path:packages/client(@types/pg@8.20.0)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+        specifier: github:oplabs/talos#e0c53b2f06b8aa627640a7cb3631140dcae14f41&path:packages/client
+        version: git+https://git@github.com:oplabs/talos.git#e0c53b2f06b8aa627640a7cb3631140dcae14f41&path:packages/client(@types/pg@8.20.0)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
@@ -2294,9 +2294,9 @@ packages:
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
 
-  '@talos/client@git+https://git@github.com:oplabs/talos.git#0a6ecc9c273561dfad4dbe69c3708f3521a1670b&path:packages/client':
-    resolution: {commit: 0a6ecc9c273561dfad4dbe69c3708f3521a1670b, path: packages/client, repo: git@github.com:oplabs/talos.git, type: git}
-    version: 0.0.21
+  '@talos/client@git+https://git@github.com:oplabs/talos.git#e0c53b2f06b8aa627640a7cb3631140dcae14f41&path:packages/client':
+    resolution: {commit: e0c53b2f06b8aa627640a7cb3631140dcae14f41, path: packages/client, repo: git@github.com:oplabs/talos.git, type: git}
+    version: 0.0.23
 
   '@trufflesuite/bigint-buffer@1.1.9':
     resolution: {integrity: sha512-bdM5cEGCOhDSwminryHJbRmXc1x7dPKg6Pqns3qyTwFlxsqUgxE29lsERS3PlIW1HTjoIGMUqsk1zQQwST1Yxw==}
@@ -10476,7 +10476,7 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@talos/client@git+https://git@github.com:oplabs/talos.git#0a6ecc9c273561dfad4dbe69c3708f3521a1670b&path:packages/client(@types/pg@8.20.0)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@talos/client@git+https://git@github.com:oplabs/talos.git#e0c53b2f06b8aa627640a7cb3631140dcae14f41&path:packages/client(@types/pg@8.20.0)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.14)
       croner: 10.0.1


### PR DESCRIPTION
The runtime didn't get bumped to the proper Talos client version so the attempted fix by Clement the other day is not live yet.