### PR TITLE
Bump @talos/client to 8f15dbbdc96a

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -145,7 +145,7 @@
     "@lodestar/state-transition": "^1.41.0",
     "@lodestar/types": "^1.41.0",
     "@lodestar/utils": "^1.41.0",
-    "@talos/client": "github:oplabs/talos#db24b13f33beb1d25443a6064991335bffe53dbc&path:packages/client",
+    "@talos/client": "github:oplabs/talos#8f15dbbdc96a4d3cabf932d41e016779c0946266&path:packages/client",
     "@types/pg": "^8.20.0",
     "origin-morpho-utils": "^0.1.1",
     "pg": "^8.20.0"

--- a/contracts/pnpm-lock.yaml
+++ b/contracts/pnpm-lock.yaml
@@ -38,8 +38,8 @@ importers:
         specifier: ^1.41.0
         version: 1.41.0
       '@talos/client':
-        specifier: github:oplabs/talos#db24b13f33beb1d25443a6064991335bffe53dbc&path:packages/client
-        version: git+https://git@github.com:oplabs/talos.git#db24b13f33beb1d25443a6064991335bffe53dbc&path:packages/client(@types/pg@8.20.0)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+        specifier: github:oplabs/talos#8f15dbbdc96a4d3cabf932d41e016779c0946266&path:packages/client
+        version: git+https://git@github.com:oplabs/talos.git#8f15dbbdc96a4d3cabf932d41e016779c0946266&path:packages/client(@types/pg@8.20.0)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
@@ -2294,9 +2294,9 @@ packages:
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
 
-  '@talos/client@git+https://git@github.com:oplabs/talos.git#db24b13f33beb1d25443a6064991335bffe53dbc&path:packages/client':
-    resolution: {commit: db24b13f33beb1d25443a6064991335bffe53dbc, path: packages/client, repo: git@github.com:oplabs/talos.git, type: git}
-    version: 0.0.23
+  '@talos/client@git+https://git@github.com:oplabs/talos.git#8f15dbbdc96a4d3cabf932d41e016779c0946266&path:packages/client':
+    resolution: {commit: 8f15dbbdc96a4d3cabf932d41e016779c0946266, path: packages/client, repo: git@github.com:oplabs/talos.git, type: git}
+    version: 0.0.25
 
   '@trufflesuite/bigint-buffer@1.1.9':
     resolution: {integrity: sha512-bdM5cEGCOhDSwminryHJbRmXc1x7dPKg6Pqns3qyTwFlxsqUgxE29lsERS3PlIW1HTjoIGMUqsk1zQQwST1Yxw==}
@@ -10476,7 +10476,7 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@talos/client@git+https://git@github.com:oplabs/talos.git#db24b13f33beb1d25443a6064991335bffe53dbc&path:packages/client(@types/pg@8.20.0)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@talos/client@git+https://git@github.com:oplabs/talos.git#8f15dbbdc96a4d3cabf932d41e016779c0946266&path:packages/client(@types/pg@8.20.0)(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.14)
       croner: 10.0.1


### PR DESCRIPTION
Pins `@talos/client` to talos `main` @ `8f15dbbdc96a` (0.0.21 → 0.0.25).

Picks up the nonce-queue read-after-mine fix (talos #11): the ethers v5/v6 send now re-fetches the mined tx response outside the nonce lock with a bounded retry, instead of failing an already-confirmed run on a transient provider miss. Directly addresses the intermittent `cross_chain_balance_update_base` failures.

Lockfile diff is limited to the `@talos/client` git resolution (SSH form preserved). Merging advances `master`, triggering a fresh runner image build.