### PR TITLE
Clean up beacon state cache after each beacon action

### DIFF
--- a/contracts/tasks/actions/verifyBalances.ts
+++ b/contracts/tasks/actions/verifyBalances.ts
@@ -4,6 +4,7 @@ import { types } from "hardhat/config";
 import { action } from "../lib/action";
 
 const { verifyBalances } = require("../beacon");
+const { cleanStateCache } = require("../../utils/beacon");
 
 action({
   name: "verifyBalances",
@@ -60,6 +61,10 @@ action({
     );
   },
   run: async ({ signer, args }) => {
-    await verifyBalances({ ...args, signer });
+    try {
+      await verifyBalances({ ...args, signer });
+    } finally {
+      cleanStateCache();
+    }
   },
 });

--- a/contracts/tasks/actions/verifyBalances.ts
+++ b/contracts/tasks/actions/verifyBalances.ts
@@ -61,10 +61,7 @@ action({
     );
   },
   run: async ({ signer, args }) => {
-    try {
-      await verifyBalances({ ...args, signer });
-    } finally {
-      cleanStateCache();
-    }
+    await verifyBalances({ ...args, signer });
+    cleanStateCache();
   },
 });

--- a/contracts/tasks/actions/verifyDeposits.ts
+++ b/contracts/tasks/actions/verifyDeposits.ts
@@ -25,10 +25,7 @@ action({
     );
   },
   run: async ({ signer, args }) => {
-    try {
-      await verifyDeposits({ ...args, signer });
-    } finally {
-      cleanStateCache();
-    }
+    await verifyDeposits({ ...args, signer });
+    cleanStateCache();
   },
 });

--- a/contracts/tasks/actions/verifyDeposits.ts
+++ b/contracts/tasks/actions/verifyDeposits.ts
@@ -4,6 +4,7 @@ import { types } from "hardhat/config";
 import { action } from "../lib/action";
 
 const { verifyDeposits } = require("../beacon");
+const { cleanStateCache } = require("../../utils/beacon");
 
 action({
   name: "verifyDeposits",
@@ -24,6 +25,10 @@ action({
     );
   },
   run: async ({ signer, args }) => {
-    await verifyDeposits({ ...args, signer });
+    try {
+      await verifyDeposits({ ...args, signer });
+    } finally {
+      cleanStateCache();
+    }
   },
 });

--- a/contracts/utils/beacon.js
+++ b/contracts/utils/beacon.js
@@ -11,25 +11,42 @@ const {
 const log = require("./logger")("utils:beacon");
 
 const SLOTS_PER_EPOCH = 32;
+const BEACON_STATE_CACHE_DIR = "./cache";
+const BEACON_STATE_CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 // Beacon state SSZ files are large and each run fetches a unique slot, so a
 // long-lived runner accumulates them in ./cache until the disk fills (ENOSPC).
-// Track the states this process wrote and delete them once the action finishes
-// (cleanStateCache runs from the action wrapper's finally). Only files this
-// invocation created are removed, so a state a concurrently-running action
-// wrote is never touched.
-const createdStateFiles = new Set();
+// After successful beacon actions, prune old beacon state files while leaving
+// recent files available for retries and avoiding unrelated Hardhat cache data.
+const cleanStateCache = (now = Date.now()) => {
+  if (!fs.existsSync(BEACON_STATE_CACHE_DIR)) {
+    return;
+  }
 
-const cleanStateCache = () => {
-  for (const file of createdStateFiles) {
+  for (const entry of fs.readdirSync(BEACON_STATE_CACHE_DIR, {
+    withFileTypes: true,
+  })) {
+    if (
+      !entry.isFile() ||
+      !entry.name.startsWith("state_") ||
+      !entry.name.endsWith(".ssz")
+    ) {
+      continue;
+    }
+
+    const file = `${BEACON_STATE_CACHE_DIR}/${entry.name}`;
     try {
+      const stats = fs.statSync(file);
+      if (now - stats.mtimeMs <= BEACON_STATE_CACHE_MAX_AGE_MS) {
+        continue;
+      }
+
       fs.rmSync(file, { force: true });
-      log(`Removed cached beacon state ${file}`);
+      log(`Removed cached beacon state older than 1 day ${file}`);
     } catch {
       // Best-effort cleanup; a missing file is fine.
     }
   }
-  createdStateFiles.clear();
 };
 
 const normalizeValidatorResponse = ({ index, balance, status, validator }) => ({
@@ -150,7 +167,6 @@ const getBeaconBlock = async (slot = "head", networkName = "mainnet") => {
     log(`Writing state to file ${stateFilename}`);
     fs.writeFileSync(stateFilename, stateRes.ssz());
     stateSsz = stateRes.ssz();
-    createdStateFiles.add(stateFilename);
   }
 
   const stateView = BeaconState.deserializeToView(stateSsz);

--- a/contracts/utils/beacon.js
+++ b/contracts/utils/beacon.js
@@ -12,6 +12,26 @@ const log = require("./logger")("utils:beacon");
 
 const SLOTS_PER_EPOCH = 32;
 
+// Beacon state SSZ files are large and each run fetches a unique slot, so a
+// long-lived runner accumulates them in ./cache until the disk fills (ENOSPC).
+// Track the states this process wrote and delete them once the action finishes
+// (cleanStateCache runs from the action wrapper's finally). Only files this
+// invocation created are removed, so a state a concurrently-running action
+// wrote is never touched.
+const createdStateFiles = new Set();
+
+const cleanStateCache = () => {
+  for (const file of createdStateFiles) {
+    try {
+      fs.rmSync(file, { force: true });
+      log(`Removed cached beacon state ${file}`);
+    } catch {
+      // Best-effort cleanup; a missing file is fine.
+    }
+  }
+  createdStateFiles.clear();
+};
+
 const normalizeValidatorResponse = ({ index, balance, status, validator }) => ({
   index: Number(index),
   validatorindex: Number(index),
@@ -130,6 +150,7 @@ const getBeaconBlock = async (slot = "head", networkName = "mainnet") => {
     log(`Writing state to file ${stateFilename}`);
     fs.writeFileSync(stateFilename, stateRes.ssz());
     stateSsz = stateRes.ssz();
+    createdStateFiles.add(stateFilename);
   }
 
   const stateView = BeaconState.deserializeToView(stateSsz);
@@ -456,6 +477,7 @@ const verifyDepositSignatureAndMessageRoot = async ({
 };
 
 module.exports = {
+  cleanStateCache,
   concatProof,
   getBeaconBlock,
   getSlot,


### PR DESCRIPTION
## Description

Cleans up cached beacon state files downloaded by the Talos beacon verification actions.

Beacon state SSZ files are large, and each verification run can fetch a unique slot into `contracts/cache/state_*.ssz`. On long-lived Talos runners, these files can accumulate until the runner runs out of disk space.

This PR updates the beacon verification actions to prune old cached beacon state files after a successful action run.

## Changes

- Runs beacon state cache cleanup after successful `verifyBalances` and `verifyDeposits` actions.
- Deletes only `./cache/state_*.ssz` files older than 1 day.
- Leaves newer beacon state files in place for retries/debugging.
- Avoids touching unrelated Hardhat cache files.

## Verification

- Ran `pnpm prettier:js`
- Ran `pnpm prettier:ts`
- Ran `pnpm lint:ts`
- Ran `pnpm exec eslint utils/beacon.js`
- Added a focused local cleanup check confirming:
  - old beacon state files are deleted
  - fresh beacon state files are kept
  - unrelated cache files are kept