### PR TITLE
Remove cache of beacon data files

### DIFF
--- a/contracts/tasks/actions/verifyBalances.ts
+++ b/contracts/tasks/actions/verifyBalances.ts
@@ -58,7 +58,10 @@ action({
     );
   },
   run: async ({ signer, args }) => {
-    await verifyBalances({ ...args, signer });
-    cleanStateCache();
+    try {
+      await verifyBalances({ ...args, signer });
+    } finally {
+      cleanStateCache();
+    }
   },
 });

--- a/contracts/tasks/actions/verifyDeposits.ts
+++ b/contracts/tasks/actions/verifyDeposits.ts
@@ -22,7 +22,10 @@ action({
     );
   },
   run: async ({ signer, args }) => {
-    await verifyDeposits({ ...args, signer });
-    cleanStateCache();
+    try {
+      await verifyDeposits({ ...args, signer });
+    } finally {
+      cleanStateCache();
+    }
   },
 });

--- a/contracts/utils/beacon.js
+++ b/contracts/utils/beacon.js
@@ -1,4 +1,6 @@
 const fs = require("fs");
+const os = require("os");
+const path = require("path");
 const ethers = require("ethers");
 const { createHash } = require("crypto");
 const { parseUnits } = require("ethers/lib/utils");
@@ -17,14 +19,14 @@ const fetchImpl =
         import("node-fetch").then(({ default: fetch }) => fetch(...args));
 
 const SLOTS_PER_EPOCH = 32;
-const BEACON_STATE_CACHE_DIR = "./cache";
-const BEACON_STATE_CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+const BEACON_STATE_CACHE_DIR = path.join(
+  os.tmpdir(),
+  "origin-dollar-beacon-states"
+);
 
-// Beacon state SSZ files are large and each run fetches a unique slot, so a
-// long-lived runner accumulates them in ./cache until the disk fills (ENOSPC).
-// After successful beacon actions, prune old beacon state files while leaving
-// recent files available for retries and avoiding unrelated Hardhat cache data.
-const cleanStateCache = (now = Date.now()) => {
+// Beacon state SSZ files are large and only needed for the duration of an
+// action, so delete them after the action completes.
+const cleanStateCache = () => {
   if (!fs.existsSync(BEACON_STATE_CACHE_DIR)) {
     return;
   }
@@ -40,15 +42,10 @@ const cleanStateCache = (now = Date.now()) => {
       continue;
     }
 
-    const file = `${BEACON_STATE_CACHE_DIR}/${entry.name}`;
+    const file = path.join(BEACON_STATE_CACHE_DIR, entry.name);
     try {
-      const stats = fs.statSync(file);
-      if (now - stats.mtimeMs <= BEACON_STATE_CACHE_MAX_AGE_MS) {
-        continue;
-      }
-
       fs.rmSync(file, { force: true });
-      log(`Removed cached beacon state older than 1 day ${file}`);
+      log(`Removed cached beacon state ${file}`);
     } catch {
       // Best-effort cleanup; a missing file is fine.
     }
@@ -149,7 +146,11 @@ const getBeaconBlock = async (slot = "head", networkName = "mainnet") => {
   const BeaconState = ssz[fork].BeaconState;
   const blockView = BeaconBlock.toView(blockRes.value().message);
 
-  const stateFilename = `./cache/state_${blockView.slot}.ssz`;
+  fs.mkdirSync(BEACON_STATE_CACHE_DIR, { recursive: true });
+  const stateFilename = path.join(
+    BEACON_STATE_CACHE_DIR,
+    `state_${blockView.slot}.ssz`
+  );
   const fetchStateSsz = async () => {
     log(`Fetching state for slot ${blockView.slot} from the beacon node`);
 


### PR DESCRIPTION
## Summary

- Store downloaded beacon state SSZ files in temporary storage instead of the project cache directory.
- Create the temporary directory on demand before writing beacon state data.
- Delete all downloaded beacon state files after `verifyBalances` and `verifyDeposits` complete.
- Run cleanup in a `finally` block so files are removed even when verification fails.

## Background

Talos containers no longer create `/app/cache` during their build. Beacon verification actions consequently failed with `ENOENT` when attempting to write `./cache/state_<slot>.ssz`.

Beacon state files are large and only needed while an action is running, so they do not need to persist between actions or container deployments.

## Testing

- Ran JavaScript and TypeScript Prettier.
- Verified `utils/beacon.js` loads successfully.
- Ran `git diff --check`.