### PR TITLE
fix: route the impersonated fork signer through the nonce queue

### DIFF
--- a/contracts/tasks/lib/signer.ts
+++ b/contracts/tasks/lib/signer.ts
@@ -83,7 +83,10 @@ export async function getSigner(): Promise<ethers.Signer> {
         "0x56bc75e2d63100000",
       ]);
     }
-    return provider.getSigner(address);
+    // Wrapped like the KMS and private-key branches: without it the
+    // transaction bypasses the nonce queue, so Talos never records it and the
+    // run shows no transactions. ethers v5 getSigner() is synchronous.
+    return maybeWrap(provider.getSigner(address));
   }
 
   throw new Error(


### PR DESCRIPTION
`getSigner()` wraps the KMS and private-key branches in `maybeWrap()`, but branch 3 does not:

| Branch | Wrapped |
|---|---|
| 1. AWS KMS | `return maybeWrap(new DirectKmsTransactionSigner(...))` ✅ |
| 2. `DEPLOYER_PK` / `GOVERNOR_PK` | `return maybeWrap(new ethers.Wallet(pk, provider))` ✅ |
| 3. `FORK=true` + `IMPERSONATE` | `return provider.getSigner(address)` ❌ |

Without the wrapper, `sendTransaction` never routes through `wrapSignerWithNonceQueueV5`, so Talos does not record the transaction. The visible symptom is a run that **completes successfully with an empty transaction list**.

```diff
-    return provider.getSigner(address);
+    return maybeWrap(provider.getSigner(address));
```

No `await` — `getSigner()` is synchronous on ethers v5 (5.7.2 here), unlike v6.

`DATABASE_URL` is present in the runner container, so `maybeWrap()` does attach the queue — nothing else was missing.

## Why now

[oplabs/talos#30](https://github.com/oplabs/talos/pull/30) makes an anvil mainnet fork with an impersonated relayer the **default** dev environment, so branch 3 goes from rarely-exercised to the everyday path. Companion fix in arm-oeth: [OriginProtocol/arm-oeth#339](https://github.com/OriginProtocol/arm-oeth/pull/339).

## Worth a reviewer's judgement

The nonce queue does real work — rebroadcasts, fee bumps, replacements, driven by the `NONCE_QUEUE_*` settings. On a fork that is arguably the point (you exercise the production path), but dev transactions become managed rather than fire-and-forget. If you would rather impersonated runs stay lightweight, the alternative is recording them without the queue.

## Not verified

I could not typecheck — the worktree has no `node_modules`. The change is a one-line call into `maybeWrap()`, already used twice in the same function, so it should be safe, but CI is the check.