### PR TITLE
Set new Campaign Remote manager on Curve Pool Boosters

### DIFF
--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -8,7 +8,7 @@ MAKEFLAGS += --no-print-directory
 # ╚══════════════════════════════════════════════════════════════════════════════╝
 
 DEPLOY_SCRIPT   := scripts/deploy/DeployManager.s.sol
-DEPLOY_BASE     := --account deployerKey --sender $(DEPLOYER_ADDRESS) --broadcast --slow --no-isolate
+DEPLOY_BASE     := --account deployerKey --sender $(DEPLOYER_ADDRESS) --broadcast --slow
 DEPLOY_BUILD    := contracts/ scripts/deploy/
 
 # ╔══════════════════════════════════════════════════════════════════════════════╗

--- a/contracts/build/deployments-1.json
+++ b/contracts/build/deployments-1.json
@@ -117,6 +117,12 @@
             "proposalId": 1,
             "tsDeployment": 1723685111,
             "tsGovernance": 1
+        },
+        {
+            "name": "004_CurvePoolBoosterRemoteManager",
+            "proposalId": 0,
+            "tsDeployment": 1785929915,
+            "tsGovernance": 0
         }
     ]
 }

--- a/contracts/scripts/deploy/mainnet/004_CurvePoolBoosterRemoteManager.s.sol
+++ b/contracts/scripts/deploy/mainnet/004_CurvePoolBoosterRemoteManager.s.sol
@@ -57,7 +57,6 @@ contract $004_CurvePoolBoosterRemoteManager is AbstractDeployScript("004_CurvePo
 
         // A governance proposal needs a fixed target list, so cross-check it against the live
         // module to catch boosters added or removed between writing and executing the proposal.
-        // Resolved rather than read from Mainnet.CurvePoolBoosterBribesModule, which is stale.
         ICurvePoolBoosterBribesModule bribesModule =
             ICurvePoolBoosterBribesModule(payable(resolver.resolve("CURVE_POOL_BOOSTER_BRIBES_MODULE")));
         address[] memory livePoolBoosters = bribesModule.getPoolBoosters();

--- a/contracts/scripts/deploy/mainnet/004_CurvePoolBoosterRemoteManager.s.sol
+++ b/contracts/scripts/deploy/mainnet/004_CurvePoolBoosterRemoteManager.s.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+// Deployment framework
+import {AbstractDeployScript} from "scripts/deploy/helpers/AbstractDeployScript.s.sol";
+import {GovHelper} from "scripts/deploy/helpers/GovHelper.sol";
+import {GovProposal} from "scripts/deploy/helpers/DeploymentTypes.sol";
+
+// Contracts
+import {ICurvePoolBooster} from "contracts/interfaces/poolBooster/ICurvePoolBooster.sol";
+import {ICurvePoolBoosterBribesModule} from "contracts/interfaces/automation/ICurvePoolBoosterBribesModule.sol";
+
+/// @title 004_CurvePoolBoosterRemoteManager
+/// @notice Repoints every Curve Pool Booster to Stake DAO's new CampaignRemoteManager.
+/// @dev Stake DAO rotated their mainnet CampaignRemoteManager on 2026-07-30
+///      (tx 0x3d0262df1cc1aedbc04e68e0bdf6e315877daf6822fe6dcc9b9f97f78983e8dc), de-whitelisting
+///      every platform on the old manager and whitelisting them on the new one in the same
+///      transaction. Since then `createCampaign()` and `manageCampaign()` on our boosters revert
+///      with `PlatformNotWhitelisted()`, which breaks the `manage_curve_pb_mainnet` automation.
+///
+///      Nothing is deployed here — the fix is a single `setCampaignRemoteManager()` call per
+///      booster, which is `onlyGovernor`, so this script only builds a governance proposal.
+///      The Votemarket platform address is unchanged and must stay as is.
+contract $004_CurvePoolBoosterRemoteManager is AbstractDeployScript("004_CurvePoolBoosterRemoteManager") {
+    using GovHelper for GovProposal;
+
+    /// @notice Stake DAO's new mainnet CampaignRemoteManager.
+    address internal constant NEW_CAMPAIGN_REMOTE_MANAGER = 0x177198aDb759a9715bC7259BE1b7bE535BeD7542;
+
+    /// @notice Votemarket V2 platform on Arbitrum. Unchanged by the rotation.
+    address internal constant VOTEMARKET = 0x8c2c5A295450DDFf4CB360cA73FCCC12243D14D9;
+
+    // ==================== Governance Proposal ==================== //
+
+    function _buildGovernanceProposal() internal override {
+        address[] memory boosters = _poolBoosters();
+
+        govProposal.setDescription(
+            "Repoint Curve Pool Boosters to the new Stake DAO CampaignRemoteManager\n\n"
+            "Stake DAO replaced their mainnet CampaignRemoteManager and moved the platform "
+            "whitelist over to the new contract. Campaign creation and management from our Curve "
+            "Pool Boosters revert until they point at the new manager. This proposal updates the "
+            "campaignRemoteManager on all 12 boosters. No other booster configuration changes."
+        );
+
+        for (uint256 i = 0; i < boosters.length; i++) {
+            govProposal.action(
+                boosters[i], "setCampaignRemoteManager(address)", abi.encode(NEW_CAMPAIGN_REMOTE_MANAGER)
+            );
+        }
+    }
+
+    // ==================== Fork Verification ==================== //
+
+    function _fork() internal override {
+        address[] memory boosters = _poolBoosters();
+
+        // A governance proposal needs a fixed target list, so cross-check it against the live
+        // module to catch boosters added or removed between writing and executing the proposal.
+        // Resolved rather than read from Mainnet.CurvePoolBoosterBribesModule, which is stale.
+        ICurvePoolBoosterBribesModule bribesModule =
+            ICurvePoolBoosterBribesModule(payable(resolver.resolve("CURVE_POOL_BOOSTER_BRIBES_MODULE")));
+        address[] memory livePoolBoosters = bribesModule.getPoolBoosters();
+        require(livePoolBoosters.length == boosters.length, "Pool booster count has changed");
+        for (uint256 i = 0; i < boosters.length; i++) {
+            require(livePoolBoosters[i] == boosters[i], "Pool booster list has changed");
+        }
+
+        for (uint256 i = 0; i < boosters.length; i++) {
+            ICurvePoolBooster booster = ICurvePoolBooster(boosters[i]);
+            require(booster.campaignRemoteManager() == NEW_CAMPAIGN_REMOTE_MANAGER, "Campaign manager not updated");
+            require(booster.votemarket() == VOTEMARKET, "Votemarket has changed");
+        }
+
+        // The invariant that broke: manageCampaign() reverts with PlatformNotWhitelisted() unless
+        // the platform is whitelisted on the manager the booster calls.
+        require(
+            ICampaignRemoteManagerWhitelist(NEW_CAMPAIGN_REMOTE_MANAGER).whitelistedPlatforms(VOTEMARKET),
+            "Votemarket not whitelisted on the new CampaignRemoteManager"
+        );
+    }
+
+    // ==================== Internal Helpers ==================== //
+
+    /// @notice The 12 Curve Pool Boosters, in `getPoolBoosters()` order.
+    function _poolBoosters() internal pure returns (address[] memory boosters) {
+        boosters = new address[](12);
+        boosters[0] = 0x2425ff98A23021BF056E96FB690BF49910a8cE49; // OUSD/crvUSD
+        boosters[1] = 0x1A43D2F1bb24aC262D1d7ac05D16823E526FcA32; // OETH/ARM-WETH-stETH
+        boosters[2] = 0xDafF0D96037B0F7bf72C6e2b3125b5D19273B149; // OUSD/msUSD
+        boosters[3] = 0xc835BcA1378acb32C522f3831b8dba161a763FBE; // frxUSD/OUSD
+        boosters[4] = 0xd5d46b7e8FF91C3227D2Cf0aAE263f87743e3340; // OGN/OETH
+        boosters[5] = 0xE9CA668D5C31Ea5162651667103537bDA5458500; // ynRWAx/OUSD
+        boosters[6] = 0x5400a839C198d787c784F370F5a27672285b2133; // OUSD/MUSD
+        boosters[7] = 0xAe6058D732f0f3E098A068A338dB07bbD5169d3D; // OUSD/pmUSD
+        boosters[8] = 0x5677d1DA3876E86f96F4492bdB8fdbb79C2Bf56c; // OUSD/eUSD
+        boosters[9] = 0xFc5fEF2D566f77262CeF4e86749fdF1170b6f63F; // OUSD/USDT
+        boosters[10] = 0x077486b01C8670e7F51Dbf7E09Cd648d4a538F87; // OUSD/avUSD
+        boosters[11] = 0x634bd2921Fab3413f7db3F03310Fd5F7663badcC; // OUSD/USDe
+    }
+}
+
+// ==================== External Interface ==================== //
+
+/// @notice Whitelist view on Stake DAO's CampaignRemoteManager, not part of ICampaignRemoteManager.
+interface ICampaignRemoteManagerWhitelist {
+    function whitelistedPlatforms(address platform) external view returns (bool);
+}

--- a/contracts/tests/utils/Addresses.sol
+++ b/contracts/tests/utils/Addresses.sol
@@ -194,7 +194,7 @@ library Mainnet {
 
     // Curve Pool Booster
     address internal constant CurvePoolBoosterOETH = 0x7B5e7aDEBC2da89912BffE55c86675CeCE59803E;
-    address internal constant CurvePoolBoosterBribesModule = 0x82447F7C3eF0a628B0c614A3eA0898a5bb7c18fe;
+    address internal constant CurvePoolBoosterBribesModule = 0x6320Db7a3c1B95fD5684DC725C2cda9B82Fa20Fa;
     address internal constant MerklPoolBoosterBribesModule = 0x6241f5e4ad5af39ef3aE54801E0AE431e0B70369;
 
     // SSV network

--- a/contracts/tests/utils/Addresses.sol
+++ b/contracts/tests/utils/Addresses.sol
@@ -127,7 +127,7 @@ library Mainnet {
     address internal constant CurveOETHETHplusGauge = 0xCAe10a7553AccA53ad58c4EC63e3aB6Ad6546F71;
 
     // Votemarket - StakeDAO
-    address internal constant CampaignRemoteManager = 0x53aD4Cd1F1e52DD02aa9FC4A8250A1b74F351CA2;
+    address internal constant CampaignRemoteManager = 0x177198aDb759a9715bC7259BE1b7bE535BeD7542;
 
     // Morpho
     address internal constant MorphoStrategyProxy = 0x5A4eEe58744D1430876d5cA93cAB5CcB763C037D;

--- a/contracts/utils/addresses.js
+++ b/contracts/utils/addresses.js
@@ -203,7 +203,7 @@ addresses.unitTests.CompoundingStakingStrategyProxy =
 
 // Votemarket - StakeDAO
 addresses.mainnet.CampaignRemoteManager =
-  "0x53aD4Cd1F1e52DD02aa9FC4A8250A1b74F351CA2";
+  "0x177198aDb759a9715bC7259BE1b7bE535BeD7542";
 
 // Morpho
 addresses.mainnet.MorphoStrategyProxy =


### PR DESCRIPTION
## Overview
This PR replaces the [old CampaingRemoteManager](0x53aD4Cd1F1e52DD02aa9FC4A8250A1b74F351CA2) with the [new one](0x177198aDb759a9715bC7259BE1b7bE535BeD7542). The StakeDAO team have migrated to a new implementation in [this transaction](https://etherscan.io/tx/0x3d0262df1cc1aedbc04e68e0bdf6e315877daf6822fe6dcc9b9f97f78983e8dc#eventlog)

Also fixes the `--no-isolate` error since `--no-isolate` doesn't exist in forge 1.5.1 forge script only has opt-in --isolate, and isolation is off by default, so the flag was expressing the default.

## Governance proposal 
[Repoint Curve Pool Boosters to the new Stake DAO CampaignRemoteManager](https://app.originprotocol.com/#/ogn/governance/1:0x1d3fbd4d129ddd2372ea85c5fa00b2682081c9ec:24977470468734366985508521635848311695522621005005638690937767796597338110006)


## Code Change Checklist

To be completed before internal review begins:

- [ ]  The contract code is complete
- [ ]  Executable deployment file
- [ ]  Fork tests that test after the deployment file runs
- [ ]  Unit tests *if needed
- [ ]  The owner has done a [full checklist review](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) of the code + tests

Internal review:

- [ ] Two approvals by internal reviewers


## Deploy checklist

Two reviewers complete the following checklist:

```
- [ ] All deployed contracts are listed in the deploy PR's description
- [ ] Deployed contract's verified code (and all dependencies) match the code in master
- [ ] Contract constructors have correct arguments
- [ ] The transactions that interacted with the newly deployed contract match the deploy script.
- [ ] Governance proposal matches the deploy script
- [ ] Smoke tests pass after fork test execution of the governance proposal
```

