### PR TITLE
Add OUSD rebalancer to Talos schedules (manual, disabled)

### DIFF
--- a/contracts/migrations/seed_schedules.sql
+++ b/contracts/migrations/seed_schedules.sql
@@ -54,6 +54,7 @@ INSERT INTO schedules (product, name, command, cron_expr, timezone, enabled, not
 ('origin-dollar', 'module_rebase_mainnet',                    'cd /app && pnpm hardhat permissionedRebase --network mainnet',           '15 10,22 * * *',        'UTC', false, NULL),
 ('origin-dollar', 'module_rebase_base',                       'cd /app && pnpm hardhat permissionedRebase --network base',              '15 10,22 * * *',        'UTC', false, NULL),
 ('origin-dollar', 'module_rebase_sonic',                      'cd /app && pnpm hardhat permissionedRebase --network sonic',             '15 10,22 * * *',        'UTC', false, NULL),
+('origin-dollar', 'ousd_rebalancer',                          'cd /app && pnpm hardhat ousdRebalancer --network mainnet',               '0 0 1 1 *',             'UTC', false, 'Manual: Run now to rebalance OUSD Morpho strategies'),
 ('origin-dollar', 'queue_proposal',                           'cd /app && pnpm hardhat queueGovernorSixProposal --network mainnet',     '0 0 1 1 *',             'UTC', false, 'Manual: add --propid then Run now'),
 ('origin-dollar', 'execute_proposal',                         'cd /app && pnpm hardhat executeGovernorSixProposal --network mainnet',   '0 0 1 1 *',             'UTC', false, 'Manual: add --propid then Run now')
 ON CONFLICT (product, name) DO NOTHING;


### PR DESCRIPTION
## Summary

Adds an `ousd_rebalancer` row to `contracts/migrations/seed_schedules.sql` so the **OUSD Rebalancer** action appears in the Talos admin UI and can be triggered manually via **Run now**.

### Why

The hardhat task `ousdRebalancer` (`tasks/actions/ousdRebalancer.ts`) is already registered, so it shows up in the actions catalog (`dump-actions-catalog.cjs` → `GET /actions/:task/params`). But the catalog only advertises a task's *editable flags* — it does not make the action listed or runnable. The runner can only dispatch a run by `scheduleId` (`POST /runs/:scheduleId`, `@talos/client` `http.ts`), and the ad-hoc arbitrary-command endpoint was removed. So without a `schedules` row, the rebalancer was neither visible nor executable from the UI.

### What

One row added, seeded with:
- `enabled = false` and the placeholder cron `0 0 1 1 *` — same convention as the other manual-only rows (`stake_validator`, `remove_validator`, `queue_proposal`, `execute_proposal`). It therefore **never fires on a schedule**; it only runs on an operator-initiated **Run now**.
- command `cd /app && pnpm hardhat ousdRebalancer --network mainnet` (broadcasts, since the task's `dryrun` defaults to `false`).

```sql
('origin-dollar', 'ousd_rebalancer', 'cd /app && pnpm hardhat ousdRebalancer --network mainnet', '0 0 1 1 *', 'UTC', false, 'Manual: Run now to rebalance OUSD Morpho strategies'),
```

The seed uses `INSERT ... ON CONFLICT (product, name) DO NOTHING`, so it is idempotent and safe to re-apply on every runner boot.

### Notes
- To later put it on an automatic cadence, flip `enabled` to `true` in the Talos admin UI (or update the cron here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)