### PR TITLE
Remove SSV validators from old staking strategy

### DIFF
--- a/contracts/docs/ACTIONS.md
+++ b/contracts/docs/ACTIONS.md
@@ -98,7 +98,7 @@ each run (see notes in `seed_schedules.sql`).
 | Action                       | Description                                                                          |
 | ---------------------------- | ------------------------------------------------------------------------------------ |
 | `stakeValidator`             | Convert WETH to ETH and deposit to a validator from the Compounding Staking Strategy |
-| `removeValidator`            | Remove a registered or exited compounding validator from the SSV cluster             |
+| `removeValidator`            | Remove registered or exited validators from Native Staking Strategy 2                |
 | `ousdRebalancer`             | Plan and execute OUSD strategy rebalancing via the RebalancerModule                  |
 | `proposeVaultStrategyMoves`  | Simulate and propose ordered OUSD/OETH strategy movements to the Strategist 2/8 Safe |
 | `queueGovernorSixProposal`   | Queue a GovernorSix proposal (`--propid`)                                            |

--- a/contracts/dump-actions-catalog.ts
+++ b/contracts/dump-actions-catalog.ts
@@ -13,7 +13,7 @@ import { registry } from "./tasks/lib/action";
 // Per-task parameter allow-lists — only these params are editable from the
 // Talos admin UI. Copied verbatim from the old dump-actions-catalog.cjs.
 const TALOS_PARAM_ALLOWLISTS: Record<string, Set<string>> = {
-  removeValidator: new Set(["consol", "pubkeys"]),
+  removeValidator: new Set(["consol", "pubkey"]),
   stakeValidator: new Set([
     "amount",
     "consol",

--- a/contracts/dump-actions-catalog.ts
+++ b/contracts/dump-actions-catalog.ts
@@ -13,7 +13,7 @@ import { registry } from "./tasks/lib/action";
 // Per-task parameter allow-lists — only these params are editable from the
 // Talos admin UI. Copied verbatim from the old dump-actions-catalog.cjs.
 const TALOS_PARAM_ALLOWLISTS: Record<string, Set<string>> = {
-  removeValidator: new Set(["consol", "operatorids", "pubkey"]),
+  removeValidator: new Set(["consol", "pubkeys"]),
   stakeValidator: new Set([
     "amount",
     "consol",

--- a/contracts/tasks/actions/removeValidator.ts
+++ b/contracts/tasks/actions/removeValidator.ts
@@ -16,8 +16,8 @@ action({
     "Removes registered or exited validators from Native Staking Strategy 2",
   params: (t) => {
     t.addParam(
-      "pubkeys",
-      "Comma-separated validator public keys in hex format with 0x prefixes",
+      "pubkey",
+      "One or more comma-separated validator public keys in hex format with 0x prefixes",
       undefined,
       types.string
     );
@@ -29,13 +29,13 @@ action({
     );
   },
   run: async ({ signer, args }) => {
-    if (!validatorKeys.test(args.pubkeys)) {
+    if (!validatorKeys.test(args.pubkey)) {
       throw new Error(
-        "pubkeys must be a comma-separated list of 48-byte hex public keys with 0x prefixes"
+        "pubkey must contain one or more comma-separated 48-byte hex public keys with 0x prefixes"
       );
     }
 
-    const pubkeys = args.pubkeys.split(",");
+    const pubkeys = args.pubkey.split(",");
     for (const [index, pubkey] of pubkeys.entries()) {
       await removeValidator({
         consol: args.consol,

--- a/contracts/tasks/actions/removeValidator.ts
+++ b/contracts/tasks/actions/removeValidator.ts
@@ -3,23 +3,21 @@
 import { types } from "../lib/action";
 import { action } from "../lib/action";
 
-const { removeValidator } = require("../validatorCompound");
+const { validatorKeys } = require("../../utils/regex");
+const { sleep } = require("../../utils/time");
+const { removeValidator } = require("../ssv");
+const NATIVE_STAKING_STRATEGY_2_OPERATOR_IDS = "752,753,754,755";
+const SSV_API_UPDATE_DELAY_MS = 30_000;
 
 action({
   name: "removeValidator",
   chains: [1],
   description:
-    "Removes a registered or exited compounding validator from the SSV cluster",
+    "Removes registered or exited validators from Native Staking Strategy 2",
   params: (t) => {
     t.addParam(
-      "operatorids",
-      "Comma separated operator ids. E.g. 342,343,344,345",
-      undefined,
-      types.string
-    );
-    t.addParam(
-      "pubkey",
-      "The validator's public key in hex format with a 0x prefix",
+      "pubkeys",
+      "Comma-separated validator public keys in hex format with 0x prefixes",
       undefined,
       types.string
     );
@@ -31,6 +29,25 @@ action({
     );
   },
   run: async ({ signer, args }) => {
-    await removeValidator({ ...args, signer });
+    if (!validatorKeys.test(args.pubkeys)) {
+      throw new Error(
+        "pubkeys must be a comma-separated list of 48-byte hex public keys with 0x prefixes"
+      );
+    }
+
+    const pubkeys = args.pubkeys.split(",");
+    for (const [index, pubkey] of pubkeys.entries()) {
+      await removeValidator({
+        consol: args.consol,
+        index: 2,
+        operatorids: NATIVE_STAKING_STRATEGY_2_OPERATOR_IDS,
+        pubkey,
+        signer,
+      });
+
+      if (index < pubkeys.length - 1) {
+        await sleep(SSV_API_UPDATE_DELAY_MS);
+      }
+    }
   },
 });

--- a/contracts/tasks/consolidation.js
+++ b/contracts/tasks/consolidation.js
@@ -78,7 +78,6 @@ async function failConsolidation({ source }) {
 }
 
 async function confirmConsolidation({ safe = false }) {
-  const signer = await getSigner();
   const controller = await resolveContract("ConsolidationController");
 
   const { balanceProofs, pendingDepositProofs } = await verifyBalances({
@@ -102,6 +101,7 @@ async function confirmConsolidation({ safe = false }) {
     return;
   }
 
+  const signer = await getSigner();
   log(`About to confirm validator consolidations`);
   const tx = await controller
     .connect(signer)

--- a/contracts/tasks/ssv.js
+++ b/contracts/tasks/ssv.js
@@ -14,8 +14,14 @@ const { resolveNativeStakingStrategyProxy } = require("./validator");
 
 const log = require("../utils/logger")("task:ssv");
 
-async function removeValidator({ consol, index, pubkey, operatorids }) {
-  const signer = await getSigner();
+async function removeValidator({
+  consol,
+  index,
+  pubkey,
+  operatorids,
+  signer: taskSigner,
+}) {
+  const signer = taskSigner || (await getSigner());
 
   log(`Splitting operator IDs ${operatorids}`);
   const operatorIds = operatorids.split(",").map((id) => parseInt(id));


### PR DESCRIPTION
## Summary

Updates the Talos `removeValidator` action to remove validators from the legacy Native Staking Strategy 2 instead of the retired Compounding Staking Strategy.

- Hardcodes Native Staking Strategy 2 and its SSV operator IDs (`752,753,754,755`)
- Allows `--pubkey` to contain one or more comma-separated validator public keys
- Validates all supplied public keys before submitting transactions
- Removes validators sequentially with a 30-second delay so the SSV API can refresh cluster state
- Reuses the signer supplied by the standalone Talos runtime
- Updates the Talos action catalog and documentation
- Avoids loading the consolidation signer when no consolidation confirmation transaction is required

## Example

```bash
cd /app && pnpm exec tsx tasks/run.ts removeValidator --network mainnet --pubkey 0xKEY1,0xKEY2 --consol true
```

## Testing

- Generated and verified the Talos action catalog
- Ran Prettier on the changed TypeScript, JavaScript, and Markdown files
- Verified the diff with `git diff --check`