### PR TITLE
Fix snap Hardhat tasks

### DIFF
--- a/contracts/tasks/lib/contracts.ts
+++ b/contracts/tasks/lib/contracts.ts
@@ -58,7 +58,10 @@ function readDeployment(
 // Resolve an ABI by contract/interface name: curated abi/<name>.json first
 // (interfaces like IVault), then the deployment artifact's abi.
 function readAbiByName(chainId: number, name: string): unknown[] {
-  const curated = join(CONTRACTS_ROOT, "abi", `${name}.json`);
+  // IERC20Metadata is a strict superset of IERC20 and is the curated ERC-20
+  // interface shipped with the standalone actions image.
+  const curatedName = name === "IERC20" ? "IERC20Metadata" : name;
+  const curated = join(CONTRACTS_ROOT, "abi", `${curatedName}.json`);
   if (existsSync(curated)) return JSON.parse(readFileSync(curated, "utf8"));
   const dep = join(
     CONTRACTS_ROOT,

--- a/contracts/tasks/lib/network.ts
+++ b/contracts/tasks/lib/network.ts
@@ -1,5 +1,4 @@
 import { ethers } from "ethers";
-import { resolveChain, getRpcEnvVar } from "@oplabs/talos-client";
 
 /**
  * Ambient network context for the standalone (hardhat-free) action runtime.
@@ -19,36 +18,71 @@ export const CHAIN_NAMES: Record<number, string> = {
   98866: "plume",
 };
 
+const CHAIN_IDS: Record<string, number> = Object.fromEntries(
+  Object.entries(CHAIN_NAMES).map(([id, name]) => [name, Number(id)])
+);
+
+const RPC_ENV_VARS: Record<number, string> = {
+  1: "MAINNET_PROVIDER_URL",
+  8453: "BASE_PROVIDER_URL",
+  146: "SONIC_PROVIDER_URL",
+  560048: "HOODI_PROVIDER_URL",
+  999: "HYPEREVM_PROVIDER_URL",
+  17000: "HOLESKY_PROVIDER_URL",
+  42161: "ARBITRUM_PROVIDER_URL",
+  98866: "PLUME_PROVIDER_URL",
+};
+
 let _chainId: number | undefined;
 let _networkName: string | undefined;
 let _provider: ethers.providers.JsonRpcProvider | undefined;
 let _signer: ethers.Signer | undefined;
 
+type HardhatGlobal = {
+  hre?: {
+    ethers?: { provider?: ethers.providers.JsonRpcProvider };
+    network?: { name?: string; config?: { chainId?: number } };
+  };
+};
+
+function hardhatRuntime() {
+  return (globalThis as typeof globalThis & HardhatGlobal).hre;
+}
+
 /** Resolve the RPC URL for a chain: LOCAL_PROVIDER_URL on a fork, else the
- *  `*_PROVIDER_URL` env var (via Talos getRpcEnvVar, matching the repo's names). */
+ *  matching `*_PROVIDER_URL` env var. */
 export function rpcUrlFor(nameOrId: string | number): {
   chainId: number;
   networkName: string;
   url: string;
 } {
-  const chain = resolveChain(nameOrId);
+  const chainId =
+    typeof nameOrId === "number"
+      ? nameOrId
+      : /^\d+$/.test(nameOrId)
+      ? Number(nameOrId)
+      : CHAIN_IDS[nameOrId.toLowerCase()];
+  const networkName = CHAIN_NAMES[chainId];
+  if (!networkName) {
+    throw new Error(`Unsupported chain: ${nameOrId}`);
+  }
   let url: string | undefined;
   if (process.env.FORK === "true" && process.env.LOCAL_PROVIDER_URL) {
     url = process.env.LOCAL_PROVIDER_URL;
   } else {
-    const envVar = getRpcEnvVar(chain);
+    const envVar = RPC_ENV_VARS[chainId];
     url = process.env[envVar];
     // Back-compat: mainnet historically used the bare PROVIDER_URL.
-    if (!url && chain.id === 1) url = process.env.PROVIDER_URL;
+    if (!url && chainId === 1) url = process.env.PROVIDER_URL;
     if (!url) {
       throw new Error(
-        `Missing RPC URL env var ${envVar} for chain ${chain.name} (${chain.id})`
+        `Missing RPC URL env var ${envVar} for chain ${networkName} (${chainId})`
       );
     }
   }
   return {
-    chainId: chain.id,
-    networkName: CHAIN_NAMES[chain.id] ?? chain.name,
+    chainId,
+    networkName,
     url,
   };
 }
@@ -69,19 +103,28 @@ export function initNetwork(nameOrId: string | number): {
 }
 
 export function getProvider(): ethers.providers.JsonRpcProvider {
-  if (!_provider)
+  const provider = _provider ?? hardhatRuntime()?.ethers?.provider;
+  if (!provider)
     throw new Error("Network not initialized — call initNetwork() first");
-  return _provider;
+  return provider;
 }
 
 export function getChainId(): number {
-  if (_chainId == null) throw new Error("Network not initialized");
-  return _chainId;
+  const hardhatNetwork = hardhatRuntime()?.network;
+  const chainId =
+    _chainId ??
+    hardhatNetwork?.config?.chainId ??
+    (hardhatNetwork?.name
+      ? CHAIN_IDS[hardhatNetwork.name.toLowerCase()]
+      : undefined);
+  if (chainId == null) throw new Error("Network not initialized");
+  return chainId;
 }
 
 export function getNetworkName(): string {
-  if (!_networkName) throw new Error("Network not initialized");
-  return _networkName;
+  const networkName = _networkName ?? hardhatRuntime()?.network?.name;
+  if (!networkName) throw new Error("Network not initialized");
+  return networkName;
 }
 
 export function setSigner(signer: ethers.Signer): void {

--- a/contracts/tasks/tasks.js
+++ b/contracts/tasks/tasks.js
@@ -1534,8 +1534,7 @@ subtask(
     types.int
   )
   .setAction(async (taskArgs) => {
-    const signer = await getSigner();
-    await snapStaking({ ...taskArgs, signer });
+    await snapStaking(taskArgs);
   });
 task("snapStaking").setAction(async (_, __, runSuper) => {
   return runSuper();

--- a/contracts/tasks/vault.js
+++ b/contracts/tasks/vault.js
@@ -13,9 +13,13 @@ async function getContracts(hre, symbol, assetSymbol) {
   const networkName = await getNetworkName();
 
   // If no symbol is provided, set to OSonic if Sonic network, else default to OETH
-  symbol = symbol ? symbol : networkName === "sonic" ? "OSonic" : "OETH";
+  symbol = symbol
+    ? symbol.toUpperCase()
+    : networkName === "sonic"
+    ? "OSonic"
+    : "OETH";
   // Convert OS to OSonic
-  symbol = symbol === "OS" ? "OSonic" : symbol;
+  symbol = symbol === "OS" || symbol === "OSONIC" ? "OSonic" : symbol;
   const contractPrefix = symbol === "OUSD" ? "" : symbol;
 
   const networkPrefix = networkName === "base" ? "Base" : "";

--- a/contracts/utils/beacon.js
+++ b/contracts/utils/beacon.js
@@ -133,15 +133,6 @@ const getBeaconBlock = async (slot = "head", networkName = "mainnet") => {
   const client = await configClient();
 
   const { ssz } = await import("@lodestar/types");
-  // Mainnet fixed-slot proof generation currently decodes against Electra-era beacon data.
-  const BeaconBlock =
-    networkName === "mainnet"
-      ? ssz.electra.BeaconBlock
-      : ssz.electra.BeaconBlock;
-  const BeaconState =
-    networkName === "mainnet"
-      ? ssz.electra.BeaconState
-      : ssz.electra.BeaconState;
 
   // Get the beacon block for the slot from the beacon node.
   log(`Fetching block for slot ${slot} from the beacon node`);
@@ -153,6 +144,9 @@ const getBeaconBlock = async (slot = "head", networkName = "mainnet") => {
     );
   }
 
+  const fork = blockRes.meta().version;
+  const BeaconBlock = ssz[fork].BeaconBlock;
+  const BeaconState = ssz[fork].BeaconState;
   const blockView = BeaconBlock.toView(blockRes.value().message);
 
   const stateFilename = `./cache/state_${blockView.slot}.ssz`;


### PR DESCRIPTION
## Summary

Fixes the following Hardhat snapshot tasks:

- `snapStakingStrat`
  - Removes the unconditional `@oplabs/talos-client` dependency from the shared network helper.
  - Restores access to the Hardhat provider and network context.
  - Uses the existing `IERC20Metadata` ABI for `IERC20` contract resolution.
  - Decodes beacon data using the fork returned by the beacon API.

- `snapStaking`
  - Removes the unnecessary signer lookup from this read-only task.

- `snapVault`
  - Normalizes the token symbol so lowercase values such as `oeth` resolve the correct deployment.

## Test plan

```bash
pnpm hardhat snapStakingStrat --network mainnet --ssv false
pnpm hardhat snapStaking --network mainnet --index 2
pnpm hardhat snapVault --network mainnet --symbol oeth
```