### PR TITLE
Reduce harvest threshold to get last ETH in 2nd Native Staking Strategy

### DIFF
--- a/contracts/docs/ACTIONS.md
+++ b/contracts/docs/ACTIONS.md
@@ -45,7 +45,7 @@ Cron times are UTC. Enable state and operational caveats (e.g. "do not enable",
 
 | Action                     | Network | Cron             | Description                                                                                         |
 | -------------------------- | ------- | ---------------- | --------------------------------------------------------------------------------------------------- |
-| `harvest`                  | mainnet | `25 11,23 * * *` | Harvest and swap rewards from native staking strategies                                             |
+| `harvest`                  | mainnet | `25 11,23 * * *` | Harvest all remaining rewards from deprecated Native Staking Strategy 2 and claim strategy rewards  |
 | `doAccounting`             | mainnet | `30 23 * * *`    | Account for consensus rewards and validator exits in the Native Staking Strategy                    |
 | `snapBalances`             | mainnet | `2 0 * * *`      | Take a snapshot of the staking strategy's balance                                                   |
 | `verifyBalances`           | mainnet | `6 0 * * *`      | Verify validator balances on the Beacon chain                                                       |

--- a/contracts/tasks/actions/harvest.ts
+++ b/contracts/tasks/actions/harvest.ts
@@ -25,8 +25,6 @@ action({
 
     const nativeStakingStrategies = [
       addresses.mainnet.NativeStakingSSVStrategy2Proxy,
-      // TODO: NativeStakingSSVStrategy3Proxy will soon be obsolete
-      addresses.mainnet.NativeStakingSSVStrategy3Proxy,
     ];
 
     const strategiesToHarvest: string[] = [];

--- a/contracts/utils/harvest.js
+++ b/contracts/utils/harvest.js
@@ -41,8 +41,7 @@ const shouldHarvestFromNativeStakingStrategy = async (strategy, signer) => {
   );
 
   return (
-    consensusRewards.gt(parseEther("1")) ||
-    executionRewards.gt(parseEther("0.5"))
+    consensusRewards.gt(parseEther("0")) || executionRewards.gt(parseEther("0"))
   );
 };
 


### PR DESCRIPTION
## Summary

The deprecated second Native Staking Strategy has `0.266459380000000896 ETH` remaining, which is below the Talos action’s previous 1 ETH consensus-reward harvest threshold.

This PR:

- Reduces the native-staking consensus and execution reward thresholds to zero, allowing any non-zero rewards to be harvested.
- Removes the empty third Native Staking Strategy from the harvest action.
- Updates the Talos action documentation.

