### PR TITLE
fix: stop the schedule seed overwriting operator edits

### DIFF
--- a/contracts/migrations/seed_schedules.sql
+++ b/contracts/migrations/seed_schedules.sql
@@ -57,4 +57,4 @@ INSERT INTO schedules (product, name, command, cron_expr, timezone, enabled, not
 ('origin-dollar', 'ousd_rebalancer',                          'cd /app && pnpm exec tsx tasks/run.ts ousdRebalancer --network mainnet',               '0 0 1 1 *',             'UTC', false, 'Manual: Run now to rebalance OUSD Morpho strategies'),
 ('origin-dollar', 'queue_proposal',                           'cd /app && pnpm exec tsx tasks/run.ts queueGovernorSixProposal --network mainnet',     '0 0 1 1 *',             'UTC', false, 'Manual: add --propid then Run now'),
 ('origin-dollar', 'execute_proposal',                         'cd /app && pnpm exec tsx tasks/run.ts executeGovernorSixProposal --network mainnet',   '0 0 1 1 *',             'UTC', false, 'Manual: add --propid then Run now')
-ON CONFLICT (product, name) DO UPDATE SET command = EXCLUDED.command;
+ON CONFLICT (product, name) DO NOTHING;

--- a/contracts/runner.ts
+++ b/contracts/runner.ts
@@ -1,32 +1,16 @@
 import { existsSync, readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
 
-import {
-  type ActionsCatalog,
-  createPool,
-  runContainer,
-} from "@oplabs/talos-client";
+import { type ActionsCatalog, runContainer } from "@oplabs/talos-client";
 
 const databaseUrl = process.env.DATABASE_URL;
 if (!databaseUrl) {
   throw new Error("DATABASE_URL env var required");
 }
 
-// Apply contracts/migrations/seed_schedules.sql before the runner boots so
-// any new schedule rows in that file land in the shared Talos Postgres on
-// container start. The file uses INSERT ... ON CONFLICT DO NOTHING, so it
-// is safe to re-run on every restart and only adds previously-unseen rows.
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const seedSqlPath = resolve(__dirname, "migrations/seed_schedules.sql");
-const seedSql = readFileSync(seedSqlPath, "utf8");
-const pool = createPool({ connectionString: databaseUrl });
-try {
-  await pool.query(seedSql);
-  console.log(`[runner] applied ${seedSqlPath}`);
-} finally {
-  await pool.end();
-}
+// Seeds are applied by runContainer (@oplabs/talos-client applySeedFiles),
+// which reads every <workdir>/migrations/seed_*.sql before starting the
+// scheduler. Applying them here too was redundant, and bypassed the
+// client-side validation of seed contents.
 
 // The catalog is dumped at image build time by docker/dump-actions-catalog.cjs
 // (Node, where hardhat works). Reading it here keeps the runner's bun parent


### PR DESCRIPTION
- Remove the issue where any deploy of the runner would overwrite the prod db user edited commands
- don't apply the seed.sql twice. The runner already does it. 

Should be deployed along: https://github.com/oplabs/talos/pull/23