### PR TITLE
Talos arbitrum fix 

### DIFF
--- a/contracts/tasks/lib/network.ts
+++ b/contracts/tasks/lib/network.ts
@@ -18,9 +18,14 @@ export const CHAIN_NAMES: Record<number, string> = {
   98866: "plume",
 };
 
-const CHAIN_IDS: Record<string, number> = Object.fromEntries(
-  Object.entries(CHAIN_NAMES).map(([id, name]) => [name, Number(id)])
-);
+const CHAIN_IDS: Record<string, number> = {
+  ...Object.fromEntries(
+    Object.entries(CHAIN_NAMES).map(([id, name]) => [name, Number(id)])
+  ),
+  // Hardhat's name for 42161, still used by Talos schedules, deployments/ and
+  // addresses.js.
+  arbitrumone: 42161,
+};
 
 const RPC_ENV_VARS: Record<number, string> = {
   1: "MAINNET_PROVIDER_URL",


### PR DESCRIPTION
This fixes Talos origin-dollar runner so it is able to run tasks using `arbitrumOne`. The capability has been lost when we migrated to the Foundry 

## Code Change Checklist

To be completed before internal review begins:

- [ ]  The contract code is complete
- [ ]  Executable deployment file
- [ ]  Fork tests that test after the deployment file runs
- [ ]  Unit tests *if needed
- [ ]  The owner has done a [full checklist review](https://github.com/OriginProtocol/security/blob/master/templates/Contract-Code-Review.md) of the code + tests

