### PR TITLE
Fix remove validator Talos action

### DIFF
--- a/contracts/tasks/ssv.js
+++ b/contracts/tasks/ssv.js
@@ -10,6 +10,7 @@ const {
 } = require("../utils/ssv");
 const { getNetworkName } = require("../utils/hardhat-helpers");
 const { logTxDetails } = require("../utils/txLogger");
+const { getChainId } = require("./lib/network");
 const { resolveNativeStakingStrategyProxy } = require("./validator");
 
 const log = require("../utils/logger")("task:ssv");
@@ -28,7 +29,7 @@ async function removeValidator({
 
   const nativeStakingStrategy = await resolveNativeStakingStrategyProxy(index);
 
-  const { chainId } = await signer.provider.getNetwork();
+  const chainId = getChainId();
 
   // Cluster details
   const { cluster } = await getClusterInfo({

--- a/contracts/tasks/ssv.js
+++ b/contracts/tasks/ssv.js
@@ -28,12 +28,11 @@ async function removeValidator({
 
   const nativeStakingStrategy = await resolveNativeStakingStrategyProxy(index);
 
-  const { chainId } = await ethers.provider.getNetwork();
+  const { chainId } = await signer.provider.getNetwork();
 
   // Cluster details
   const { cluster } = await getClusterInfo({
     chainId,
-    ssvNetwork: hre.network.name.toUpperCase(),
     operatorids,
     ownerAddress: nativeStakingStrategy.address,
   });

--- a/contracts/utils/vault.js
+++ b/contracts/utils/vault.js
@@ -16,7 +16,7 @@ async function withdrawFromStrategyIfNeeded({
   dryrun,
 }) {
   const wethInStrategy = await weth.balanceOf(strategy.address);
-  const ethInStrategy = await ethers.provider.getBalance(strategy.address);
+  const ethInStrategy = await signer.provider.getBalance(strategy.address);
   log(`WETH available in strategy ${formatUnits(wethInStrategy, 18)}`);
   log(`ETH available in strategy ${formatUnits(ethInStrategy, 18)}`);
 


### PR DESCRIPTION
## Summary

Fixes Talos actions that referenced Hardhat-provided global `ethers` and `hre` objects, which are unavailable in the standalone Talos runtime.

- Use the action signer’s provider to resolve the chain ID in `removeValidator`.
- Remove the unused `hre.network` argument from the SSV cluster lookup.
- Use the signer’s provider when checking strategy ETH balances for automatic validator deposits and withdrawals.

## Testing

- Ran Prettier on the changed JavaScript files.
- Ran focused ESLint checks.
- Ran `git diff --check`.
- Verified all registered Talos action modules load successfully.

