### PR TITLE
Bump @talos/client to db24b13f33be

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -145,7 +145,7 @@
     "@lodestar/state-transition": "^1.41.0",
     "@lodestar/types": "^1.41.0",
     "@lodestar/utils": "^1.41.0",
-    "@talos/client": "github:oplabs/talos#e0c53b2f06b8aa627640a7cb3631140dcae14f41&path:packages/client",
+    "@talos/client": "github:oplabs/talos#db24b13f33beb1d25443a6064991335bffe53dbc&path:packages/client",
     "@types/pg": "^8.20.0",
     "origin-morpho-utils": "^0.1.1",
     "pg": "^8.20.0"

--- a/contracts/pnpm-lock.yaml
+++ b/contracts/pnpm-lock.yaml
@@ -38,8 +38,8 @@ importers:
         specifier: ^1.41.0
         version: 1.41.0
       '@talos/client':
-        specifier: github:oplabs/talos#e0c53b2f06b8aa627640a7cb3631140dcae14f41&path:packages/client
-        version: git+https://git@github.com:oplabs/talos.git#e0c53b2f06b8aa627640a7cb3631140dcae14f41&path:packages/client(@types/pg@8.20.0)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+        specifier: github:oplabs/talos#db24b13f33beb1d25443a6064991335bffe53dbc&path:packages/client
+        version: git+https://git@github.com:oplabs/talos.git#db24b13f33beb1d25443a6064991335bffe53dbc&path:packages/client(@types/pg@8.20.0)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
@@ -2294,8 +2294,8 @@ packages:
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
 
-  '@talos/client@git+https://git@github.com:oplabs/talos.git#e0c53b2f06b8aa627640a7cb3631140dcae14f41&path:packages/client':
-    resolution: {commit: e0c53b2f06b8aa627640a7cb3631140dcae14f41, path: packages/client, repo: git@github.com:oplabs/talos.git, type: git}
+  '@talos/client@git+https://git@github.com:oplabs/talos.git#db24b13f33beb1d25443a6064991335bffe53dbc&path:packages/client':
+    resolution: {commit: db24b13f33beb1d25443a6064991335bffe53dbc, path: packages/client, repo: git@github.com:oplabs/talos.git, type: git}
     version: 0.0.23
 
   '@trufflesuite/bigint-buffer@1.1.9':
@@ -10476,7 +10476,7 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@talos/client@git+https://git@github.com:oplabs/talos.git#e0c53b2f06b8aa627640a7cb3631140dcae14f41&path:packages/client(@types/pg@8.20.0)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@talos/client@git+https://git@github.com:oplabs/talos.git#db24b13f33beb1d25443a6064991335bffe53dbc&path:packages/client(@types/pg@8.20.0)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.14)
       croner: 10.0.1


### PR DESCRIPTION
Bumps the `@talos/client` pin for the origin-dollar runner from talos `e0c53b2f06b8` (2026-06-22) to talos `db24b13f33be` (current `oplabs/talos@main` HEAD).

This pulls in the one client commit that landed since the previous pin:
- talos `9819242` — *api-keys: admin-managed scoped API keys; gate `/api/health` on `health:read` (replaces `HEALTH_API_TOKEN`)*

Prod admin already runs `9819242`; this aligns the origin-dollar runner's bundled client with it (no admin/runner skew on the health/auth surface).

Lockfile: only the `@talos/client` resolution SHA changes — version stays `0.0.23`, transitive deps unchanged, `git@github.com:` SSH form preserved (deploy-key flow / security/M-005).

Merging advances `master`, so CI builds a fresh runner image; the talos release is proposed + signed afterward.