### PR TITLE
Better timeout handling of beacon chain data

### DIFF
--- a/contracts/utils/beacon.js
+++ b/contracts/utils/beacon.js
@@ -19,6 +19,7 @@ const fetchImpl =
         import("node-fetch").then(({ default: fetch }) => fetch(...args));
 
 const SLOTS_PER_EPOCH = 32;
+const BEACON_STATE_FETCH_TIMEOUT_MS = 15 * 60 * 1000;
 const BEACON_STATE_CACHE_DIR = path.join(
   os.tmpdir(),
   "origin-dollar-beacon-states"
@@ -181,27 +182,39 @@ const getBeaconBlock = async (slot = "head", networkName = "mainnet") => {
     }
 
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 5 * 60 * 1000);
+    const timeout = setTimeout(() => {
+      log(
+        `Aborting state fetch for slot ${blockView.slot} after ${
+          BEACON_STATE_FETCH_TIMEOUT_MS / 60000
+        } minutes`
+      );
+      controller.abort();
+    }, BEACON_STATE_FETCH_TIMEOUT_MS);
 
-    let response;
+    let stateSszBytes;
     try {
-      response = await fetchImpl(parsedUrl.toString(), {
+      const response = await fetchImpl(parsedUrl.toString(), {
         method: "GET",
         headers,
         signal: controller.signal,
       });
+
+      if (!response.ok) {
+        throw new Error(
+          `Failed to get state for slot ${blockView.slot}. Probably because it was missed. Error: ${response.status} ${response.statusText}`
+        );
+      }
+
+      log(
+        `Received response headers for state at slot ${blockView.slot}, downloading body`
+      );
+      stateSszBytes = new Uint8Array(await response.arrayBuffer());
+      log(
+        `Downloaded ${stateSszBytes.byteLength} bytes for state at slot ${blockView.slot}`
+      );
     } finally {
       clearTimeout(timeout);
     }
-
-    if (!response.ok) {
-      throw new Error(
-        `Failed to get state for slot ${blockView.slot}. Probably because it was missed. Error: ${response.status} ${response.statusText}`
-      );
-    }
-
-    // Read as ArrayBuffer to get raw binary SSZ bytes without text decoding.
-    const stateSszBytes = new Uint8Array(await response.arrayBuffer());
 
     log(`Writing state to file ${stateFilename}`);
     fs.writeFileSync(stateFilename, stateSszBytes);


### PR DESCRIPTION
## Summary

- Extend the beacon-state fetch timeout from 5 to 15 minutes.
- Keep the timeout active while downloading the complete SSZ response body.
- Add progress logs when response headers arrive and when the body download completes.
- Log when a beacon-state request is aborted after reaching the timeout.

## Background

Beacon-state responses are large and can take approximately seven minutes to download. The existing five-minute timeout was cleared as soon as the response headers arrived, leaving the subsequent `response.arrayBuffer()` operation without any timeout.

This caused Talos actions to remain in the `running` state indefinitely if the response body stalled.

The updated timeout covers both the initial request and the full body download while allowing enough time for the observed response duration.

This applies to all actions using the shared beacon-state loader, including `daily_verify_deposits` and `daily_verify_balances`.

## Testing

- Ran `pnpm prettier:js`.
- Verified `utils/beacon.js` loads successfully.
- Ran `git diff --check`.