### PR TITLE
Fix getStandaloneSigner is not defined

### DIFF
--- a/contracts/utils/signers.js
+++ b/contracts/utils/signers.js
@@ -1,43 +1,18 @@
 const { parseEther } = require("ethers/lib/utils");
-const hhHelpers = require("@nomicfoundation/hardhat-network-helpers");
-const {
-  getKmsAddress,
-  getKmsSigner,
-  hasAwsKmsCredentials,
-} = require("./signersNoHardhat");
-const { ethereumAddress, privateKey } = require("./regex");
+const { getKmsSigner } = require("./signersNoHardhat");
+const { ethereumAddress } = require("./regex");
 
 const log = require("./logger")("utils:signers");
 
-// @oplabs/talos-client ships only in the Talos runner image, not in a plain
-// contracts checkout (it's an optional dependency). Load it lazily so hardhat —
-// which pulls this module in through tasks/tasks.js — boots without it. The
-// require only fires once DATABASE_URL opts into the nonce queue.
-let talosClient = null;
-function talosClientLib() {
-  if (!talosClient) talosClient = require("@oplabs/talos-client");
-  return talosClient;
+// These modules are TypeScript and belong to the standalone Talos runtime.
+// Resolve them lazily so importing this legacy CommonJS helper still works in
+// Hardhat environments where the optional Talos dependencies are not installed.
+function getProvider() {
+  return require("../tasks/lib/network").getProvider();
 }
 
-let dbInstance = null;
-function getNonceDb() {
-  if (!process.env.DATABASE_URL) return null;
-  if (!dbInstance) {
-    const { createPool, createDb } = talosClientLib();
-    const pool = createPool({ connectionString: process.env.DATABASE_URL });
-    dbInstance = createDb(pool);
-  }
-  return dbInstance;
-}
-
-// Wrap a raw signer with the nonce-queue Proxy when DATABASE_URL is set.
-// Returning the raw signer unchanged in dev / fork flows preserves the
-// DATABASE_URL gate invariant: no queue engagement without explicit opt-in.
-function maybeWrap(rawSigner) {
-  const db = getNonceDb();
-  if (!db) return rawSigner;
-  const { wrapSignerWithNonceQueueV5 } = talosClientLib();
-  return wrapSignerWithNonceQueueV5(rawSigner, { db });
+async function getStandaloneSigner() {
+  return await require("../tasks/lib/signer").getSigner();
 }
 
 /**


### PR DESCRIPTION
## Summary

Fix Talos actions failing with:

```text
ReferenceError: getStandaloneSigner is not defined
```

The Hardhat-to-standalone migration updated `utils/signers.js` to call the new Talos signer and network utilities but omitted the required bridge functions. This affected `otokenOethbUpdateWoethPrice` and other actions using the shared `getSigner()` helper.

## Changes

- Lazily resolve the standalone signer from `tasks/lib/signer.ts`.
- Lazily resolve the provider from `tasks/lib/network.ts`.
- Preserve compatibility when optional Talos dependencies are unavailable.
- Remove stale signer and nonce-queue code superseded by the standalone signer implementation.

## Verification

- Ran Prettier.
- Ran targeted ESLint.
- Verified `utils/signers.js` loads without optional Talos dependencies.
- Ran `git diff --check`.

Full TypeScript checking remains blocked by unrelated existing export errors and the locally absent optional `@oplabs/talos-client` dependency.

