### PR TITLE
Fix verify deposits

### DIFF
--- a/contracts/tasks/beacon.js
+++ b/contracts/tasks/beacon.js
@@ -175,15 +175,7 @@ async function requestValidatorWithdraw({ pubkey, amount, signer }) {
   await logTxDetails(tx, "requestWithdraw");
 }
 
-async function verifyValidator({
-  slot,
-  index,
-  ids,
-  dryrun,
-  cred,
-  ssv,
-  signer,
-}) {
+async function verifyValidator({ slot, index, ids, dryrun, cred, signer }) {
   if (index === undefined && ids === undefined) {
     throw new Error("Pass either --index or --ids");
   }
@@ -213,15 +205,10 @@ async function verifyValidator({
     networkName
   );
 
-  const strategy = ssv
-    ? await resolveContract(
-        "CompoundingStakingSSVStrategyProxy",
-        "CompoundingStakingSSVStrategy"
-      )
-    : await resolveContract(
-        "CompoundingStakingStrategyProxy",
-        "CompoundingStakingStrategy"
-      );
+  const strategy = await resolveContract(
+    "CompoundingStakingStrategyProxy",
+    "CompoundingStakingStrategy"
+  );
 
   if (cred) {
     log(`Overriding withdrawal credentials to ${cred}`);
@@ -367,8 +354,8 @@ async function getProcessedDeposits(pendingDeposits) {
 
 async function verifyDeposits({ dryrun, signer, consol = false }) {
   const stakingStrategy = await resolveContract(
-    "CompoundingStakingSSVStrategyProxy",
-    "CompoundingStakingSSVStrategy"
+    "CompoundingStakingStrategyProxy",
+    "CompoundingStakingStrategy"
   );
   const contract = consol
     ? await resolveContract("ConsolidationController")
@@ -422,8 +409,8 @@ async function verifyDeposit({
   signer,
 }) {
   const strategy = await resolveContract(
-    "CompoundingStakingSSVStrategyProxy",
-    "CompoundingStakingSSVStrategy"
+    "CompoundingStakingStrategyProxy",
+    "CompoundingStakingStrategy"
   );
 
   let strategyDepositSlot = 0;
@@ -625,8 +612,8 @@ async function verifyBalances({
   const strategy = test
     ? undefined
     : await resolveContract(
-        "CompoundingStakingSSVStrategyProxy",
-        "CompoundingStakingSSVStrategy"
+        "CompoundingStakingStrategyProxy",
+        "CompoundingStakingStrategy"
       );
   const strategyView = await resolveContract("CompoundingStakingStrategyView");
 

--- a/contracts/tasks/beacon.js
+++ b/contracts/tasks/beacon.js
@@ -175,7 +175,7 @@ async function requestValidatorWithdraw({ pubkey, amount, signer }) {
   await logTxDetails(tx, "requestWithdraw");
 }
 
-async function verifyValidator({ slot, index, dryrun, cred, signer }) {
+async function verifyValidator({ slot, index, dryrun, cred, ssv, signer }) {
   // Get provider to mainnet or testnet and not a local fork
   const provider = await getLiveProvider(signer.provider);
 
@@ -186,10 +186,15 @@ async function verifyValidator({ slot, index, dryrun, cred, signer }) {
     networkName
   );
 
-  const strategy = await resolveContract(
-    "CompoundingStakingSSVStrategyProxy",
-    "CompoundingStakingSSVStrategy"
-  );
+  const strategy = ssv
+    ? await resolveContract(
+        "CompoundingStakingSSVStrategyProxy",
+        "CompoundingStakingSSVStrategy"
+      )
+    : await resolveContract(
+        "CompoundingStakingStrategyProxy",
+        "CompoundingStakingStrategy"
+      );
 
   if (cred) {
     log(`Overriding withdrawal credentials to ${cred}`);

--- a/contracts/tasks/beacon.js
+++ b/contracts/tasks/beacon.js
@@ -175,7 +175,34 @@ async function requestValidatorWithdraw({ pubkey, amount, signer }) {
   await logTxDetails(tx, "requestWithdraw");
 }
 
-async function verifyValidator({ slot, index, dryrun, cred, ssv, signer }) {
+async function verifyValidator({
+  slot,
+  index,
+  ids,
+  dryrun,
+  cred,
+  ssv,
+  signer,
+}) {
+  if (index === undefined && ids === undefined) {
+    throw new Error("Pass either --index or --ids");
+  }
+  if (index !== undefined && ids !== undefined) {
+    throw new Error("Pass either --index or --ids, not both");
+  }
+
+  const validatorIds =
+    ids === undefined ? [String(index)] : ids.split(",").map((id) => id.trim());
+  if (validatorIds.length === 0 || validatorIds.some((id) => id === "")) {
+    throw new Error("--ids must contain at least one validator ID");
+  }
+  const validatorIndexes = [...new Set(validatorIds)].map((id) => {
+    if (!/^\d+$/.test(id) || !Number.isSafeInteger(Number(id))) {
+      throw new Error(`Invalid validator ID: "${id}"`);
+    }
+    return Number(id);
+  });
+
   // Get provider to mainnet or testnet and not a local fork
   const provider = await getLiveProvider(signer.provider);
 
@@ -199,25 +226,29 @@ async function verifyValidator({ slot, index, dryrun, cred, ssv, signer }) {
   if (cred) {
     log(`Overriding withdrawal credentials to ${cred}`);
 
-    // Update the validator's withdrawalCredentials in stateView
-    const validator = stateView.validators.get(index);
-    if (
-      !validator ||
-      toHex(validator.node.root) ==
-        "0x0000000000000000000000000000000000000000000000000000000000000000"
-    ) {
-      throw new Error(`Validator at index ${index} not found for slot ${slot}`);
+    for (const validatorIndex of validatorIndexes) {
+      // Update the validator's withdrawalCredentials in stateView
+      const validator = stateView.validators.get(validatorIndex);
+      if (
+        !validator ||
+        toHex(validator.node.root) ==
+          "0x0000000000000000000000000000000000000000000000000000000000000000"
+      ) {
+        throw new Error(
+          `Validator at index ${validatorIndex} not found for slot ${blockView.slot}`
+        );
+      }
+
+      log(
+        `Original withdrawal credentials for validator ${validatorIndex}: ${toHex(
+          validator.withdrawalCredentials
+        )}`
+      );
+
+      // Override the address in the withdrawal credentials
+      validator.withdrawalCredentials = arrayify(cred);
+      stateView.validators.set(validatorIndex, validator);
     }
-
-    log(
-      `Original withdrawal credentials: ${toHex(
-        validator.withdrawalCredentials
-      )}`
-    );
-
-    // Override the address in the withdrawal credentials
-    validator.withdrawalCredentials = arrayify(cred);
-    stateView.validators.set(index, validator); // Update validator in state
 
     // Update blockTree with new stateRoot
     const stateRootGindex = blockView.type.getPathInfo(["stateRoot"]).gindex;
@@ -232,45 +263,67 @@ async function verifyValidator({ slot, index, dryrun, cred, ssv, signer }) {
     `Next execution layer block ${nextBlock} has timestamp ${nextBlockTimestamp}`
   );
 
-  const {
-    proof,
-    leaf: pubKeyHash,
-    root: beaconBlockRoot,
-    pubKey,
-  } = await generateValidatorPubKeyProof({
-    validatorIndex: index,
-    blockView,
-    blockTree,
-    stateView,
-  });
+  const validatorProofs = [];
+  for (const validatorIndex of validatorIndexes) {
+    const {
+      proof,
+      leaf: pubKeyHash,
+      root: beaconBlockRoot,
+      pubKey,
+    } = await generateValidatorPubKeyProof({
+      validatorIndex,
+      blockView,
+      blockTree,
+      stateView,
+    });
 
-  // Check the validator is in STAKED state
-  const stateEnum = (await strategy.validator(pubKeyHash)).state;
-  log(`Validator with pub key hash ${pubKeyHash} has state: ${stateEnum}`);
-  if (stateEnum !== 2)
-    // STAKED
-    throw Error(
-      `Validator ${index} with pub key hash ${pubKeyHash} is not STAKED. Status: ${stateEnum}`
-    );
+    // Check the validator is in STAKED state
+    const stateEnum = (await strategy.validator(pubKeyHash)).state;
+    log(`Validator with pub key hash ${pubKeyHash} has state: ${stateEnum}`);
+    if (stateEnum !== 2)
+      // STAKED
+      throw Error(
+        `Validator ${validatorIndex} with pub key hash ${pubKeyHash} is not STAKED. Status: ${stateEnum}`
+      );
+
+    validatorProofs.push({
+      beaconBlockRoot,
+      proof,
+      pubKey,
+      pubKeyHash,
+      stateEnum,
+      validatorIndex,
+    });
+  }
 
   if (dryrun) {
-    console.log(`beaconBlockRoot       : ${beaconBlockRoot}`);
-    console.log(`nextBlockTimestamp    : ${nextBlockTimestamp}`);
-    console.log(`validator index       : ${index}`);
-    console.log(`pubKeyHash            : ${pubKeyHash}`);
-    console.log(`withdrawal credentials: ${cred}`);
-    console.log(`Validator status      : ${stateEnum}`);
-    console.log(`proof:\n${proof}`);
+    for (const validatorProof of validatorProofs) {
+      console.log(`beaconBlockRoot       : ${validatorProof.beaconBlockRoot}`);
+      console.log(`nextBlockTimestamp    : ${nextBlockTimestamp}`);
+      console.log(`validator index       : ${validatorProof.validatorIndex}`);
+      console.log(`pubKeyHash            : ${validatorProof.pubKeyHash}`);
+      console.log(`withdrawal credentials: ${cred}`);
+      console.log(`Validator status      : ${validatorProof.stateEnum}`);
+      console.log(`proof:\n${validatorProof.proof}`);
+    }
     return;
   }
 
-  log(
-    `About verify validator ${index} with pub key ${pubKey}, pub key hash ${pubKeyHash}, withdrawal credential ${cred} at slot ${blockView.slot} to beacon chain root ${beaconBlockRoot}`
-  );
-  const tx = await strategy
-    .connect(signer)
-    .verifyValidator(nextBlockTimestamp, index, pubKeyHash, cred, proof);
-  await logTxDetails(tx, "verifyValidator");
+  for (const validatorProof of validatorProofs) {
+    log(
+      `About verify validator ${validatorProof.validatorIndex} with pub key ${validatorProof.pubKey}, pub key hash ${validatorProof.pubKeyHash}, withdrawal credential ${cred} at slot ${blockView.slot} to beacon chain root ${validatorProof.beaconBlockRoot}`
+    );
+    const tx = await strategy
+      .connect(signer)
+      .verifyValidator(
+        nextBlockTimestamp,
+        validatorProof.validatorIndex,
+        validatorProof.pubKeyHash,
+        cred,
+        validatorProof.proof
+      );
+    await logTxDetails(tx, "verifyValidator");
+  }
 }
 
 // get deposits that have been processed on the beacon chain but not yet validated by the strategy

--- a/contracts/tasks/lib/signer.ts
+++ b/contracts/tasks/lib/signer.ts
@@ -1,10 +1,4 @@
 import { ethers } from "ethers";
-import {
-  createDb,
-  createPool,
-  wrapSignerWithNonceQueueV5,
-  type Db,
-} from "@oplabs/talos-client";
 import { DirectKmsTransactionSigner } from "@lastdotnet/purrikey";
 import { getProvider } from "./network";
 // CJS util.
@@ -23,12 +17,28 @@ import {
  * instead of hre.ethers.provider.
  */
 
+type Db = unknown;
+type TalosClient = {
+  createDb(pool: unknown): Db;
+  createPool(options: { connectionString: string }): unknown;
+  wrapSignerWithNonceQueueV5(
+    signer: ethers.Signer,
+    options: { db: Db }
+  ): unknown;
+};
+
+let talosClient: TalosClient | null = null;
 let dbInstance: Db | null = null;
 function getNonceDb(): Db | null {
   if (!process.env.DATABASE_URL) return null;
+  if (!talosClient) {
+    // Talos is an optional peer dependency so non-Talos Hardhat commands do not
+    // require credentials for the private package registry.
+    talosClient = require("@oplabs/talos-client") as TalosClient;
+  }
   if (!dbInstance) {
-    dbInstance = createDb(
-      createPool({ connectionString: process.env.DATABASE_URL })
+    dbInstance = talosClient.createDb(
+      talosClient.createPool({ connectionString: process.env.DATABASE_URL })
     );
   }
   return dbInstance;
@@ -37,7 +47,9 @@ function getNonceDb(): Db | null {
 function maybeWrap(signer: ethers.Signer): ethers.Signer {
   const db = getNonceDb();
   return db
-    ? (wrapSignerWithNonceQueueV5(signer, { db }) as unknown as ethers.Signer)
+    ? (talosClient!.wrapSignerWithNonceQueueV5(signer, {
+        db,
+      }) as unknown as ethers.Signer)
     : signer;
 }
 

--- a/contracts/tasks/tasks.js
+++ b/contracts/tasks/tasks.js
@@ -1951,11 +1951,17 @@ task("getValidators").setAction(async (_, __, runSuper) => {
 });
 
 subtask("verifyValidator", "Verify a validator on the Beacon chain")
-  .addParam(
+  .addOptionalParam(
     "index",
     "Index of the validator on the Beacon chain",
     undefined,
     types.int
+  )
+  .addOptionalParam(
+    "ids",
+    "Comma-separated validator indexes to verify using one beacon state",
+    undefined,
+    types.string
   )
   .addOptionalParam(
     "slot",

--- a/contracts/tasks/tasks.js
+++ b/contracts/tasks/tasks.js
@@ -1975,6 +1975,12 @@ subtask("verifyValidator", "Verify a validator on the Beacon chain")
     undefined,
     types.string
   )
+  .addOptionalParam(
+    "ssv",
+    "Use the SSV compounding staking strategy instead of the non-SSV compounding staking strategy.",
+    false,
+    types.boolean
+  )
   .setAction(async (taskArgs) => {
     const signer = await getSigner();
     await verifyValidator({ ...taskArgs, signer });

--- a/contracts/tasks/tasks.js
+++ b/contracts/tasks/tasks.js
@@ -1981,12 +1981,6 @@ subtask("verifyValidator", "Verify a validator on the Beacon chain")
     undefined,
     types.string
   )
-  .addOptionalParam(
-    "ssv",
-    "Use the SSV compounding staking strategy instead of the non-SSV compounding staking strategy.",
-    false,
-    types.boolean
-  )
   .setAction(async (taskArgs) => {
     const signer = await getSigner();
     await verifyValidator({ ...taskArgs, signer });

--- a/contracts/tasks/validatorCompound.js
+++ b/contracts/tasks/validatorCompound.js
@@ -1,4 +1,6 @@
 const addresses = require("../utils/addresses");
+const { readFileSync } = require("fs");
+const path = require("path");
 const { formatUnits, parseUnits } = require("ethers/lib/utils");
 const { BigNumber } = require("ethers");
 
@@ -11,6 +13,7 @@ const {
   calcSlot,
   getValidatorBalance,
   getBeaconBlock,
+  getValidators: getValidatorsBeacon,
   hashPubKey,
 } = require("../utils/beacon");
 const { getNetworkName } = require("./lib/network");
@@ -40,22 +43,25 @@ const VALIDATOR_STATE_NON_REGISTERED = 0;
 const VALIDATOR_STATE_REGISTERED = 1;
 
 const resolveCompoundingStakingContract = async (ssv = false) => {
+  const proxyName = ssv
+    ? "CompoundingStakingSSVStrategyProxy"
+    : "CompoundingStakingStrategyProxy";
+  const implementationName = ssv
+    ? "CompoundingStakingSSVStrategy"
+    : "CompoundingStakingStrategy";
+
   if (ssv) {
     return {
       creatingDepositState: VALIDATOR_STATE_REGISTERED,
-      strategy: await resolveContract(
-        "CompoundingStakingSSVStrategyProxy",
-        "CompoundingStakingSSVStrategy"
-      ),
+      proxyName,
+      strategy: await resolveContract(proxyName, implementationName),
     };
   }
 
   return {
     creatingDepositState: VALIDATOR_STATE_NON_REGISTERED,
-    strategy: await resolveContract(
-      "CompoundingStakingStrategyProxy",
-      "CompoundingStakingStrategy"
-    ),
+    proxyName,
+    strategy: await resolveContract(proxyName, implementationName),
   };
 };
 
@@ -737,11 +743,17 @@ async function snapStakingStrategy({
   const ssvToken = addresses[networkName].SSV
     ? await getContractAt("IERC20", addresses[networkName].SSV)
     : undefined;
-  const { strategy } = await resolveCompoundingStakingContract(ssv);
+  const { proxyName, strategy } = await resolveCompoundingStakingContract(ssv);
   const vault = await resolveContract("OETHVaultProxy", "IVault");
 
   // Pending deposits
-  const totalDeposits = await logDeposits(strategy, blockTag, stateView);
+  const totalDeposits = await logDeposits(
+    strategy,
+    proxyName,
+    networkName,
+    blockTag,
+    stateView
+  );
 
   if (stateView.pendingDeposits.length === 0) {
     console.log("No pending beacon chain deposits");
@@ -875,13 +887,34 @@ async function snapStakingStrategy({
   );
 }
 
-async function logDeposits(strategy, blockTag = "latest", stateView) {
+async function logDeposits(
+  strategy,
+  proxyName,
+  networkName,
+  blockTag = "latest",
+  stateView
+) {
   const deposits = await getPendingDeposits(strategy, blockTag);
+  const depositsMissingPubKeys = deposits.filter(
+    ({ pendingDepositRoot }) =>
+      !findDepositInQueue(pendingDepositRoot, stateView).pendingDeposit
+  );
+  const eventPubKeys = await getDepositPubKeysFromEvents(
+    strategy,
+    proxyName,
+    networkName,
+    depositsMissingPubKeys,
+    blockTag
+  );
+  const validatorIndexes = await getValidatorIndexes(
+    [...eventPubKeys.values()],
+    stateView.slot
+  );
   let totalDeposits = BigNumber.from(0);
   console.log(`\n${deposits.length || "No"} pending strategy deposits:`);
   if (deposits.length > 0) {
     console.log(
-      `  Pending deposit root                                               amount (ETH)   slot    Q pos public key`
+      `  Pending deposit root                                               amount (ETH)   slot     Q pos V index public key`
     );
   }
   for (const deposit of deposits) {
@@ -891,19 +924,87 @@ async function logDeposits(strategy, blockTag = "latest", stateView) {
     );
     const pubKey = pendingDeposit
       ? toHex(pendingDeposit.pubkey)
-      : deposit.pubKeyHash;
+      : eventPubKeys.get(deposit.pendingDepositRoot) || deposit.pubKeyHash;
+    const validatorIndex = pendingDeposit
+      ? "-"
+      : validatorIndexes.get(pubKey.toLowerCase()) ?? "-";
     console.log(
       `  ${deposit.pendingDepositRoot} ${formatUnits(
         deposit.amountGwei,
         9
       ).padEnd(14)} ${deposit.slot} ${position
         .toString()
-        .padStart(5)} ${pubKey}`
+        .padStart(5)} ${validatorIndex.toString().padStart(7)} ${pubKey}`
     );
     totalDeposits = totalDeposits.add(deposit.amountGwei);
   }
 
   return totalDeposits;
+}
+
+async function getDepositPubKeysFromEvents(
+  strategy,
+  proxyName,
+  networkName,
+  deposits,
+  blockTag
+) {
+  const pubKeys = new Map();
+  if (deposits.length === 0) return pubKeys;
+
+  try {
+    const deploymentPath = path.join(
+      __dirname,
+      "..",
+      "deployments",
+      networkName,
+      `${proxyName}.json`
+    );
+    const deployment = JSON.parse(readFileSync(deploymentPath, "utf8"));
+    const fromBlock = deployment.receipt.blockNumber;
+    const eventTopic = strategy.interface.getEventTopic("ETHStaked");
+    const pubKeyHashes = deposits.map(({ pubKeyHash }) => pubKeyHash);
+    const blockBatchSize = 10000;
+
+    for (let startBlock = fromBlock; startBlock <= blockTag; ) {
+      const endBlock = Math.min(startBlock + blockBatchSize - 1, blockTag);
+      const logs = await strategy.provider.getLogs({
+        address: strategy.address,
+        topics: [eventTopic, pubKeyHashes],
+        fromBlock: startBlock,
+        toBlock: endBlock,
+      });
+      for (const rawLog of logs) {
+        const event = strategy.interface.parseLog(rawLog);
+        pubKeys.set(event.args.pendingDepositRoot, event.args.pubKey);
+      }
+      if (pubKeys.size === deposits.length) break;
+      startBlock = endBlock + 1;
+    }
+  } catch (err) {
+    log(
+      `Failed to load full validator public keys from ETHStaked events: ${err}`
+    );
+  }
+
+  return pubKeys;
+}
+
+async function getValidatorIndexes(pubKeys, stateId) {
+  const indexes = new Map();
+  if (pubKeys.length === 0) return indexes;
+
+  try {
+    const validators = await getValidatorsBeacon(pubKeys, stateId);
+    const validatorList = Array.isArray(validators) ? validators : [validators];
+    for (const validator of validatorList) {
+      indexes.set(validator.pubkey.toLowerCase(), validator.index);
+    }
+  } catch (err) {
+    log(`Failed to load processed validator indexes: ${err}`);
+  }
+
+  return indexes;
 }
 
 function findDepositInQueue(pendingDepositRoot, stateView) {


### PR DESCRIPTION
## Summary

Updates the validator tooling for the new `CompoundingStakingStrategy`:

- Targets `CompoundingStakingStrategy` instead of the legacy SSV strategy for validator verification actions.
- Adds batch verification via `--ids`, reusing a single beacon-state snapshot across validators.
- Enhances staking snapshots with full public keys and validator indexes for processed deposits by reading `ETHStaked` events and querying the beacon API.
- Lazily loads the optional Talos client so regular Hardhat commands do not require private registry credentials.

No contract or deployment changes are included.

## Testing

- Formatting and lint
- Build
- Unit tests
- Fork and smoke test suites via CI